### PR TITLE
Fix bug: module dns.name has no attribution .to_text(); should be <@ nam...

### DIFF
--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -38,7 +38,7 @@ def to_text(keyring):
     
     textring = {}
     for keyname in keyring:
-        keytext = dns.name.to_text(keyname)
+        keytext = keyname.to_text()
         secret = base64.encodestring(keyring[keyname])
         textring[keytext] = secret
     return textring


### PR DESCRIPTION
@dns.tsigkeyring:  dns.name is a module which has no attribute to_text; should change to <@ name>::keyname.to_text()
