### PR TITLE
Add response time to the response when querying a server.

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -322,7 +322,7 @@ def tcp(q, where, timeout=None, port=53, af=None, source=None, source_port=0,
         (l,) = struct.unpack("!H", ldata)
         wire = _net_read(s, l, expiration)
     finally:
-        response_time = time.time() - begin_time()
+        response_time = time.time() - begin_time
         s.close()
     r = dns.message.from_wire(wire, keyring=q.keyring, request_mac=q.mac,
                               one_rr_per_rrset=one_rr_per_rrset)


### PR DESCRIPTION
Have an application where accurate timing of the response of a DNS request is important. In order to get accurate times when sending a DNS request I need to get the times for sending the request and receiving the response as close to the actual events as possible.

This pull request contains a proposal that have worked well for me in my particular application, any other suggestions are appreciated. 