### PR TITLE
specific error raised when all nameservers fail

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -78,7 +78,10 @@ class NoMetaqueries(dns.exception.DNSException):
     """Metaqueries are not allowed."""
     pass
 
-
+class AllNameserversFailed(dns.exception.DNSException):
+	""" All nameservers failed for one reason or another."""
+	pass
+	
 class Answer(object):
     """DNS stub resolver answer
 
@@ -895,6 +898,8 @@ class Resolver(object):
                     sleep_time = min(timeout, backoff)
                     backoff *= 2
                     time.sleep(sleep_time)
+                else:
+                	raise AllNameserversFailed
             if response.rcode() == dns.rcode.NXDOMAIN:
                 continue
             all_nxdomain = False


### PR DESCRIPTION
I wouldn't call it a bug per-se, but I did find it a little confusing when dnspython was raising a 'NoNameservers' exception when it had actually been supplied with name servers, but they had all failed for one reason or another (I'm manually specifying nameservers rather than relying on the OS defined ones).

This commit creates a new 'AllNameserversFailed' exception, which allows for more fine-grained control over error conditions.
