### PR TITLE
Support per-nameserver port setting to dns.resolver.Resolver.

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -57,7 +57,8 @@ class BaseResolverTests(object):
         def testRead(self):
             f = cStringIO.StringIO(resolv_conf)
             r = dns.resolver.Resolver(f)
-            self.failUnless(r.nameservers == ['10.0.0.1', '10.0.0.2'] and
+            self.failUnless(r.nameservers == [('10.0.0.1', 53),
+                                              ('10.0.0.2', 53)] and
                             r.domain == dns.name.from_text('foo'))
 
     def testCacheExpiration(self):


### PR DESCRIPTION
This is useful when adding a special nameserver that runs on non-standard DNS port. (For example, a Consul agent).

Note that this is a breaking change for any third party code code that inspects `dns.resolver.Resolver.nameservers` or `dns.resolver.Resolver.port`  directly.