### PR TITLE
Parametrized exceptions

### DIFF
--- a/dns/exception.py
+++ b/dns/exception.py
@@ -63,10 +63,29 @@ class DNSException(Exception):
                 'following set of keyword args is required: %s' % (
                     self.supp_kwargs)
 
+    def _fmt_kwargs(self, **kwargs):
+        """Format kwargs before printing them.
+
+        Resulting dictionary has to have keys necessary for str.format call
+        on fmt class variable.
+        """
+        fmtargs = {}
+        for kw, data in kwargs.items():
+            if isinstance(data, (list, set)):
+                # convert list of <someobj> to list of str(<someobj>)
+                fmtargs[kw] = list(map(str, data))
+                if len(fmtargs[kw]) == 1:
+                    # remove list brackets [] from single-item lists
+                    fmtargs[kw] = fmtargs[kw].pop()
+            else:
+                fmtargs[kw] = data
+        return fmtargs
+
     def __str__(self):
         if self.kwargs and self.fmt:
             # provide custom message constructed from keyword arguments
-            return self.fmt.format(**self.kwargs)
+            fmtargs = self._fmt_kwargs(**self.kwargs)
+            return self.fmt.format(**fmtargs)
         else:
             # print *args directly in the same way as old DNSException
             return super(DNSException, self).__str__()

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -110,3 +110,5 @@ class TooBig(DNSException):
 
 class Timeout(DNSException):
     """The DNS operation timed out."""
+    supp_kwargs = set(['timeout'])
+    fmt = "%s after {timeout} seconds" % __doc__[:-1]

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -25,6 +25,8 @@ class DNSException(Exception):
        empty **kwargs.
     In compatible mode all *args are passed to standard Python Exception class
     as before and all *args are printed by standard __str__ implementation.
+    Class variable msg (or doc string if msg is None) is returned from str()
+    if *args is empty.
 
     b) New/parametrized mode is used if __init__ was called with
        non-empty **kwargs.
@@ -36,18 +38,21 @@ class DNSException(Exception):
     In the simplest case it is enough to override supp_kwargs and fmt
     class variables to get nice parametrized messages.
     """
-    supp_kwargs = set()
-    fmt = None
+    msg = None  # non-parametrized message
+    supp_kwargs = set()  # accepted parameters for _fmt_kwargs (sanity check)
+    fmt = None  # message parametrized with results from _fmt_kwargs
 
     def __init__(self, *args, **kwargs):
         self._check_params(*args, **kwargs)
         self._check_kwargs(**kwargs)
         self.kwargs = kwargs
+        if self.msg is None:
+            # doc string is better implicit message than empty string
+            self.msg = self.__doc__
         if args:
             super(DNSException, self).__init__(*args)
         else:
-            # doc string is better implicit message than empty string
-            super(DNSException, self).__init__(self.__doc__)
+            super(DNSException, self).__init__(self.msg)
 
     def _check_params(self, *args, **kwargs):
         """Old exceptions supported only args and not kwargs.

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -70,19 +70,11 @@ class YXDOMAIN(dns.exception.DNSException):
 
 Timeout = dns.exception.Timeout
 
+
 class NoAnswer(dns.exception.DNSException):
     """The DNS response does not contain an answer to the question."""
-    def __init__(self, question=None):
-        super(dns.exception.DNSException, self).__init__()
-        self.question = question
-
-    def __str__(self):
-        message = self.__doc__
-        if self.question:
-            message = message[0:-1]
-            for q in self.question:
-                message += ' %s' % q
-        return message
+    fmt = '%s: {question}' % __doc__[:-1]
+    supp_kwargs = set(['question'])
 
 
 class NoNameservers(dns.exception.DNSException):
@@ -178,7 +170,7 @@ class Answer(object):
                 if raise_on_no_answer:
                     raise NoAnswer(question=response.question)
         if rrset is None and raise_on_no_answer:
-            raise NoAnswer(question=response.question)
+            raise NoAnswer(question=request.question)
         self.canonical_name = qname
         self.rrset = rrset
         if rrset is None:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -73,9 +73,12 @@ Timeout = dns.exception.Timeout
 
 class NoAnswer(dns.exception.DNSException):
     """The DNS response does not contain an answer to the question."""
-    fmt = '%s: {question}' % __doc__[:-1]
-    supp_kwargs = set(['question'])
+    fmt = '%s: {query}' % __doc__[:-1]
+    supp_kwargs = set(['response'])
 
+    def _fmt_kwargs(self, **kwargs):
+        return super(NoAnswer, self)._fmt_kwargs(
+            query=kwargs['response'].question)
 
 class NoNameservers(dns.exception.DNSException):
     """No non-broken nameservers are available to answer the query."""
@@ -166,11 +169,11 @@ class Answer(object):
                         continue
                     except KeyError:
                         if raise_on_no_answer:
-                            raise NoAnswer(question=response.question)
+                            raise NoAnswer(response=response)
                 if raise_on_no_answer:
-                    raise NoAnswer(question=response.question)
+                    raise NoAnswer(response=response)
         if rrset is None and raise_on_no_answer:
-            raise NoAnswer(question=request.question)
+            raise NoAnswer(response=response)
         self.canonical_name = qname
         self.rrset = rrset
         if rrset is None:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -45,6 +45,21 @@ if sys.platform == 'win32':
 
 class NXDOMAIN(dns.exception.DNSException):
     """The DNS query name does not exist."""
+    supp_kwargs = set(['qname'])
+
+    def __str__(self):
+        if not 'qname' in self.kwargs:
+            return super(NXDOMAIN, self).__str__()
+
+        qname = self.kwargs['qname']
+        msg = self.__doc__[:-1]
+        if isinstance(qname, (list, set)):
+            if len(qname) > 1:
+                msg = 'None of DNS query names exist'
+                qname = list(map(str, qname))
+            else:
+                qname = qname[0]
+        return "%s: %s" % (msg, (str(qname)))
 
 class YXDOMAIN(dns.exception.DNSException):
     """The DNS query name is too long after DNAME substitution."""
@@ -934,7 +949,7 @@ class Resolver(object):
             all_nxdomain = False
             break
         if all_nxdomain:
-            raise NXDOMAIN
+            raise NXDOMAIN(qname=qnames_to_try)
         answer = Answer(qname, rdtype, rdclass, response,
                         raise_on_no_answer)
         if self.cache:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -744,18 +744,18 @@ class Resolver(object):
 
     def _compute_timeout(self, start):
         now = time.time()
-        if now < start:
-            if start - now > 1:
+        duration = now - start
+        if duration < 0:
+            if duration < -1:
                 # Time going backwards is bad.  Just give up.
-                raise Timeout
+                raise Timeout(timeout=duration)
             else:
                 # Time went backwards, but only a little.  This can
                 # happen, e.g. under vmware with older linux kernels.
                 # Pretend it didn't happen.
                 now = start
-        duration = now - start
         if duration >= self.lifetime:
-            raise Timeout
+            raise Timeout(timeout=duration)
         return min(self.lifetime - duration, self.timeout)
 
     def query(self, qname, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,6 +18,12 @@ import unittest
 
 from dns.exception import DNSException
 
+
+class FormatedError(DNSException):
+    fmt = "Custom format: {parameter}"
+    supp_kwargs = set(['parameter'])
+
+
 class ExceptionTestCase(unittest.TestCase):
 
     def test_custom_message(self):
@@ -33,6 +39,24 @@ class ExceptionTestCase(unittest.TestCase):
         except DNSException as ex:
             self.assertEqual(ex.__class__.__doc__, str(ex))
 
+    def test_formatted_error(self):
+        """Exceptions with explicit format has to respect it."""
+        params = {'parameter': 'value'}
+        try:
+            raise FormatedError(**params)
+        except FormatedError as ex:
+            msg = FormatedError.fmt.format(**params)
+            self.assertEqual(msg, str(ex))
+
+    def test_kwargs_only(self):
+        """Kwargs cannot be combined with args."""
+        with self.assertRaises(AssertionError):
+            raise FormatedError(1, a=2)
+
+    def test_kwargs_unsupported(self):
+        """Only supported kwargs are accepted."""
+        with self.assertRaises(AssertionError):
+            raise FormatedError(unsupported=2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello @rthalley!

After some time I found that previous attempt with human-readable exceptions from #85 is not sufficient - it simply does not give enough information. This led to more generic implementation of DNSException which allows easy customization and is (I believe) 100 % compatible with the older code.

It is explained in detail in commit messages and comments. Are you okay with that approach? My hope is that it should limit amount of __init__() and __str__() duplication which was previously necessary for implementation of parametrized messages.

I will extend this to other exceptions if you are okay with the approach. Thank you very much for your time!