### PR TITLE
Fix failing test for Zone.to_file

### DIFF
--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -121,12 +121,25 @@ class ZoneTestCase(unittest.TestCase):
                 os.unlink('example2.out')
         self.assertTrue(ok)
 
+    def testFromFile2b(self):
+        """Test to_file with a binary file"""
+        z = dns.zone.from_file('example', 'example', relativize=False)
+        ok = False
+        try:
+            with open('example2b.out', 'wb') as f:
+                z.to_file(f, relativize=False, nl='\x0a', binary=True)
+            ok = filecmp.cmp('example2b.out', 'example2.good')
+        finally:
+            if not _keep_output:
+                os.unlink('example2b.out')
+        self.assertTrue(ok)
+
     def testToText(self):
         z = dns.zone.from_file('example', 'example')
         ok = False
         try:
             text_zone = z.to_text(nl='\x0a')
-            f = open('example3.out', 'wb')
+            f = open('example3.out', 'w')
             f.write(text_zone)
             f.close()
             ok = filecmp.cmp('example3.out', 'example3.good')


### PR DESCRIPTION
A fix for https://github.com/rthalley/dnspython/issues/94

Make the to_file method work on string files, unless explicitly told
to do binary encoding.
Take the line terminator from os, rather than relying on the print
function.

Change the test to use a text file rather than binary, and add a new
test for to_file with a binary file.