### PR TITLE
Py3: Implement the pickle protocol for Name objects

### DIFF
--- a/dns/name.py
+++ b/dns/name.py
@@ -168,6 +168,13 @@ class Name(object):
     def __deepcopy__(self, memo):
         return Name(copy.deepcopy(self.labels, memo))
 
+    def __getstate__(self):
+        return { 'labels' : self.labels }
+
+    def __setstate__(self, state):
+        super(Name, self).__setattr__('labels', state['labels'])
+        _validate_labels(self.labels)
+
     def is_absolute(self):
         """Is the most significant label of this name the root label?
         @rtype: bool

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -18,6 +18,7 @@ import unittest
 import io
 import socket
 import sys
+import pickle
 
 import dns.name
 import dns.reversename
@@ -698,6 +699,12 @@ class NameTestCase(unittest.TestCase):
         e = '+16505551212'
         text = dns.e164.to_e164(n)
         self.assertTrue(text == e)
+
+    def testPickling(self):
+        n = dns.name.from_text('foo.bar')
+        pickled = pickle.dumps(n)
+        unpickled = pickle.loads(pickled)
+        self.assertEqual(n, unpickled)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Another patch that was left out of the python3 branch.

I've added a test; feel free to push it also to master.