### PR TITLE
Rename tests with duplicate names

### DIFF
--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -38,7 +38,7 @@ class FlagsTestCase(unittest.TestCase):
         self.assertTrue(dns.rcode.from_flags(0, 0x01000000) == \
                         dns.rcode.BADVERS)
 
-    def test_rcode6(self):
+    def test_rcode6a(self):
         self.assertTrue(dns.rcode.from_flags(5, 0) == dns.rcode.REFUSED)
 
     def test_rcode7(self):

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -113,7 +113,7 @@ class NameTestCase(unittest.TestCase):
     def testAbs3(self):
         self.assertTrue(self.origin.is_absolute())
 
-    def testAbs3(self):
+    def testAbs4(self):
         n = dns.name.from_text('foo', origin=None)
         self.assertTrue(not n.is_absolute())
 
@@ -299,7 +299,7 @@ class NameTestCase(unittest.TestCase):
         r = n1 + n2
         self.assertTrue(r == e)
 
-    def testConcat2(self):
+    def testConcat2a(self):
         n1 = dns.name.Name([])
         n2 = dns.name.Name(['a', 'b'])
         e = dns.name.Name(['a', 'b'])

--- a/tests/test_ntoaaton.py
+++ b/tests/test_ntoaaton.py
@@ -67,22 +67,6 @@ class NtoAAtoNTestCase(unittest.TestCase):
             a = aton6('1:2:3:4:5:6:7:8:9')
         self.assertRaises(dns.exception.SyntaxError, bad)
 
-    def test_aton1(self):
-        a = aton6('::')
-        self.assertTrue(a == b'\x00' * 16)
-
-    def test_aton2(self):
-        a = aton6('::1')
-        self.assertTrue(a == b'\x00' * 15 + b'\x01')
-
-    def test_aton3(self):
-        a = aton6('::10.0.0.1')
-        self.assertTrue(a == b'\x00' * 12 + b'\x0a\x00\x00\x01')
-
-    def test_aton4(self):
-        a = aton6('abcd::dcba')
-        self.assertTrue(a == b'\xab\xcd' + b'\x00' * 12 + b'\xdc\xba')
-
     def test_ntoa1(self):
         b = bytes.fromhex('00010002000300040005000600070008')
         t = ntoa6(b)

--- a/tests/test_rdtypeandclass.py
+++ b/tests/test_rdtypeandclass.py
@@ -52,7 +52,7 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_class_totext1(self):
         self.assertTrue(dns.rdataclass.to_text(dns.rdataclass.IN) == 'IN')
 
-    def test_class_totext1(self):
+    def test_class_totext2(self):
         self.assertTrue(dns.rdataclass.to_text(999) == 'CLASS999')
 
     def test_class_totext_bounds1(self):
@@ -106,7 +106,7 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_type_totext1(self):
         self.assertTrue(dns.rdatatype.to_text(dns.rdatatype.A) == 'A')
 
-    def test_type_totext1(self):
+    def test_type_totext2(self):
         self.assertTrue(dns.rdatatype.to_text(999) == 'TYPE999')
 
     def test_type_totext_bounds1(self):


### PR DESCRIPTION
Some tests were shadowed by a different test of the same name.
Rename to resolve the conflicts.

In test_ntoaaton, there were exact duplicates; only keep one of each.