### PR TITLE
Expose responses on NXDOMAIN exception (python3)

### DIFF
--- a/dns/e164.py
+++ b/dns/e164.py
@@ -68,7 +68,7 @@ def query(number, domains, resolver=None):
     """
     if resolver is None:
         resolver = dns.resolver.get_default_resolver()
-    e_nx = dns.resolver.NXDOMAIN(qnames=[])
+    e_nx = dns.resolver.NXDOMAIN()
     for domain in domains:
         if isinstance(domain, str):
             domain = dns.name.from_text(domain)

--- a/dns/e164.py
+++ b/dns/e164.py
@@ -68,12 +68,13 @@ def query(number, domains, resolver=None):
     """
     if resolver is None:
         resolver = dns.resolver.get_default_resolver()
+    e_nx = dns.resolver.NXDOMAIN(qnames=[])
     for domain in domains:
         if isinstance(domain, str):
             domain = dns.name.from_text(domain)
         qname = dns.e164.from_e164(number, domain)
         try:
             return resolver.query(qname, 'NAPTR')
-        except dns.resolver.NXDOMAIN:
-            pass
-    raise dns.resolver.NXDOMAIN
+        except dns.resolver.NXDOMAIN as e:
+            e_nx += e
+    raise e_nx

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -44,8 +44,10 @@ class DNSException(Exception):
 
     def __init__(self, *args, **kwargs):
         self._check_params(*args, **kwargs)
-        self._check_kwargs(**kwargs)
-        self.kwargs = kwargs
+        if kwargs:
+            self.kwargs = self._check_kwargs(**kwargs)
+        else:
+            self.kwargs = dict()  # defined but empty for old mode exceptions
         if self.msg is None:
             # doc string is better implicit message than empty string
             self.msg = self.__doc__
@@ -67,6 +69,7 @@ class DNSException(Exception):
             assert set(kwargs.keys()) == self.supp_kwargs, \
                 'following set of keyword args is required: %s' % (
                     self.supp_kwargs)
+        return kwargs
 
     def _fmt_kwargs(self, **kwargs):
         """Format kwargs before printing them.

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -46,6 +46,7 @@ class DNSException(Exception):
         self._check_params(*args, **kwargs)
         if kwargs:
             self.kwargs = self._check_kwargs(**kwargs)
+            self.msg = str(self)
         else:
             self.kwargs = dict()  # defined but empty for old mode exceptions
         if self.msg is None:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -75,6 +75,8 @@ class NXDOMAIN(dns.exception.DNSException):
         return "%s: %s" % (msg, qnames)
 
     def canonical_name(self):
+        if not 'qnames' in self.kwargs:
+            raise TypeError("parametrized exception required")
         IN = dns.rdataclass.IN
         CNAME = dns.rdatatype.CNAME
         cname = None
@@ -86,10 +88,7 @@ class NXDOMAIN(dns.exception.DNSException):
                 cname = answer.items[0].target.to_text()
             if cname is not None:
                 return dns.name.from_text(cname)
-        try:
-            return self.kwargs['qnames'][0]
-        except KeyError:
-            return NOne
+        return self.kwargs['qnames'][0]
     canonical_name = property(canonical_name, doc=(
         "Return the unresolved canonical name."))
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -50,9 +50,12 @@ class NXDOMAIN(dns.exception.DNSException):
     """The DNS query name does not exist."""
     supp_kwargs = set(['qnames', 'responses'])
 
-    def __init__(self, qnames, responses=None):
-        if not isinstance(qnames, (list, tuple, set)):
-            qnames=[qnames]
+    def __init__(self, qnames=None, responses=None):
+        if qnames is not None:
+            if not isinstance(qnames, (list, tuple, set)):
+                qnames=[qnames]
+        else:
+            qnames = []
         if responses is None:
             responses = {}
         return super(NXDOMAIN, self).__init__(

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -85,6 +85,10 @@ class NXDOMAIN(dns.exception.DNSException):
                 cname = answer.items[0].target.to_text()
             if cname is not None:
                 return dns.name.from_text(cname)
+        try:
+            return self.kwargs['qnames'][0]
+        except KeyError:
+            return NOne
     canonical_name = property(canonical_name, doc=(
         "Return the unresolved canonical name."))
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -48,21 +48,54 @@ if sys.platform == 'win32':
 
 class NXDOMAIN(dns.exception.DNSException):
     """The DNS query name does not exist."""
-    supp_kwargs = set(['qname'])
+    supp_kwargs = set(['qnames', 'responses'])
+
+    def __init__(self, qnames, responses=None):
+        if not isinstance(qnames, (list, tuple, set)):
+            qnames=[qnames]
+        if responses is None:
+            responses = {}
+        return super(NXDOMAIN, self).__init__(
+            qnames=qnames, responses=responses)
 
     def __str__(self):
-        if not 'qname' in self.kwargs:
+        if not 'qnames' in self.kwargs:
             return super(NXDOMAIN, self).__str__()
 
-        qname = self.kwargs['qname']
-        msg = self.__doc__[:-1]
-        if isinstance(qname, (list, set)):
-            if len(qname) > 1:
-                msg = 'None of DNS query names exist'
-                qname = list(map(str, qname))
-            else:
-                qname = qname[0]
-        return "%s: %s" % (msg, (str(qname)))
+        qnames = self.kwargs['qnames']
+        if len(qnames) > 1:
+            msg = 'None of DNS query names exist'
+        else:
+            msg = self.__doc__[:-1]
+        qnames = ', '.join(map(str, qnames))
+        return "%s: %s" % (msg, qnames)
+
+    def canonical_name(self):
+        IN = dns.rdataclass.IN
+        CNAME = dns.rdatatype.CNAME
+        cname = None
+        for qname in self.kwargs['qnames']:
+            response = self.kwargs['responses'][qname]
+            for answer in response.answer:
+                if answer.rdtype != CNAME or answer.rdclass != IN:
+                    continue
+                cname = answer.items[0].target.to_text()
+            if cname is not None:
+                return dns.name.from_text(cname)
+    canonical_name = property(canonical_name, doc=(
+        "Return the unresolved canonical name."))
+
+    def __add__(self, e_nx):
+        """Augment by results from another NXDOMAIN exception."""
+        qnames0 = self.kwargs['qnames']
+        responses0 = self.kwargs['responses']
+        responses1 = e_nx.kwargs['responses']
+        for qname1 in e_nx.kwargs['qnames']:
+            if qname1 not in qnames0:
+                qnames0.append(qname1)
+            responses0[qname1] = responses1[qname1]
+        return self
+
 
 class YXDOMAIN(dns.exception.DNSException):
     """The DNS query name is too long after DNAME substitution."""
@@ -823,6 +856,7 @@ class Resolver(object):
             else:
                 qnames_to_try.append(qname.concatenate(self.domain))
         all_nxdomain = True
+        nxdomain_responses = {}
         start = time.time()
         for qname in qnames_to_try:
             if self.cache:
@@ -947,11 +981,12 @@ class Resolver(object):
                     backoff *= 2
                     time.sleep(sleep_time)
             if response.rcode() == dns.rcode.NXDOMAIN:
+                nxdomain_responses[qname] = response
                 continue
             all_nxdomain = False
             break
         if all_nxdomain:
-            raise NXDOMAIN(qname=qnames_to_try)
+            raise NXDOMAIN(qnames=qnames_to_try, responses=nxdomain_responses)
         answer = Answer(qname, rdtype, rdclass, response,
                         raise_on_no_answer)
         if self.cache:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -167,10 +167,12 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
     def test_nxdomain_compatible(self):
         n1 = dns.name.Name(('a', 'b', ''))
         n2 = dns.name.Name(('a', 'b', 's', ''))
+        py3 = (sys.version_info[0] > 2)
 
         try:
             raise dns.resolver.NXDOMAIN
         except Exception as e:
+            if not py3: self.assertTrue((e.message == e.__doc__))
             self.assertTrue((e.args == (e.__doc__,)))
             self.assertTrue(('kwargs' in dir(e)))
             self.assertTrue((str(e) == e.__doc__), str(e))
@@ -180,6 +182,7 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         try:
             raise dns.resolver.NXDOMAIN("errmsg")
         except Exception as e:
+            if not py3: self.assertTrue((e.message == "errmsg"))
             self.assertTrue((e.args == ("errmsg",)))
             self.assertTrue(('kwargs' in dir(e)))
             self.assertTrue((str(e) == "errmsg"), str(e))
@@ -189,6 +192,7 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         try:
             raise dns.resolver.NXDOMAIN("errmsg", -1)
         except Exception as e:
+            if not py3: self.assertTrue((e.message == ""))
             self.assertTrue((e.args == ("errmsg", -1)))
             self.assertTrue(('kwargs' in dir(e)))
             self.assertTrue((str(e) == "('errmsg', -1)"), str(e))
@@ -213,9 +217,11 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         try:
             raise dns.resolver.NXDOMAIN(qnames=[n1])
         except Exception as e:
-            self.assertTrue((e.args == (e.__doc__,)))
+            MSG = "The DNS query name does not exist: a.b."
+            if not py3: self.assertTrue((e.message == MSG), e.message)
+            self.assertTrue((e.args == (MSG,)), repr(e.args))
             self.assertTrue(('kwargs' in dir(e)))
-            self.assertTrue((str(e) == "The DNS query name does not exist: a.b."), str(e))
+            self.assertTrue((str(e) == MSG), str(e))
             self.assertTrue(('qnames' in e.kwargs))
             self.assertTrue((e.kwargs['qnames'] == [n1]))
             self.assertTrue(('responses' in e.kwargs))
@@ -226,9 +232,11 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         except Exception as e:
             e0 = dns.resolver.NXDOMAIN("errmsg")
             e = e0 + e
-            self.assertTrue((e.args == (e.__doc__,)), repr(e.args))
+            MSG = "None of DNS query names exist: a.b.s., a.b."
+            if not py3: self.assertTrue((e.message == MSG), e.message)
+            self.assertTrue((e.args == (MSG,)), repr(e.args))
             self.assertTrue(('kwargs' in dir(e)))
-            self.assertTrue((str(e) == "None of DNS query names exist: a.b.s., a.b."), str(e))
+            self.assertTrue((str(e) == MSG), str(e))
             self.assertTrue(('qnames' in e.kwargs))
             self.assertTrue((e.kwargs['qnames'] == [n2, n1]))
             self.assertTrue(('responses' in e.kwargs))
@@ -242,10 +250,12 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         try:
             raise dns.resolver.NXDOMAIN(qnames=[n1], responses={n1: 'r1.1'})
         except Exception as e:
-            self.assertTrue((e.args == (e.__doc__,)))
+            MSG = "The DNS query name does not exist: a.b."
+            if not py3: self.assertTrue((e.message == MSG), e.message)
+            self.assertTrue((e.args == (MSG,)), repr(e.args))
             self.assertTrue(('kwargs' in dir(e)))
+            self.assertTrue((str(e) == MSG), str(e))
             self.assertTrue(('qnames' in e.kwargs))
-            self.assertTrue((str(e) == "The DNS query name does not exist: a.b."), str(e))
             self.assertTrue((e.kwargs['qnames'] == [n1]))
             self.assertTrue(('responses' in e.kwargs))
             self.assertTrue((e.kwargs['responses'] == {n1: 'r1.1'}))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -153,6 +153,20 @@ if hasattr(select, 'poll'):
 
 class NXDOMAINExceptionTestCase(unittest.TestCase):
 
+    def test_nxdomain_compatible(self):
+        def do0():
+            raise dns.resolver.NXDOMAIN
+        def do(*args, **kwargs):
+            raise dns.resolver.NXDOMAIN(*args, **kwargs)
+        n1 = dns.name.Name(('a', 'b', ''))
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do0)
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do)
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do, "errmsg")
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do, "errmsg", -1)
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do, qnames=[])
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do, qnames=[n1])
+        self.failUnlessRaises(dns.resolver.NXDOMAIN, do, qnames=[n1], responses=['r1.1'])
+
     def test_nxdomain_merge(self):
         n1 = dns.name.Name(('a', 'b', ''))
         n2 = dns.name.Name(('a', 'b', ''))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -263,6 +263,7 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         e1 = dns.resolver.NXDOMAIN(qnames=qnames1, responses=responses1)
         e2 = dns.resolver.NXDOMAIN(qnames=qnames2, responses=responses2)
         e = e1 + e0 + e2
+        self.assertRaises(AttributeError, lambda : e0 + e0)
         self.assertTrue(e.kwargs['qnames'] == [n1, n4, n3], repr(e.kwargs['qnames']))
         self.assertTrue(e.kwargs['responses'][n1].startswith('r2.'))
         self.assertTrue(e.kwargs['responses'][n2].startswith('r2.'))
@@ -280,9 +281,11 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         qname1 = message1.question[0].name
         qname2 = message2.question[0].name
         responses = {qname0: message0, qname1: message1, qname2: message2}
+        eX = dns.resolver.NXDOMAIN()
         e0 = dns.resolver.NXDOMAIN(qnames=[qname0], responses=responses)
         e1 = dns.resolver.NXDOMAIN(qnames=[qname0, qname1, qname2], responses=responses)
         e2 = dns.resolver.NXDOMAIN(qnames=[qname0, qname2, qname1], responses=responses)
+        self.assertRaises(TypeError, lambda : eX.canonical_name)
         self.assertTrue(e0.canonical_name == qname0)
         self.assertTrue(e1.canonical_name == dns.name.from_text(cname1))
         self.assertTrue(e2.canonical_name == dns.name.from_text(cname2))


### PR DESCRIPTION
Rename NXDOMAIN exception's parameter `qname` to `qnames` and make it a list per default.
Add parameter `responses` to NXDOMAIN exception, and add `canonical_name` property.
Modify `Resolver.query()` and `dns.e164.query()` to pass proper arguments to the exception.