### PR TITLE
When serializing with sorted=True, respect DNSSEC order within RRsets.

### DIFF
--- a/dns/node.py
+++ b/dns/node.py
@@ -15,8 +15,6 @@
 
 """DNS nodes.  A node is a set of rdatasets."""
 
-import StringIO
-
 import dns.rdataset
 import dns.rdatatype
 import dns.renderer
@@ -37,7 +35,7 @@ class Node(object):
 
         self.rdatasets = [];
 
-    def to_text(self, name, **kw):
+    def to_text(self, name, sorted=True, **kw):
         """Convert a node to text format.
 
         Each rdataset at the node is printed.  Any keyword arguments
@@ -45,13 +43,19 @@ class Node(object):
         @param name: the owner name of the rdatasets
         @type name: dns.name.Name object
         @rtype: string
+        @param sorted: if True, the text will be written with the
+        records sorted in DNSSEC order from least to greatest.  Otherwise
+        the records will be written in whatever order they happen to have
+        in the node.
         """
 
-        s = StringIO.StringIO()
+        texts = []
         for rds in self.rdatasets:
             if len(rds) > 0:
-                print >> s, rds.to_text(name, **kw)
-        return s.getvalue()[:-1]
+                texts += rds.to_text(name, **kw).split('\n')
+        if sorted:
+            texts.sort()
+        return '\n'.join(texts)
 
     def __repr__(self):
         return '<DNS node ' + str(id(self)) + '>'

--- a/dns/node.py
+++ b/dns/node.py
@@ -15,6 +15,8 @@
 
 """DNS nodes.  A node is a set of rdatasets."""
 
+import os
+
 import dns.rdataset
 import dns.rdatatype
 import dns.renderer
@@ -48,14 +50,14 @@ class Node(object):
         the records will be written in whatever order they happen to have
         in the node.
         """
-
+        nl = kw.get('nl', os.linesep)
         texts = []
         for rds in self.rdatasets:
             if len(rds) > 0:
-                texts += rds.to_text(name, **kw).split('\n')
+                texts += rds.to_text(name, **kw).split(nl)
         if sorted:
             texts.sort()
-        return '\n'.join(texts)
+        return nl.join(texts)
 
     def __repr__(self):
         return '<DNS node ' + str(id(self)) + '>'

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -496,7 +496,8 @@ class Zone(object):
                 names = self.iterkeys()
             for n in names:
                 l = self[n].to_text(n, origin=self.origin,
-                                    relativize=relativize)
+                                    relativize=relativize,
+                                    sorted=sorted)
                 if nl is None:
                     print >> f, l
                 else:


### PR DESCRIPTION
Previously, sorting only applied to Names, but records within each node
were serialized in whatever order they happened to have been stored.

https://tools.ietf.org/html/rfc4034#section-6.3