### PR TITLE
Assign b'' to other_data in make_response when using TSIG.

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1095,7 +1095,7 @@ def make_response(query, recursion_available=False, our_payload=8192,
     if query.edns >= 0:
         response.use_edns(0, 0, our_payload, query.payload)
     if query.had_tsig:
-        response.use_tsig(query.keyring, query.keyname, fudge, None, 0, '',
+        response.use_tsig(query.keyring, query.keyname, fudge, None, 0, b'',
                           query.keyalgorithm)
         response.request_mac = query.mac
     return response


### PR DESCRIPTION
Hit the following error when using `make_response` to an existing query with TSIG:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/asyncio/events.py", line 120, in _run
    self._callback(*self._args)
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/asyncio/selector_events.py", line 1006, in _read_ready
    self._protocol.datagram_received(data, addr)
  File "b.py", line 26, in datagram_received
    self.transport.sendto(r.to_wire(), addr)
  File "/Users/kivikakk/.virtualenv/belonging/lib/python3.4/site-packages/dns/message.py", line 424, in to_wire
    self.keyalgorithm)
  File "/Users/kivikakk/.virtualenv/belonging/lib/python3.4/site-packages/dns/renderer.py", line 287, in add_tsig
    algorithm=algorithm)
  File "/Users/kivikakk/.virtualenv/belonging/lib/python3.4/site-packages/dns/tsig.py", line 106, in sign
    post_mac = struct.pack('!HH', error, ol) + other_data
TypeError: can't concat bytes to str
```

It turned out `make_response` was assigning a `str` to `other_data` instead of a `bytes` instance.

For now the work-around is to simply initialise `other_data` oneself:

```python
r = dns.message.make_response(q)
r.other_data = b''
```