### PR TITLE
Offline Build Process Facilitation

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -18,6 +18,7 @@ import select
 import sys
 import time
 import unittest
+import urllib
 
 import dns.name
 import dns.message
@@ -46,6 +47,13 @@ example. 1 IN A 10.0.0.1
 ;AUTHORITY
 ;ADDITIONAL
 """
+
+try:
+    with network = urllib.request.urlopen('http://www.dnspython.org/',
+                                  timeout=1) as response:
+        network = (response.getcode() == 200)
+except urllib.error.URLError:
+    network = False
 
 class FakeAnswer(object):
     def __init__(self, expiration):
@@ -82,18 +90,21 @@ class BaseResolverTests(object):
         self.assertTrue(cache.get((name, dns.rdatatype.A, dns.rdataclass.IN))
                         is None)
 
+    @unittest.skipUnless(network, "requires network access")
     def testZoneForName1(self):
         name = dns.name.from_text('www.dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')
         zname = dns.resolver.zone_for_name(name)
         self.assertTrue(zname == ezname)
 
+    @unittest.skipUnless(network, "requires network access")
     def testZoneForName2(self):
         name = dns.name.from_text('a.b.www.dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')
         zname = dns.resolver.zone_for_name(name)
         self.assertTrue(zname == ezname)
 
+    @unittest.skipUnless(network, "requires network access")
     def testZoneForName3(self):
         name = dns.name.from_text('dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')


### PR DESCRIPTION
This is a PR to facilitate offline package build process. When building the ubuntu package offline these tests fail due to a lack of network access. Here we detect network access and disable said tests if no access is available. 