### PR TITLE
Dictionary keys doesn't support slicing. 

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -467,7 +467,7 @@ class Message(object):
 
         self.keyring = keyring
         if keyname is None:
-            self.keyname = self.keyring.keys()[0]
+            self.keyname = list(self.keyring.keys())[0]
         else:
             if isinstance(keyname, string_types):
                 keyname = dns.name.from_text(keyname)


### PR DESCRIPTION
That's throw an error in the… program if the 'keyname' parameter is not passed.

Doing a **list(dict())[0]** solve this problem.