### PR TITLE
test: add makefile target for python3

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,9 +15,10 @@
 
 # $Id: Makefile,v 1.5 2004/03/19 00:17:27 halley Exp $
 
-PYTHON=python
-
 check: test
 
 test:
-	${PYTHON} ./utest.py
+	python ./utest.py
+
+test3:
+	python3 ./utest.py


### PR DESCRIPTION
If `python` does not link to `python3`, which is the case on most platforms, it is not possible to run the tests with `python3` without modifying the source (which I want to prevent for packaging).