### PR TITLE
Add compatibility with BlockingIOError for Python3

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -292,9 +292,12 @@ def _connect(s, address):
         s.connect(address)
     except socket.error:
         (ty, v) = sys.exc_info()[:2]
-        if v[0] != errno.EINPROGRESS and \
-            v[0] != errno.EWOULDBLOCK and \
-                v[0] != errno.EALREADY:
+
+        if hasattr(v, 'errno'):
+            v_err = v.errno
+        else:
+            v_err = v[0]
+        if v_err not in [errno.EINPROGRESS, errno.EWOULDBLOCK, errno.EALREADY]:
             raise v
 
 


### PR DESCRIPTION
Fixes rthalley/dnspython#156

At least in Python3.5, BlockingIOError is not subscriptable. Its
`.errno` attribute seems to be able to provide the necessary
information.