### PR TITLE
Explicitly use bytes to avoid TypeError with concatenation

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -264,11 +264,11 @@ def _net_read(sock, count, expiration):
     A Timeout exception will be raised if the operation is not completed
     by the expiration time.
     """
-    s = ''
+    s = b''
     while count > 0:
         _wait_for_readable(sock, expiration)
         n = sock.recv(count)
-        if n == '':
+        if n == b'':
             raise EOFError
         count = count - len(n)
         s = s + n


### PR DESCRIPTION
Fixes rthalley/dnspython#157

On Python3, this previously would raise a TypeError when one tried to
add bytes and a string, this initializes s and n to bytes instead.