### PR TITLE
Python3

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -171,7 +171,7 @@ def _destination_and_source(af, where, port, source, source_port):
     return (af, destination, source)
 
 def udp(q, where, timeout=None, port=53, af=None, source=None, source_port=0,
-        ignore_unexpected=False, one_rr_per_rrset=False):
+        ignore_unexpected=False, one_rr_per_rrset=False, ipttl = 128):
     """Return the response obtained after sending a query via UDP.
 
     @param q: the query
@@ -204,6 +204,7 @@ def udp(q, where, timeout=None, port=53, af=None, source=None, source_port=0,
     (af, destination, source) = _destination_and_source(af, where, port, source,
                                                         source_port)
     s = socket.socket(af, socket.SOCK_DGRAM, 0)
+    s.setsockopt(socket.SOL_IP, socket.IP_TTL, ipttl)
     begin_time = None
     try:
         expiration = _compute_expiration(timeout)

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -768,7 +768,7 @@ class Resolver(object):
             raise Timeout(timeout=duration)
         return min(self.lifetime - duration, self.timeout)
 
-    def query(self, qname, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN,
+    def query(self, qname, rdtype=dns.rdatatype.A, af=None, rdclass=dns.rdataclass.IN,
               tcp=False, source=None, raise_on_no_answer=True, source_port=0, ipttl=128):
         """Query nameservers to find the answer to the question.
 
@@ -787,6 +787,10 @@ class Resolver(object):
         @type tcp: bool
         @param source: bind to this IP address (defaults to machine default IP).
         @type source: IP address in dotted quad notation
+        @param af: the address family to use.  The default is None, which
+        causes the address family to use to be inferred from the form of of where.
+        If the inference attempt fails, AF_INET is used.
+        @type af: int
         @param raise_on_no_answer: raise NoAnswer if there's no answer
         (defaults is True).
         @type raise_on_no_answer: bool
@@ -860,13 +864,15 @@ class Resolver(object):
                             response = dns.query.tcp(request, nameserver,
                                                      timeout, self.port,
                                                      source=source,
-                                                     source_port=source_port)
+                                                     source_port=source_port,
+                                                     af=af)
                         else:
                             response = dns.query.udp(request, nameserver,
                                                      timeout, self.port,
                                                      source=source,
                                                      source_port=source_port,
-                                                     ipttl=ipttl)
+                                                     ipttl=ipttl,
+                                                     af=af)
                             if response.flags & dns.flags.TC:
                                 # Response truncated; retry with TCP.
                                 tcp_attempt = True

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -769,7 +769,7 @@ class Resolver(object):
         return min(self.lifetime - duration, self.timeout)
 
     def query(self, qname, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN,
-              tcp=False, source=None, raise_on_no_answer=True, source_port=0):
+              tcp=False, source=None, raise_on_no_answer=True, source_port=0, ipttl=128):
         """Query nameservers to find the answer to the question.
 
         The I{qname}, I{rdtype}, and I{rdclass} parameters may be objects
@@ -865,7 +865,8 @@ class Resolver(object):
                             response = dns.query.udp(request, nameserver,
                                                      timeout, self.port,
                                                      source=source,
-                                                     source_port=source_port)
+                                                     source_port=source_port,
+                                                     ipttl=ipttl)
                             if response.flags & dns.flags.TC:
                                 # Response truncated; retry with TCP.
                                 tcp_attempt = True

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 import sys
 from distutils.core import setup
 
-version = '1.12.0-ttl'
+version = '1.12.0'
 
 kwargs = {
     'name' : 'dnspython3',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 import sys
 from distutils.core import setup
 
-version = '1.12.0'
+version = '1.12.0-ttl'
 
 kwargs = {
     'name' : 'dnspython3',


### PR DESCRIPTION
Add support for IP TTL (optional) and Address Family (optional) to `resolver.query()`