### PR TITLE
Fix dns.name.Name.to_text()

### DIFF
--- a/dns/name.py
+++ b/dns/name.py
@@ -387,7 +387,7 @@ class Name(object):
 
         if len(self.labels) == 0:
             return u'@'
-        if len(self.labels) == 1 and self.labels[0] == '':
+        if len(self.labels) == 1 and self.labels[0] == b'':
             return u'.'
         if omit_final_dot and self.is_absolute():
             l = self.labels[:-1]

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -242,6 +242,14 @@ class NameTestCase(unittest.TestCase):
         t = n.to_text()
         self.assertEqual(t, br'x80\.bar')
 
+    def testToText10(self):
+        t = dns.name.empty.to_unicode()
+        self.assertEqual(t, '@')
+
+    def testToText11(self):
+        t = dns.name.root.to_unicode()
+        self.assertEqual(t, '.')
+
     def testSlice1(self):
         n = dns.name.from_text(r'a.b.c.', origin=None)
         s = n[:]


### PR DESCRIPTION
Fix dns.name.Name.to_text(), so root is displayed properly.