### PR TITLE
Py3: round compatible with py2

### DIFF
--- a/dns/_compat.py
+++ b/dns/_compat.py
@@ -1,5 +1,6 @@
 import sys
-
+import decimal
+from decimal import Context
 
 if sys.version_info > (3,):
     long = int
@@ -29,3 +30,18 @@ else:
         return x
     def maybe_encode(x):
         return x
+
+
+def round_py2_compat(what):
+    """
+    Python 2 and Python 3 use different rounding strategies in round(). This
+    function ensures that results are python2/3 compatible and backward
+    compatible with previous py2 releases
+    :param what: float
+    :return: rounded long
+    """
+    d = Context(
+        prec=len(str(long(what))),  # round to integer with max precision
+        rounding=decimal.ROUND_HALF_UP
+    ).create_decimal(str(what))  # str(): python 2.6 compat
+    return long(d)

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -19,7 +19,7 @@ import struct
 
 import dns.exception
 import dns.rdata
-from dns._compat import long, xrange
+from dns._compat import long, xrange, round_py2_compat
 
 
 _pows = tuple(long(10**i) for i in range(0, 11))
@@ -49,7 +49,7 @@ def _float_to_tuple(what):
         what *= -1
     else:
         sign = 1
-    what = long(round(what * 3600000))
+    what = round_py2_compat(what * 3600000)
     degrees = int(what // 3600000)
     what -= degrees * 3600000
     minutes = int(what // 60000)

--- a/pylintrc
+++ b/pylintrc
@@ -31,7 +31,6 @@ disable=
     no-member,
     protected-access,
     redefined-builtin,
-    round-builtin,
     too-many-lines,
     unused-argument,
     unused-variable,


### PR DESCRIPTION
Python 3 and Python 2 uses different rounding strategies in round().
Function round_py2_compat() do rounding in py2 compatible strategy for both py2 and py3

Fixes #179 