### PR TITLE
Fix encoding errors zone.to_file()

### DIFF
--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -132,6 +132,59 @@ class ZoneTestCase(unittest.TestCase):
                 os.unlink(here('example2.out'))
         self.failUnless(ok)
 
+    def testToFileTextualStream(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=True)
+        f = StringIO()
+        z.to_file(f)
+        out = f.getvalue()
+        f.close()
+        self.assertEqual(out, example_text_output)
+
+    def testToFileBinaryStream(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=True)
+        f = BytesIO()
+        z.to_file(f)
+        out = f.getvalue()
+        f.close()
+        self.assertEqual(out, example_text_output.encode())
+
+    def testToFileTextual(self):
+        z = dns.zone.from_file(here('example'), 'example')
+        try:
+            f = open(here('example3-textual.out'), 'w')
+            z.to_file(f)
+            f.close()
+            ok = filecmp.cmp(here('example3-textual.out'),
+                             here('example3.good'))
+        finally:
+            if not _keep_output:
+                os.unlink(here('example3-textual.out'))
+        self.failUnless(ok)
+
+    def testToFileBinary(self):
+        z = dns.zone.from_file(here('example'), 'example')
+        try:
+            f = open(here('example3-binary.out'), 'wb')
+            z.to_file(f)
+            f.close()
+            ok = filecmp.cmp(here('example3-binary.out'),
+                             here('example3.good'))
+        finally:
+            if not _keep_output:
+                os.unlink(here('example3-binary.out'))
+        self.failUnless(ok)
+
+    def testToFileFilename(self):
+        z = dns.zone.from_file(here('example'), 'example')
+        try:
+            z.to_file('example3-filename.out')
+            ok = filecmp.cmp(here('example3-filename.out'),
+                             here('example3.good'))
+        finally:
+            if not _keep_output:
+                os.unlink(here('example3-filename.out'))
+        self.failUnless(ok)
+
     def testToText(self):
         z = dns.zone.from_file(here('example'), 'example')
         ok = False


### PR DESCRIPTION
From the code it looks like the only 'binary' mode is supported after migration to py3.
I fixed py3 with 'wb', but I think that also files in text mode should be supported.


This needed much more love than I originally thought. I'm not sure If I fixed it right.

I think that it should also allow files opened in text mode (sys.stdout, sys.stderr)

Partially fixes #182 (only binary mode)