### PR TITLE
Reseed entropy pool after forking

### DIFF
--- a/dns/entropy.py
+++ b/dns/entropy.py
@@ -46,8 +46,10 @@ class EntropyPool(object):
         if seed is not None:
             self.stir(bytearray(seed))
             self.seeded = True
+            self.seed_pid = os.getpid()
         else:
             self.seeded = False
+            self.seed_pid = 0
 
     def stir(self, entropy, already_locked=False):
         if not already_locked:
@@ -64,7 +66,7 @@ class EntropyPool(object):
                 self.lock.release()
 
     def _maybe_seed(self):
-        if not self.seeded:
+        if not self.seeded or self.seed_pid != os.getpid():
             try:
                 seed = os.urandom(16)
             except:
@@ -77,6 +79,8 @@ class EntropyPool(object):
                 except:
                     seed = str(time.time())
             self.seeded = True
+            self.seed_pid = os.getpid()
+            self.digest = None
             seed = bytearray(seed)
             self.stir(seed, True)
 


### PR DESCRIPTION
As orginally reported in https://bugzilla.redhat.com/show_bug.cgi?id=1004427

If a message ID is created and then the process is forked, duplicate message IDs will be created due to the entropy pool not being reseeded.

Example code
```python
import os
import dns.entropy
import multiprocessing

print("Parent (%d): %d" % (os.getpid(), dns.entropy.random_16()))

def child():
    print("Child (%d): %d" % (os.getpid(), dns.entropy.random_16()))
    os._exit(0)  

def parent():
    newpid = os.fork()
    if newpid == 0:
        child()

# Basic Forking
for i in range(5):
    parent()

# Multiprocessing
for i in range(5):
    p = multiprocessing.Process(target=child)
    p.start()

# Parent
print("Parent (%d): %d" % (os.getpid(), dns.entropy.random_16()))
```

Before patch:

```console
Parent (22248): 32568
Child (22249): 56529
Child (22250): 56529
Child (22253): 56529
Child (22251): 56529
Child (22252): 56529
Child (22254): 56529
Child (22255): 56529
Child (22257): 56529
Child (22256): 56529
Parent (22248): 56529
Child (22258): 56529
```

After patch:

```console
Parent (22506): 18616
Child (22507): 57533
Child (22508): 35707
Child (22509): 44468
Child (22510): 47858
Child (22511): 19736
Child (22512): 27605
Child (22513): 36563
Child (22514): 55013
Child (22515): 22381
Parent (22506): 18236
Child (22516): 41315
```

This pull request attempts to patch the existing class and works on my test machine (Fedora 24), but has not been tested on other operating systems. It should work as os.getpid() is supported on Linux, Unix, and Windows.

An alternative would be to remove or greatly simplify the entropy module and rely directly on os.urandom since the entropy module is only used to get a 16 bit number for the message id. For example:

```python
messageID = struct.unpack("H", os.urandom(2))[0]
```

Though some additional logic would still be required in the event urandom was unavailable.


