### PR TITLE
Add support for ASCII representations of a DN

### DIFF
--- a/dns/name.py
+++ b/dns/name.py
@@ -171,6 +171,7 @@ class Name(object):
     up to 63 octets."""
 
     __slots__ = ['labels']
+    
 
     def __init__(self, labels):
         """Initialize a domain name from a list of labels.
@@ -396,6 +397,22 @@ class Name(object):
         s = u'.'.join([_escapify(encodings.idna.ToUnicode(x), True)
                       for x in l])
         return s
+
+    def to_ASCII(self , omit_final_dot=False):
+        """ Decoding Name
+        IDN ACE labels are converted
+        """
+        if len(self.labels) == 0:
+            return u'@'
+        if len(self.labels) == 1 and self.labels[0] == b'':
+            return u'.'
+        if omit_final_dot and self.is_absolute():
+            l = self.labels[:-1]
+        else:
+            l = self.labels
+        v = u'.'.join([_escapify(encodings.idna.ToASCII(x), True)
+                          for x in l])
+        return v
 
     def to_digestable(self, origin=None):
         """Convert name to a format suitable for digesting in hashes.

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- 
 # Copyright (C) 2003-2007, 2009-2011 Nominum, Inc.
 #
 # Permission to use, copy, modify, and distribute this software and its
@@ -12,7 +13,6 @@
 # WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 from __future__ import print_function
 
 try:
@@ -254,6 +254,10 @@ class NameTestCase(unittest.TestCase):
         t = dns.name.root.to_unicode()
         self.assertEqual(t, '.')
 
+    def testToText12(self):
+        n = dns.name.from_text(u'ýšáěíčýáíšěčýáíšěýáíčšěýčáíšěýáíčý.com')
+        t = n.to_ASCII(True)
+        self.assertEqual(t, u'xn--1caaaaaa3fbbbbb0rcccccc81adgbf34afeee19rhafff.com')
     def testSlice1(self):
         n = dns.name.from_text(r'a.b.c.', origin=None)
         s = n[:]


### PR DESCRIPTION
use an existing function in 'encoding.idna' for
convert unicode to ascii using the function
according to the standard on
https://www.ietf.org/rfc/rfc3490.txt