### PR TITLE
Pylint

### DIFF
--- a/dns/entropy.py
+++ b/dns/entropy.py
@@ -70,14 +70,14 @@ class EntropyPool(object):
         if not self.seeded or self.seed_pid != os.getpid():
             try:
                 seed = os.urandom(16)
-            except:
+            except Exception:
                 try:
                     r = open('/dev/urandom', 'rb', 0)
                     try:
                         seed = r.read(16)
                     finally:
                         r.close()
-                except:
+                except Exception:
                     seed = str(time.time())
             self.seeded = True
             self.seed_pid = os.getpid()
@@ -125,7 +125,7 @@ pool = EntropyPool()
 
 try:
     system_random = random.SystemRandom()
-except:
+except Exception:
     system_random = None
 
 def random_16():

--- a/dns/inet.py
+++ b/dns/inet.py
@@ -85,7 +85,7 @@ def af_for_address(text):
     try:
         dns.ipv4.inet_aton(text)
         return AF_INET
-    except:
+    except Exception:
         try:
             dns.ipv6.inet_aton(text)
             return AF_INET6
@@ -103,9 +103,9 @@ def is_multicast(text):
     try:
         first = ord(dns.ipv4.inet_aton(text)[0])
         return first >= 224 and first <= 239
-    except:
+    except Exception:
         try:
             first = ord(dns.ipv6.inet_aton(text)[0])
             return first == 255
-        except:
+        except Exception:
             raise ValueError

--- a/dns/message.py
+++ b/dns/message.py
@@ -898,7 +898,7 @@ class _TextReader(object):
                 raise dns.exception.SyntaxError
         except dns.exception.SyntaxError:
             raise dns.exception.SyntaxError
-        except:
+        except Exception:
             rdclass = dns.rdataclass.IN
         # Type
         rdtype = dns.rdatatype.from_text(token.value)
@@ -931,7 +931,7 @@ class _TextReader(object):
                 raise dns.exception.SyntaxError
         except dns.exception.SyntaxError:
             raise dns.exception.SyntaxError
-        except:
+        except Exception:
             ttl = 0
         # Class
         try:
@@ -944,7 +944,7 @@ class _TextReader(object):
                 rdclass = self.zone_rdclass
         except dns.exception.SyntaxError:
             raise dns.exception.SyntaxError
-        except:
+        except Exception:
             rdclass = dns.rdataclass.IN
         # Type
         rdtype = dns.rdatatype.from_text(token.value)

--- a/dns/name.py
+++ b/dns/name.py
@@ -34,7 +34,7 @@ from ._compat import long, binary_type, text_type, unichr
 
 try:
     maxint = sys.maxint
-except:
+except AttributeError:
     maxint = (1 << (8 * struct.calcsize("P"))) // 2 - 1
 
 NAMERELN_NONE = 0

--- a/dns/query.py
+++ b/dns/query.py
@@ -176,7 +176,7 @@ def _destination_and_source(af, where, port, source, source_port):
     if af is None:
         try:
             af = dns.inet.af_for_address(where)
-        except:
+        except Exception:
             af = dns.inet.AF_INET
     if af == dns.inet.AF_INET:
         destination = (where, port)

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -71,4 +71,3 @@ class CAA(dns.rdata.Rdata):
         tag = wire[current: current + l]
         value = wire[current + l:current + rdlen - 2]
         return cls(rdclass, rdtype, flags, tag, value)
-

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -119,4 +119,3 @@ class CERT(dns.rdata.Rdata):
         certificate = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, certificate_type, key_tag, algorithm,
                    certificate)
-

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -82,4 +82,3 @@ class HINFO(dns.rdata.Rdata):
             raise dns.exception.FormError
         os = wire[current: current + l].unwrap()
         return cls(rdclass, rdtype, cpu, os)
-

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -95,4 +95,3 @@ class ISDN(dns.rdata.Rdata):
         else:
             subaddress = ''
         return cls(rdclass, rdtype, address, subaddress)
-

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -138,16 +138,12 @@ class LOC(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, **kw):
         if self.latitude[4] > 0:
             lat_hemisphere = 'N'
-            lat_degrees = self.latitude[0]
         else:
             lat_hemisphere = 'S'
-            lat_degrees = -1 * self.latitude[0]
         if self.longitude[4] > 0:
             long_hemisphere = 'E'
-            long_degrees = self.longitude[0]
         else:
             long_hemisphere = 'W'
-            long_degrees = -1 * self.longitude[0]
         text = "%d %d %d.%03d %s %d %d %d.%03d %s %0.2fm" % (
             self.latitude[0], self.latitude[1],
             self.latitude[2], self.latitude[3], lat_hemisphere,

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -189,4 +189,3 @@ class NSEC3(dns.rdata.Rdata):
             windows.append((window, bitmap))
         return cls(rdclass, rdtype, algorithm, flags, iterations, salt, next,
                    windows)
-

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -86,4 +86,3 @@ class NSEC3PARAM(dns.rdata.Rdata):
         if rdlen != 0:
             raise dns.exception.FormError
         return cls(rdclass, rdtype, algorithm, flags, iterations, salt)
-

--- a/dns/rdtypes/ANY/SSHFP.py
+++ b/dns/rdtypes/ANY/SSHFP.py
@@ -75,4 +75,3 @@ class SSHFP(dns.rdata.Rdata):
         rdlen -= 2
         fingerprint = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, header[0], header[1], fingerprint)
-

--- a/dns/rdtypes/ANY/TLSA.py
+++ b/dns/rdtypes/ANY/TLSA.py
@@ -80,4 +80,3 @@ class TLSA(dns.rdata.Rdata):
         rdlen -= 3
         cert = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, header[0], header[1], header[2], cert)
-

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -78,4 +78,3 @@ class URI(dns.rdata.Rdata):
         current += rdlen
 
         return cls(rdclass, rdtype, priority, weight, target)
-

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -62,4 +62,3 @@ class X25(dns.rdata.Rdata):
             raise dns.exception.FormError
         address = wire[current: current + l].unwrap()
         return cls(rdclass, rdtype, address)
-

--- a/dns/rdtypes/IN/A.py
+++ b/dns/rdtypes/IN/A.py
@@ -50,4 +50,3 @@ class A(dns.rdata.Rdata):
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         address = dns.ipv4.inet_ntoa(wire[current: current + rdlen]).decode()
         return cls(rdclass, rdtype, address)
-

--- a/dns/rdtypes/IN/AAAA.py
+++ b/dns/rdtypes/IN/AAAA.py
@@ -51,4 +51,3 @@ class AAAA(dns.rdata.Rdata):
         address = dns.inet.inet_ntop(dns.inet.AF_INET6,
                                      wire[current: current + rdlen])
         return cls(rdclass, rdtype, address)
-

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -159,4 +159,3 @@ class APL(dns.rdata.Rdata):
             item = APLItem(header[0], negation, address, header[1])
             items.append(item)
         return cls(rdclass, rdtype, items)
-

--- a/dns/rdtypes/IN/DHCID.py
+++ b/dns/rdtypes/IN/DHCID.py
@@ -57,4 +57,3 @@ class DHCID(dns.rdata.Rdata):
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         data = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, data)
-

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -146,4 +146,3 @@ class IPSECKEY(dns.rdata.Rdata):
         key = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, header[0], gateway_type, header[2],
                    gateway, key)
-

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -56,4 +56,3 @@ class NSAP(dns.rdata.Rdata):
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         address = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, address)
-

--- a/dns/rdtypes/IN/WKS.py
+++ b/dns/rdtypes/IN/WKS.py
@@ -103,4 +103,3 @@ class WKS(dns.rdata.Rdata):
         rdlen -= 5
         bitmap = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, address, protocol, bitmap)
-

--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -81,4 +81,3 @@ class DSBase(dns.rdata.Rdata):
         rdlen -= 4
         digest = wire[current: current + rdlen].unwrap()
         return cls(rdclass, rdtype, header[0], header[1], header[2], digest)
-

--- a/dns/rdtypes/euibase.py
+++ b/dns/rdtypes/euibase.py
@@ -69,4 +69,3 @@ class EUIBase(dns.rdata.Rdata):
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         eui = wire[current:current + rdlen].unwrap()
         return cls(rdclass, rdtype, eui)
-

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -88,4 +88,3 @@ class TXTBase(dns.rdata.Rdata):
             rdlen -= l
             strings.append(s)
         return cls(rdclass, rdtype, strings)
-

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -581,6 +581,24 @@ class Resolver(object):
         POSIX systems and from the registry on Windows systems.)
         @type configure: bool"""
 
+        self.domain = None
+        self.nameservers = None
+        self.nameserver_ports = None
+        self.port = None
+        self.search = None
+        self.timeout = None
+        self.lifetime = None
+        self.keyring = None
+        self.keyname = None
+        self.keyalgorithm = None
+        self.edns = None
+        self.ednsflags = None
+        self.payload = None
+        self.cache = None
+        self.flags = None
+        self.retry_servfail = False
+        self.rotate = False
+
         self.reset()
         if configure:
             if sys.platform == 'win32':

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1212,13 +1212,13 @@ def _getaddrinfo(host=None, service=None, family=socket.AF_UNSPEC, socktype=0,
             addr = dns.ipv6.inet_aton(ahost)
             v6addrs.append(host)
             canonical_name = host
-    except:
+    except Exception:
         try:
             # Is it a V4 address literal?
             addr = dns.ipv4.inet_aton(host)
             v4addrs.append(host)
             canonical_name = host
-        except:
+        except Exception:
             if flags & socket.AI_NUMERICHOST == 0:
                 try:
                     if family == socket.AF_INET6 or family == socket.AF_UNSPEC:
@@ -1250,11 +1250,11 @@ def _getaddrinfo(host=None, service=None, family=socket.AF_UNSPEC, socktype=0,
             port = 0
         else:
             port = int(service)
-    except:
+    except Exception:
         if flags & socket.AI_NUMERICSERV == 0:
             try:
                 port = socket.getservbyname(service)
-            except:
+            except Exception:
                 pass
     if port is None:
         raise socket.gaierror(socket.EAI_NONAME)
@@ -1329,7 +1329,7 @@ def _getfqdn(name=None):
         name = socket.gethostname()
     try:
         return _getnameinfo(_getaddrinfo(name, 80)[0][4])[0]
-    except:
+    except Exception:
         return name
 
 
@@ -1354,7 +1354,7 @@ def _gethostbyaddr(ip):
         dns.ipv6.inet_aton(ip)
         sockaddr = (ip, 80, 0, 0)
         family = socket.AF_INET6
-    except:
+    except Exception:
         sockaddr = (ip, 80)
         family = socket.AF_INET
     (name, port) = _getnameinfo(sockaddr, socket.NI_NAMEREQD)

--- a/dns/reversename.py
+++ b/dns/reversename.py
@@ -51,7 +51,7 @@ def from_address(text):
         else:
             parts = [x for x in str(binascii.hexlify(v6).decode())]
             origin = ipv6_reverse_domain
-    except:
+    except Exception:
         parts = ['%d' %
                  byte for byte in bytearray(dns.ipv4.inet_aton(text))]
         origin = ipv4_reverse_domain

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -658,7 +658,7 @@ class _MasterReader(object):
                 raise dns.exception.SyntaxError
         except dns.exception.SyntaxError:
             raise dns.exception.SyntaxError
-        except:
+        except Exception:
             rdclass = self.zone.rdclass
         if rdclass != self.zone.rdclass:
             raise dns.exception.SyntaxError("RR class is not zone's class")
@@ -777,7 +777,7 @@ class _MasterReader(object):
                 raise dns.exception.SyntaxError
         except dns.exception.SyntaxError:
             raise dns.exception.SyntaxError
-        except:
+        except Exception:
             rdclass = self.zone.rdclass
         if rdclass != self.zone.rdclass:
             raise dns.exception.SyntaxError("RR class is not zone's class")
@@ -787,7 +787,7 @@ class _MasterReader(object):
             token = self.tok.get()
             if not token.is_identifier():
                 raise dns.exception.SyntaxError
-        except:
+        except Exception:
             raise dns.exception.SyntaxError("unknown rdatatype '%s'" %
                                             token.value)
 

--- a/examples/zonediff.py
+++ b/examples/zonediff.py
@@ -199,7 +199,7 @@ The differences shown will be logical differences, not textual differences.
                 if proc.returncode == 0:
                     return proc.stdout
                 sys.stderr.write(err + "\n")
-            except:
+            except Exception:
                 sys.stderr.write(err + "\n")
                 if opts.tracebacks:
                     traceback.print_exc()
@@ -207,7 +207,7 @@ The differences shown will be logical differences, not textual differences.
             # Open as normal file
             try:
                 return open(what, 'rb')
-            except:
+            except IOError:
                 sys.stderr.write(err + "\n")
                 if opts.tracebacks:
                     traceback.print_exc()

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ disable=
     assigning-non-slot,
     bad-builtin,
     bad-continuation,
-    bare-except,
+    broad-except,
     deprecated-method,
     fixme,
     getslice-method,

--- a/pylintrc
+++ b/pylintrc
@@ -35,7 +35,6 @@ disable=
     unused-variable,
     wrong-import-order,
     wrong-import-position,
-    trailing-newlines,
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,6 @@ disable=
     anomalous-backslash-in-string,
     arguments-differ,
     assigning-non-slot,
-    attribute-defined-outside-init,
     bad-builtin,
     bad-continuation,
     bare-except,

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -41,7 +41,7 @@ class BugsTestCase(unittest.TestCase):
 
     def test_TTL_bounds_check(self):
         def bad():
-            ttl = dns.ttl.from_text("2147483648")
+            dns.ttl.from_text("2147483648")
         self.failUnlessRaises(dns.ttl.BadTTL, bad)
 
     def test_empty_NSEC3_window(self):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -142,12 +142,12 @@ class GenerateTestCase(unittest.TestCase):
 
     def testFromText(self):
         def bad():
-            z = dns.zone.from_text(example_text, 'example.', relativize=True)
+            dns.zone.from_text(example_text, 'example.', relativize=True)
         self.failUnlessRaises(dns.zone.NoSOA, bad)
 
     def testFromText1(self):
         def bad():
-            z = dns.zone.from_text(example_text1, 'example.', relativize=True)
+            dns.zone.from_text(example_text1, 'example.', relativize=True)
         self.failUnlessRaises(dns.zone.NoSOA, bad)
 
     def testIterateAllRdatas2(self):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -140,7 +140,7 @@ class MessageTestCase(unittest.TestCase):
                                             dns.rdatatype.A,
                                             '10.0.0.%d' % i)
                 q.additional.append(rrset)
-            w = q.to_wire(max_size=512)
+            q.to_wire(max_size=512)
         self.failUnlessRaises(dns.exception.TooBig, bad)
 
     def test_answer1(self):
@@ -151,20 +151,20 @@ class MessageTestCase(unittest.TestCase):
     def test_TrailingJunk(self):
         def bad():
             badwire = goodwire + b'\x00'
-            m = dns.message.from_wire(badwire)
+            dns.message.from_wire(badwire)
         self.failUnlessRaises(dns.message.TrailingJunk, bad)
 
     def test_ShortHeader(self):
         def bad():
             badwire = b'\x00' * 11
-            m = dns.message.from_wire(badwire)
+            dns.message.from_wire(badwire)
         self.failUnlessRaises(dns.message.ShortHeader, bad)
 
     def test_RespondingToResponse(self):
         def bad():
             q = dns.message.make_query('foo', 'A')
             r1 = dns.message.make_response(q)
-            r2 = dns.message.make_response(r1)
+            dns.message.make_response(r1)
         self.failUnlessRaises(dns.exception.FormError, bad)
 
     def test_ExtendedRcodeSetting(self):

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -85,13 +85,13 @@ class NameTestCase(unittest.TestCase):
             ]
         for t in good:
             try:
-                n = dns.name.from_text(t)
+                dns.name.from_text(t)
             except Exception:
                 self.fail("good test '%s' raised an exception" % t)
         for t in bad:
             caught = False
             try:
-                n = dns.name.from_text(t)
+                dns.name.from_text(t)
             except Exception:
                 caught = True
             if not caught:
@@ -271,12 +271,12 @@ class NameTestCase(unittest.TestCase):
 
     def testEmptyLabel1(self):
         def bad():
-            n = dns.name.Name(['a', '', 'b'])
+            dns.name.Name(['a', '', 'b'])
         self.failUnlessRaises(dns.name.EmptyLabel, bad)
 
     def testEmptyLabel2(self):
         def bad():
-            n = dns.name.Name(['', 'b'])
+            dns.name.Name(['', 'b'])
         self.failUnlessRaises(dns.name.EmptyLabel, bad)
 
     def testEmptyLabel3(self):
@@ -289,7 +289,7 @@ class NameTestCase(unittest.TestCase):
 
     def testLabelTooLong(self):
         def bad():
-            n = dns.name.Name(['a' * 64, 'b'])
+            dns.name.Name(['a' * 64, 'b'])
         self.failUnlessRaises(dns.name.LabelTooLong, bad)
 
     def testLongName(self):
@@ -298,7 +298,7 @@ class NameTestCase(unittest.TestCase):
 
     def testNameTooLong(self):
         def bad():
-            n = dns.name.Name(['a' * 63, 'a' * 63, 'a' * 63, 'a' * 63])
+            dns.name.Name(['a' * 63, 'a' * 63, 'a' * 63, 'a' * 63])
         self.failUnlessRaises(dns.name.NameTooLong, bad)
 
     def testConcat1(self):
@@ -340,7 +340,7 @@ class NameTestCase(unittest.TestCase):
         def bad():
             n1 = dns.name.Name(['a', 'b', ''])
             n2 = dns.name.Name(['c'])
-            r = n1 + n2
+            return n1 + n2
         self.failUnlessRaises(dns.name.AbsoluteConcatenation, bad)
 
     def testBadEscape(self):
@@ -373,7 +373,7 @@ class NameTestCase(unittest.TestCase):
     def testBadDigestable(self):
         def bad():
             n = dns.name.from_text('FOO.bar', None)
-            d = n.to_digestable()
+            n.to_digestable()
         self.failUnlessRaises(dns.name.NeedAbsoluteNameOrOrigin, bad)
 
     def testToWire1(self):
@@ -463,13 +463,13 @@ class NameTestCase(unittest.TestCase):
     def testBadSplit1(self):
         def bad():
             n = dns.name.from_text('foo.bar.')
-            (prefix, suffix) = n.split(-1)
+            n.split(-1)
         self.failUnlessRaises(ValueError, bad)
 
     def testBadSplit2(self):
         def bad():
             n = dns.name.from_text('foo.bar.')
-            (prefix, suffix) = n.split(4)
+            n.split(4)
         self.failUnlessRaises(ValueError, bad)
 
     def testRelativize1(self):
@@ -588,25 +588,25 @@ class NameTestCase(unittest.TestCase):
     def testBadFromWire1(self):
         def bad():
             w = b'\x03foo\xc0\x04'
-            (n, cused) = dns.name.from_wire(w, 0)
+            dns.name.from_wire(w, 0)
         self.failUnlessRaises(dns.name.BadPointer, bad)
 
     def testBadFromWire2(self):
         def bad():
             w = b'\x03foo\xc0\x05'
-            (n, cused) = dns.name.from_wire(w, 0)
+            dns.name.from_wire(w, 0)
         self.failUnlessRaises(dns.name.BadPointer, bad)
 
     def testBadFromWire3(self):
         def bad():
             w = b'\xbffoo'
-            (n, cused) = dns.name.from_wire(w, 0)
+            dns.name.from_wire(w, 0)
         self.failUnlessRaises(dns.name.BadLabelType, bad)
 
     def testBadFromWire4(self):
         def bad():
             w = b'\x41foo'
-            (n, cused) = dns.name.from_wire(w, 0)
+            dns.name.from_wire(w, 0)
         self.failUnlessRaises(dns.name.BadLabelType, bad)
 
     def testParent1(self):
@@ -683,12 +683,12 @@ class NameTestCase(unittest.TestCase):
 
     def testBadReverseIPv4(self):
         def bad():
-            n = dns.reversename.from_address('127.0.foo.1')
+            dns.reversename.from_address('127.0.foo.1')
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testBadReverseIPv6(self):
         def bad():
-            n = dns.reversename.from_address('::1::1')
+            dns.reversename.from_address('::1::1')
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testForwardIPv4(self):

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -86,13 +86,13 @@ class NameTestCase(unittest.TestCase):
         for t in good:
             try:
                 n = dns.name.from_text(t)
-            except:
+            except Exception:
                 self.fail("good test '%s' raised an exception" % t)
         for t in bad:
             caught = False
             try:
                 n = dns.name.from_text(t)
-            except:
+            except Exception:
                 caught = True
             if not caught:
                 self.fail("bad test '%s' did not raise an exception" % t)

--- a/tests/test_namedict.py
+++ b/tests/test_namedict.py
@@ -57,18 +57,18 @@ class NameTestCase(unittest.TestCase):
     def testLookup5(self):
         def bad():
             n = dns.name.from_text('a.b.c.')
-            (k, v) = self.ndict.get_deepest_match(n)
+            self.ndict.get_deepest_match(n)
         self.failUnlessRaises(KeyError, bad)
 
     def testLookup6(self):
         def bad():
-            (k, v) = self.ndict.get_deepest_match(dns.name.empty)
+            self.ndict.get_deepest_match(dns.name.empty)
         self.failUnlessRaises(KeyError, bad)
 
     def testLookup7(self):
         self.ndict[dns.name.empty] = 100
         n = dns.name.from_text('a.b.c.')
-        (k, v) = self.ndict.get_deepest_match(n)
+        v = self.ndict.get_deepest_match(n)[1]
         self.failUnless(v == 100)
 
     def testLookup8(self):
@@ -98,7 +98,7 @@ class NameTestCase(unittest.TestCase):
     def testRelLookup7(self):
         self.rndict[dns.name.empty] = 100
         n = dns.name.from_text('a.b.c', None)
-        (k, v) = self.rndict.get_deepest_match(n)
+        v = self.rndict.get_deepest_match(n)[1]
         self.failUnless(v == 100)
 
 if __name__ == '__main__':

--- a/tests/test_ntoaaton.py
+++ b/tests/test_ntoaaton.py
@@ -60,17 +60,17 @@ class NtoAAtoNTestCase(unittest.TestCase):
 
     def test_bad_aton1(self):
         def bad():
-            a = aton6('abcd:dcba')
+            aton6('abcd:dcba')
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def test_bad_aton2(self):
         def bad():
-            a = aton6('abcd::dcba::1')
+            aton6('abcd::dcba::1')
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def test_bad_aton3(self):
         def bad():
-            a = aton6('1:2:3:4:5:6:7:8:9')
+            aton6('1:2:3:4:5:6:7:8:9')
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def test_aton6(self):
@@ -161,12 +161,12 @@ class NtoAAtoNTestCase(unittest.TestCase):
 
     def test_bad_ntoa1(self):
         def bad():
-            a = ntoa6('')
+            ntoa6('')
         self.failUnlessRaises(ValueError, bad)
 
     def test_bad_ntoa2(self):
         def bad():
-            a = ntoa6('\x00' * 17)
+            ntoa6('\x00' * 17)
         self.failUnlessRaises(ValueError, bad)
 
     def test_good_v4_aton(self):

--- a/tests/test_rdtypeandclass.py
+++ b/tests/test_rdtypeandclass.py
@@ -44,12 +44,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
 
     def test_class_bytext_bounds2(self):
         def bad():
-            junk = dns.rdataclass.from_text('CLASS65536')
+            dns.rdataclass.from_text('CLASS65536')
         self.failUnlessRaises(ValueError, bad)
 
     def test_class_bytext_unknown(self):
         def bad():
-            junk = dns.rdataclass.from_text('XXX')
+            dns.rdataclass.from_text('XXX')
         self.failUnlessRaises(dns.rdataclass.UnknownRdataclass, bad)
 
     def test_class_totext1(self):
@@ -60,12 +60,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
 
     def test_class_totext_bounds1(self):
         def bad():
-            junk = dns.rdataclass.to_text(-1)
+            dns.rdataclass.to_text(-1)
         self.failUnlessRaises(ValueError, bad)
 
     def test_class_totext_bounds2(self):
         def bad():
-            junk = dns.rdataclass.to_text(65536)
+            dns.rdataclass.to_text(65536)
         self.failUnlessRaises(ValueError, bad)
 
     # Types
@@ -98,12 +98,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
 
     def test_type_bytext_bounds2(self):
         def bad():
-            junk = dns.rdatatype.from_text('TYPE65536')
+            dns.rdatatype.from_text('TYPE65536')
         self.failUnlessRaises(ValueError, bad)
 
     def test_type_bytext_unknown(self):
         def bad():
-            junk = dns.rdatatype.from_text('XXX')
+            dns.rdatatype.from_text('XXX')
         self.failUnlessRaises(dns.rdatatype.UnknownRdatatype, bad)
 
     def test_type_totext1(self):
@@ -114,12 +114,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
 
     def test_type_totext_bounds1(self):
         def bad():
-            junk = dns.rdatatype.to_text(-1)
+            dns.rdatatype.to_text(-1)
         self.failUnlessRaises(ValueError, bad)
 
     def test_type_totext_bounds2(self):
         def bad():
-            junk = dns.rdatatype.to_text(65536)
+            dns.rdatatype.to_text(65536)
         self.failUnlessRaises(ValueError, bad)
 
 if __name__ == '__main__':

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -158,7 +158,7 @@ class BaseResolverTests(unittest.TestCase):
     def testZoneForName4(self):
         def bad():
             name = dns.name.from_text('dnspython.org', None)
-            zname = dns.resolver.zone_for_name(name)
+            dns.resolver.zone_for_name(name)
         self.failUnlessRaises(dns.resolver.NotAbsolute, bad)
 
     def testLRUReplace(self):
@@ -363,7 +363,6 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         self.assertTrue(e.kwargs['responses'][n4].startswith('r1.'))
 
     def test_nxdomain_canonical_name(self):
-        cname0 = "91.11.8-22.17.172.in-addr.arpa.none."
         cname1 = "91.11.8-22.17.172.in-addr.arpa."
         cname2 = "91-11-17-172.dynamic.example."
         message0 = dns.message.from_text(dangling_cname_0_message_text)

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -58,19 +58,19 @@ class TokenizerTestCase(unittest.TestCase):
     def testQuotedString5(self):
         def bad():
             tok = dns.tokenizer.Tokenizer(r'"foo')
-            token = tok.get()
+            tok.get()
         self.failUnlessRaises(dns.exception.UnexpectedEnd, bad)
 
     def testQuotedString6(self):
         def bad():
             tok = dns.tokenizer.Tokenizer(r'"foo\01')
-            token = tok.get()
+            tok.get()
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testQuotedString7(self):
         def bad():
             tok = dns.tokenizer.Tokenizer('"foo\nbar"')
-            token = tok.get()
+            tok.get()
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testEmpty1(self):
@@ -134,13 +134,13 @@ class TokenizerTestCase(unittest.TestCase):
     def testMultiline3(self):
         def bad():
             tok = dns.tokenizer.Tokenizer('foo)')
-            tokens = list(iter(tok))
+            list(iter(tok))
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testMultiline4(self):
         def bad():
             tok = dns.tokenizer.Tokenizer('((foo)')
-            tokens = list(iter(tok))
+            list(iter(tok))
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testUnget1(self):

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -166,7 +166,7 @@ class ZoneTestCase(unittest.TestCase):
         f = BytesIO()
         o = dns.name.from_text('example.')
         z = dns.zone.from_file(here('example'), o)
-        for (name, node) in z.items():
+        for node in z.values():
             for rds in node:
                 for rd in rds:
                     f.seek(0)
@@ -211,7 +211,7 @@ class ZoneTestCase(unittest.TestCase):
     def testFindRdataset2(self):
         def bad():
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
-            rds = z.find_rdataset('@', 'loc')
+            z.find_rdataset('@', 'loc')
         self.failUnlessRaises(KeyError, bad)
 
     def testFindRRset1(self):
@@ -223,7 +223,7 @@ class ZoneTestCase(unittest.TestCase):
     def testFindRRset2(self):
         def bad():
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
-            rrs = z.find_rrset('@', 'loc')
+            z.find_rrset('@', 'loc')
         self.failUnlessRaises(KeyError, bad)
 
     def testGetRdataset1(self):
@@ -285,7 +285,7 @@ class ZoneTestCase(unittest.TestCase):
         def bad():
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
             node = z['@']
-            rds = node.find_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
+            node.find_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
         self.failUnlessRaises(KeyError, bad)
 
     def testNodeGetRdataset1(self):
@@ -304,14 +304,14 @@ class ZoneTestCase(unittest.TestCase):
     def testNodeDeleteRdataset1(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
-        rds = node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
+        node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         self.failUnless(rds is None)
 
     def testNodeDeleteRdataset2(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
-        rds = node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
+        node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
         self.failUnless(rds is None)
 
@@ -391,14 +391,12 @@ class ZoneTestCase(unittest.TestCase):
 
     def testNoSOA(self):
         def bad():
-            z = dns.zone.from_text(no_soa_text, 'example.',
-                                   relativize=True)
+            dns.zone.from_text(no_soa_text, 'example.', relativize=True)
         self.failUnlessRaises(dns.zone.NoSOA, bad)
 
     def testNoNS(self):
         def bad():
-            z = dns.zone.from_text(no_ns_text, 'example.',
-                                   relativize=True)
+            dns.zone.from_text(no_ns_text, 'example.', relativize=True)
         self.failUnlessRaises(dns.zone.NoNS, bad)
 
     def testInclude(self):
@@ -409,8 +407,7 @@ class ZoneTestCase(unittest.TestCase):
 
     def testBadDirective(self):
         def bad():
-            z = dns.zone.from_text(bad_directive_text, 'example.',
-                                   relativize=True)
+            dns.zone.from_text(bad_directive_text, 'example.', relativize=True)
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
 
     def testFirstRRStartsWithWhitespace(self):
@@ -427,14 +424,14 @@ class ZoneTestCase(unittest.TestCase):
         self.failUnless(z.origin == dns.name.from_text('example.'))
         def bad1():
             o = dns.name.from_text('example', None)
-            z = dns.zone.Zone(o)
+            dns.zone.Zone(o)
         self.failUnlessRaises(ValueError, bad1)
         def bad2():
-            z = dns.zone.Zone(1.0)
+            dns.zone.Zone(1.0)
         self.failUnlessRaises(ValueError, bad2)
 
     def testZoneOriginNone(self):
-        z = dns.zone.Zone(None)
+        dns.zone.Zone(None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
More pylint fixes. I partially fixed unsued variables, but we have to decide how to mark unused variables in iteration, unpacking and list comprehension. By default Pylint has regexp "_$|dummy" for which names unused variables check is ignored. I prefer to save ` _ ` for future, because it is usually used for translations. And dummy sounds weirf ro me. I can configure pylint with any regexp. Maybe '^ignore_', '^unused_', or just '^_' prefixes?