### PR TITLE
DWIMmmy

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -271,10 +271,10 @@ class Answer(object):
             raise AttributeError(attr)
 
     def __len__(self):
-        return len(self.rrset)
+        return self.rrset and len(self.rrset) or 0
 
     def __iter__(self):
-        return iter(self.rrset)
+        return self.rrset and iter(self.rrset) or iter(tuple())
 
     def __getitem__(self, i):
         return self.rrset[i]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -221,7 +221,7 @@ class BaseResolverTests(unittest.TestCase):
         message = dns.message.from_text(dangling_cname_0_message_text)
         name = dns.name.from_text('example.')
         answer = dns.resolver.Answer(name, dns.rdatatype.A, dns.rdataclass.IN,
-                                     message,raise_on_no_answer=False)
+                                     message, raise_on_no_answer=False)
         def test_python_internal_truth(answer):
             if answer:
                 return True

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -214,6 +214,23 @@ class BaseResolverTests(unittest.TestCase):
                                        dns.rdataclass.IN))
                             is None)
 
+    def testEmptyAnswerSection(self):
+        # TODO: dangling_cname_0_message_text was the only sample message
+        #       with an empty answer section. Other than that it doesn't
+        #       apply.
+        message = dns.message.from_text(dangling_cname_0_message_text)
+        name = dns.name.from_text('example.')
+        answer = dns.resolver.Answer(name, dns.rdatatype.A, dns.rdataclass.IN,
+                                     message,raise_on_no_answer=False)
+        def test_python_internal_truth(answer):
+            if answer:
+                return True
+            else:
+                return False
+        self.assertFalse(test_python_internal_truth(answer))
+        for a in answer:
+            pass
+
 class PollingMonkeyPatchMixin(object):
     def setUp(self):
         self.__native_polling_backend = dns.query._polling_backend


### PR DESCRIPTION
Basically, Answer is a wrapper for its enclosed rrset. When raise_on_no_answer
is False, the enclosed rrset is set to None and this is not taken into
account when evaluating built-in methods.

Assuming that code like the following is common:

    try:
        answer = dns.response.query(...)
    except e:
        answer = None
        
and that there are no RRs in the Answer section:

    if answer:
   
fails when a (NOERROR) valid response is returned which contains zero answers.
There is no easy way around it, you pretty much have to reach in and test the rrset:

    if answer is not None and answer.rrset:
    
and one has to specifically test "is not None" because otherwise it fails
as already noted.

The problem occurs because python calls the built-in function __len__, which
fails when it attempts to take len(self.rrset). A similar situation occurs
with __iter__; the other builtins should not be called without testing first
and therefore can be left as-is.
