### PR TITLE
Test creates file in wrong location

### DIFF
--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -177,7 +177,7 @@ class ZoneTestCase(unittest.TestCase):
     def testToFileFilename(self):
         z = dns.zone.from_file(here('example'), 'example')
         try:
-            z.to_file('example3-filename.out')
+            z.to_file(here('example3-filename.out'))
             ok = filecmp.cmp(here('example3-filename.out'),
                              here('example3.good'))
         finally:


### PR DESCRIPTION
test_zone.ZoneTestCase.testToFileFilename fails with OSError: [Errno 2] No such file or directory