### PR TITLE
Fix dns.ipv4.inet_aton() behavior in Python 3

### DIFF
--- a/dns/inet.py
+++ b/dns/inet.py
@@ -19,7 +19,7 @@ import socket
 
 import dns.ipv4
 import dns.ipv6
-
+from sys import version_info
 
 # We assume that AF_INET is always defined.
 
@@ -101,7 +101,12 @@ def is_multicast(text):
     @rtype: bool
     """
     try:
-        first = ord(dns.ipv4.inet_aton(text)[0])
+        if version_info[0] < 3:
+            # In Python 2 the dns.ipv4.inet_aton() returns a String object
+            first = ord(dns.ipv4.inet_aton(text)[0])
+        else:
+            # In Python 3 the dns.ipv4.inet_aton() returns a Bytes object
+            first = dns.ipv4.inet_aton(text)[0]
         return first >= 224 and first <= 239
     except Exception:
         try:

--- a/dns/ipv4.py
+++ b/dns/ipv4.py
@@ -19,7 +19,6 @@ import struct
 
 import dns.exception
 from ._compat import binary_type
-from sys import version_info
 
 def inet_ntoa(address):
     """Convert an IPv4 address in network form to text form.
@@ -55,15 +54,6 @@ def inet_aton(text):
             raise dns.exception.SyntaxError
     try:
         bytes = [int(part) for part in parts]
-        # Check for Python's major version
-        if(version_info[0] < 3):
-            # In Python 2, the struct.pack() returns a String object,
-            # while In Python 3, the struct.pack() returns a Bytes object
-            return struct.pack('BBBB', *bytes)
-        # In Python 3+, return the same String object as in Python 2
-        s=''
-        for byte in bytes:
-            s+=chr(byte)
-        return s
+        return struct.pack('BBBB', *bytes)
     except:
         raise dns.exception.SyntaxError

--- a/dns/ipv4.py
+++ b/dns/ipv4.py
@@ -19,6 +19,7 @@ import struct
 
 import dns.exception
 from ._compat import binary_type
+from sys import version_info
 
 def inet_ntoa(address):
     """Convert an IPv4 address in network form to text form.
@@ -54,6 +55,15 @@ def inet_aton(text):
             raise dns.exception.SyntaxError
     try:
         bytes = [int(part) for part in parts]
-        return struct.pack('BBBB', *bytes)
+        # Check for Python's major version
+        if(version_info[0] < 3):
+            # In Python 2, the struct.pack() returns a String object,
+            # while In Python 3, the struct.pack() returns a Bytes object
+            return struct.pack('BBBB', *bytes)
+        # In Python 3+, return the same String object as in Python 2
+        s=''
+        for byte in bytes:
+            s+=chr(byte)
+        return s
     except:
         raise dns.exception.SyntaxError

--- a/dns/ipv4.py
+++ b/dns/ipv4.py
@@ -56,14 +56,14 @@ def inet_aton(text):
     try:
         bytes = [int(part) for part in parts]
         # Check for Python's major version
-        if version_info[0] < 3:
+        if(version_info[0] < 3):
             # In Python 2, the struct.pack() returns a String object,
             # while In Python 3, the struct.pack() returns a Bytes object
             return struct.pack('BBBB', *bytes)
         # In Python 3+, return the same String object as in Python 2
-        s = ''
+        s=''
         for byte in bytes:
-            s += chr(byte)
+            s+=chr(byte)
         return s
     except:
         raise dns.exception.SyntaxError

--- a/dns/ipv4.py
+++ b/dns/ipv4.py
@@ -56,14 +56,14 @@ def inet_aton(text):
     try:
         bytes = [int(part) for part in parts]
         # Check for Python's major version
-        if(version_info[0] < 3):
+        if version_info[0] < 3:
             # In Python 2, the struct.pack() returns a String object,
             # while In Python 3, the struct.pack() returns a Bytes object
             return struct.pack('BBBB', *bytes)
         # In Python 3+, return the same String object as in Python 2
-        s=''
+        s = ''
         for byte in bytes:
-            s+=chr(byte)
+            s += chr(byte)
         return s
     except:
         raise dns.exception.SyntaxError


### PR DESCRIPTION
In Python 3, the struct.pack() returns a Bytes object, while in Python 2 it returns a String.
Because of that, with Python 3, the dns.inet.is_multicast() function fails when processing the object returned by dns.ipv4.inet_aton().
This commit creates a workaround so that dns.ipv4.inet_aton() returns the same String in Python 3 as in Python 2.