### PR TITLE
Basic comment support

### DIFF
--- a/dns/node.py
+++ b/dns/node.py
@@ -32,13 +32,15 @@ class Node(object):
         #: the set of rdatsets, represented as a list.
         self.rdatasets = []
 
-    def to_text(self, name, **kw):
+    def to_text(self, name, want_comment=False, **kw):
         """Convert a node to text format.
 
         Each rdataset at the node is printed.  Any keyword arguments
         to this method are passed on to the rdataset's to_text() method.
 
         *name*, a ``dns.name.Name``, the owner name of the rdatasets.
+        *want_comment*, a ``bool`` if True, stored comments will be printed 
+        behind the records.
 
         Returns a ``text``.
         """
@@ -46,7 +48,7 @@ class Node(object):
         s = StringIO()
         for rds in self.rdatasets:
             if len(rds) > 0:
-                s.write(rds.to_text(name, **kw))
+                s.write(rds.to_text(name, want_comment=want_comment, **kw))
                 s.write(u'\n')
         return s.getvalue()[:-1]
 

--- a/dns/node.py
+++ b/dns/node.py
@@ -32,13 +32,20 @@ class Node(object):
         #: the set of rdatsets, represented as a list.
         self.rdatasets = []
 
-    def to_text(self, name, want_comment=False, **kw):
+    def to_text(self, name,
+                pprint=u'%(name)s%(ttl)d %(rdclass)s %(rdtype)s %(rdata)s%(rcomment)s\n',
+                want_comment=False, **kw):
         """Convert a node to text format.
 
         Each rdataset at the node is printed.  Any keyword arguments
         to this method are passed on to the rdataset's to_text() method.
 
         *name*, a ``dns.name.Name``, the owner name of the rdatasets.
+        
+        *pprint*, a ``string``. A printf format string for pretty printing
+        the output. The following mapping keys need to be used:
+        ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
+        
         *want_comment*, a ``bool`` if True, stored comments will be printed 
         behind the records.
 
@@ -48,7 +55,8 @@ class Node(object):
         s = StringIO()
         for rds in self.rdatasets:
             if len(rds) > 0:
-                s.write(rds.to_text(name, want_comment=want_comment, **kw))
+                s.write(rds.to_text(name, pprint=pprint,
+                        want_comment=want_comment, **kw))
                 s.write(u'\n')
         return s.getvalue()[:-1]
 

--- a/dns/node.py
+++ b/dns/node.py
@@ -41,12 +41,12 @@ class Node(object):
         to this method are passed on to the rdataset's to_text() method.
 
         *name*, a ``dns.name.Name``, the owner name of the rdatasets.
-        
+
         *pprint*, a ``string``. A printf format string for pretty printing
         the output. The following mapping keys need to be used:
         ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
-        
-        *want_comment*, a ``bool`` if True, stored comments will be printed 
+
+        *want_comment*, a ``bool`` if True, stored comments will be printed
         behind the records.
 
         Returns a ``text``.

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -88,17 +88,19 @@ def _truncate_bitmap(what):
 class Rdata(object):
     """Base class for all DNS rdata types."""
 
-    __slots__ = ['rdclass', 'rdtype']
+    __slots__ = ['rdclass', 'rdtype', 'comment']
 
-    def __init__(self, rdclass, rdtype):
+    def __init__(self, rdclass, rdtype, comment=None):
         """Initialize an rdata.
 
         *rdclass*, an ``int`` is the rdataclass of the Rdata.
         *rdtype*, an ``int`` is the rdatatype of the Rdata.
+        *comment*, an ``string`` is the comment behind the record.
         """
 
         self.rdclass = rdclass
         self.rdtype = rdtype
+        self.comment = comment
 
     def covers(self):
         """Return the type a Rdata covers.
@@ -264,8 +266,8 @@ class GenericRdata(Rdata):
 
     __slots__ = ['data']
 
-    def __init__(self, rdclass, rdtype, data):
-        super(GenericRdata, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, data, comment=None):
+        super(GenericRdata, self).__init__(rdclass, rdtype, comment)
         self.data = data
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -186,12 +186,12 @@ class Rdataset(dns.set.Set):
 
         *relativize*, a ``bool``.  If ``True``, names will be relativized
         to *origin*.
-        
+
         *pprint*, a ``string``. A printf format string for pretty printing
         the output. The following mapping keys need to be used:
         ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
-        
-        *want_comment*, a ``bool`` if True, stored comments will be printed 
+
+        *want_comment*, a ``bool`` if True, stored comments will be printed
         behind the records.
         """
 

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -166,7 +166,9 @@ class Rdataset(dns.set.Set):
         return not self.__eq__(other)
 
     def to_text(self, name=None, origin=None, relativize=True,
-                override_rdclass=None, want_comment=False, **kw):
+                override_rdclass=None,
+                pprint=u'%(name)s%(ttl)d %(rdclass)s %(rdtype)s %(rdata)s%(rcomment)s\n',
+                want_comment=False, **kw):
         """Convert the rdataset into DNS master file format.
 
         See ``dns.name.Name.choose_relativity`` for more information
@@ -185,38 +187,42 @@ class Rdataset(dns.set.Set):
         *relativize*, a ``bool``.  If ``True``, names will be relativized
         to *origin*.
         
+        *pprint*, a ``string``. A printf format string for pretty printing
+        the output. The following mapping keys need to be used:
+        ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
+        
         *want_comment*, a ``bool`` if True, stored comments will be printed 
         behind the records.
         """
 
         if name is not None:
             name = name.choose_relativity(origin, relativize)
-            ntext = str(name)
-            pad = ' '
+            ntext = str(name) + ' '
         else:
             ntext = ''
-            pad = ''
         s = StringIO()
         if override_rdclass is not None:
             rdclass = override_rdclass
         else:
             rdclass = self.rdclass
         if len(self) == 0:
-            #
-            # Empty rdatasets are used for the question section, and in
-            # some dynamic updates, so we don't need to print out the TTL
-            # (which is meaningless anyway).
-            #
-            s.write(u'%s%s%s %s\n' % (ntext, pad,
-                                      dns.rdataclass.to_text(rdclass),
-                                      dns.rdatatype.to_text(self.rdtype)))
+            s.write(pprint % {"name" : ntext, "ttl" : self.ttl,
+                              "rdclass" : dns.rdataclass.to_text(rdclass),
+                              "rdtype" : dns.rdatatype.to_text(self.rdtype),
+                              "rdata" : '', "rcomment": ''})
         else:
             for rd in self:
-                s.write(u'%s%s%d %s %s %s\n' %
-                        (ntext, pad, self.ttl, dns.rdataclass.to_text(rdclass),
-                         dns.rdatatype.to_text(self.rdtype),
-                         rd.to_text(origin=origin, relativize=relativize,
-                         want_comment=want_comment, **kw)))
+                rdata = rd.to_text(origin=origin, relativize=relativize,
+                                   want_comment=want_comment, **kw).split(';')
+                rcomment = ''
+                if want_comment:
+                    rcomment = ';' + rdata[1]
+                rdata = rdata[0]
+                s.write(pprint %
+                        {"name" : ntext, "ttl" : self.ttl,
+                              "rdclass" : dns.rdataclass.to_text(rdclass),
+                              "rdtype" : dns.rdatatype.to_text(self.rdtype),
+                              "rdata" : rdata, "rcomment": rcomment})
         #
         # We strip off the final \n for the caller's convenience in printing
         #

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -166,7 +166,7 @@ class Rdataset(dns.set.Set):
         return not self.__eq__(other)
 
     def to_text(self, name=None, origin=None, relativize=True,
-                override_rdclass=None, **kw):
+                override_rdclass=None, want_comment=False, **kw):
         """Convert the rdataset into DNS master file format.
 
         See ``dns.name.Name.choose_relativity`` for more information
@@ -184,6 +184,9 @@ class Rdataset(dns.set.Set):
 
         *relativize*, a ``bool``.  If ``True``, names will be relativized
         to *origin*.
+        
+        *want_comment*, a ``bool`` if True, stored comments will be printed 
+        behind the records.
         """
 
         if name is not None:
@@ -213,7 +216,7 @@ class Rdataset(dns.set.Set):
                         (ntext, pad, self.ttl, dns.rdataclass.to_text(rdclass),
                          dns.rdatatype.to_text(self.rdtype),
                          rd.to_text(origin=origin, relativize=relativize,
-                         **kw)))
+                         want_comment=want_comment, **kw)))
         #
         # We strip off the final \n for the caller's convenience in printing
         #

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -34,8 +34,8 @@ class CAA(dns.rdata.Rdata):
 
     __slots__ = ['flags', 'tag', 'value']
 
-    def __init__(self, rdclass, rdtype, flags, tag, value):
-        super(CAA, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, flags, tag, value, comment=None):
+        super(CAA, self).__init__(rdclass, rdtype, comment)
         self.flags = flags
         self.tag = tag
         self.value = value

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -54,7 +54,13 @@ class CAA(dns.rdata.Rdata):
         if not tag.isalnum():
             raise dns.exception.SyntaxError("tag is not alphanumeric")
         value = tok.get_string().encode()
-        return cls(rdclass, rdtype, flags, tag, value)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, flags, tag, value, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(struct.pack('!B', self.flags))

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -40,7 +40,12 @@ class CAA(dns.rdata.Rdata):
         self.tag = tag
         self.value = value
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%u %s "%s" ;%s' % (self.flags,
+                                       dns.rdata._escapify(self.tag),
+                                       dns.rdata._escapify(self.value),
+                                       self.comment)
         return '%u %s "%s"' % (self.flags,
                                dns.rdata._escapify(self.tag),
                                dns.rdata._escapify(self.value))

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -69,8 +69,8 @@ class CERT(dns.rdata.Rdata):
     __slots__ = ['certificate_type', 'key_tag', 'algorithm', 'certificate']
 
     def __init__(self, rdclass, rdtype, certificate_type, key_tag, algorithm,
-                 certificate):
-        super(CERT, self).__init__(rdclass, rdtype)
+                 certificate, comment=None):
+        super(CERT, self).__init__(rdclass, rdtype, comment)
         self.certificate_type = certificate_type
         self.key_tag = key_tag
         self.algorithm = algorithm

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -76,8 +76,13 @@ class CERT(dns.rdata.Rdata):
         self.algorithm = algorithm
         self.certificate = certificate
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         certificate_type = _ctype_to_text(self.certificate_type)
+        if want_comment and self.comment:
+            return "%s %d %s %s ;%s" % (certificate_type, self.key_tag, 
+                                    dns.dnssec.algorithm_to_text(self.algorithm),
+                                    dns.rdata._base64ify(self.certificate),
+                                    self.comment)
         return "%s %d %s %s" % (certificate_type, self.key_tag,
                                 dns.dnssec.algorithm_to_text(self.algorithm),
                                 dns.rdata._base64ify(self.certificate))

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -90,17 +90,21 @@ class CERT(dns.rdata.Rdata):
         if algorithm < 0 or algorithm > 255:
             raise dns.exception.SyntaxError("bad algorithm type")
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment=t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         b64 = b''.join(chunks)
         certificate = base64.b64decode(b64)
         return cls(rdclass, rdtype, certificate_type, key_tag,
-                   algorithm, certificate)
+                   algorithm, certificate, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         prefix = struct.pack("!HHB", self.certificate_type, self.key_tag,

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -79,7 +79,7 @@ class CERT(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         certificate_type = _ctype_to_text(self.certificate_type)
         if want_comment and self.comment:
-            return "%s %d %s %s ;%s" % (certificate_type, self.key_tag, 
+            return "%s %d %s %s ;%s" % (certificate_type, self.key_tag,
                                     dns.dnssec.algorithm_to_text(self.algorithm),
                                     dns.rdata._base64ify(self.certificate),
                                     self.comment)

--- a/dns/rdtypes/ANY/CSYNC.py
+++ b/dns/rdtypes/ANY/CSYNC.py
@@ -34,8 +34,8 @@ class CSYNC(dns.rdata.Rdata):
 
     __slots__ = ['serial', 'flags', 'windows']
 
-    def __init__(self, rdclass, rdtype, serial, flags, windows):
-        super(CSYNC, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, serial, flags, windows, comment=None):
+        super(CSYNC, self).__init__(rdclass, rdtype, comment)
         self.serial = serial
         self.flags = flags
         self.windows = windows

--- a/dns/rdtypes/ANY/CSYNC.py
+++ b/dns/rdtypes/ANY/CSYNC.py
@@ -52,7 +52,7 @@ class CSYNC(dns.rdata.Rdata):
                                                           i * 8 + j))
             text += (' ' + ' '.join(bits))
         if want_comment and self.comment:
-            return '%d %d%s ;%s' % (self.serial, self.flags, text, 
+            return '%d %d%s ;%s' % (self.serial, self.flags, text,
                                     self.comment)
         return '%d %d%s' % (self.serial, self.flags, text)
 

--- a/dns/rdtypes/ANY/CSYNC.py
+++ b/dns/rdtypes/ANY/CSYNC.py
@@ -40,7 +40,7 @@ class CSYNC(dns.rdata.Rdata):
         self.flags = flags
         self.windows = windows
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         text = ''
         for (window, bitmap) in self.windows:
             bits = []
@@ -51,6 +51,9 @@ class CSYNC(dns.rdata.Rdata):
                         bits.append(dns.rdatatype.to_text(window * 256 +
                                                           i * 8 + j))
             text += (' ' + ' '.join(bits))
+        if want_comment and self.comment:
+            return '%d %d%s ;%s' % (self.serial, self.flags, text, 
+                                    self.comment)
         return '%d %d%s' % (self.serial, self.flags, text)
 
     @classmethod

--- a/dns/rdtypes/ANY/CSYNC.py
+++ b/dns/rdtypes/ANY/CSYNC.py
@@ -58,10 +58,14 @@ class CSYNC(dns.rdata.Rdata):
         serial = tok.get_uint32()
         flags = tok.get_uint16()
         rdtypes = []
+        comment = None
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             nrdtype = dns.rdatatype.from_text(token.value)
             if nrdtype == 0:
                 raise dns.exception.SyntaxError("CSYNC with bit 0")
@@ -90,7 +94,7 @@ class CSYNC(dns.rdata.Rdata):
             bitmap[byte] = bitmap[byte] | (0x80 >> bit)
 
         windows.append((window, bitmap[0:octets]))
-        return cls(rdclass, rdtype, serial, flags, windows)
+        return cls(rdclass, rdtype, serial, flags, windows, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(struct.pack('!IH', self.serial, self.flags))

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -90,8 +90,13 @@ class GPOS(dns.rdata.Rdata):
         latitude = tok.get_string()
         longitude = tok.get_string()
         altitude = tok.get_string()
-        tok.get_eol()
-        return cls(rdclass, rdtype, latitude, longitude, altitude)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, latitude, longitude, altitude, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.latitude)

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -80,7 +80,12 @@ class GPOS(dns.rdata.Rdata):
         self.longitude = longitude
         self.altitude = altitude
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s %s %s ;%s' % (self.latitude.decode(),
+                                 self.longitude.decode(),
+                                 self.altitude.decode(),
+                                 self.comment)
         return '%s %s %s' % (self.latitude.decode(),
                              self.longitude.decode(),
                              self.altitude.decode())

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -55,8 +55,9 @@ class GPOS(dns.rdata.Rdata):
 
     __slots__ = ['latitude', 'longitude', 'altitude']
 
-    def __init__(self, rdclass, rdtype, latitude, longitude, altitude):
-        super(GPOS, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, latitude, longitude, altitude, 
+                 comment=None):
+        super(GPOS, self).__init__(rdclass, rdtype, comment)
         if isinstance(latitude, float) or \
            isinstance(latitude, int) or \
            isinstance(latitude, long):

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -55,7 +55,7 @@ class GPOS(dns.rdata.Rdata):
 
     __slots__ = ['latitude', 'longitude', 'altitude']
 
-    def __init__(self, rdclass, rdtype, latitude, longitude, altitude, 
+    def __init__(self, rdclass, rdtype, latitude, longitude, altitude,
                  comment=None):
         super(GPOS, self).__init__(rdclass, rdtype, comment)
         if isinstance(latitude, float) or \

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -33,8 +33,8 @@ class HINFO(dns.rdata.Rdata):
 
     __slots__ = ['cpu', 'os']
 
-    def __init__(self, rdclass, rdtype, cpu, os):
-        super(HINFO, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, cpu, os, comment=None):
+        super(HINFO, self).__init__(rdclass, rdtype, comment)
         if isinstance(cpu, text_type):
             self.cpu = cpu.encode()
         else:

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -47,7 +47,7 @@ class HINFO(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if want_comment and self.comment:
             return '"%s" "%s" ;%s' % (dns.rdata._escapify(self.cpu),
-                                      dns.rdata._escapify(self.os), 
+                                      dns.rdata._escapify(self.os),
                                       self.comment)
         return '"%s" "%s"' % (dns.rdata._escapify(self.cpu),
                               dns.rdata._escapify(self.os))

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -44,7 +44,11 @@ class HINFO(dns.rdata.Rdata):
         else:
             self.os = os
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '"%s" "%s" ;%s' % (dns.rdata._escapify(self.cpu),
+                                      dns.rdata._escapify(self.os), 
+                                      self.comment)
         return '"%s" "%s"' % (dns.rdata._escapify(self.cpu),
                               dns.rdata._escapify(self.os))
 

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -52,8 +52,13 @@ class HINFO(dns.rdata.Rdata):
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         cpu = tok.get_string()
         os = tok.get_string()
-        tok.get_eol()
-        return cls(rdclass, rdtype, cpu, os)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, cpu, os, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.cpu)

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -38,8 +38,9 @@ class HIP(dns.rdata.Rdata):
 
     __slots__ = ['hit', 'algorithm', 'key', 'servers']
 
-    def __init__(self, rdclass, rdtype, hit, algorithm, key, servers):
-        super(HIP, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, hit, algorithm, key, servers, 
+                 comment=None):
+        super(HIP, self).__init__(rdclass, rdtype, comment)
         self.hit = hit
         self.algorithm = algorithm
         self.key = key

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -46,7 +46,7 @@ class HIP(dns.rdata.Rdata):
         self.key = key
         self.servers = servers
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         hit = binascii.hexlify(self.hit).decode()
         key = base64.b64encode(self.key).replace(b'\n', b'').decode()
         text = u''
@@ -55,6 +55,9 @@ class HIP(dns.rdata.Rdata):
             servers.append(server.choose_relativity(origin, relativize))
         if len(servers) > 0:
             text += (u' ' + u' '.join((x.to_unicode() for x in servers)))
+        if want_comment and self.comment:
+            return u'%u %s %s%s ;%s' % (self.algorithm, hit, key, text, 
+                                        self.comment)
         return u'%u %s %s%s' % (self.algorithm, hit, key, text)
 
     @classmethod

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -66,13 +66,16 @@ class HIP(dns.rdata.Rdata):
         key = base64.b64decode(tok.get_string().encode())
         servers = []
         while 1:
-            token = tok.get()
+            token = tok.get(want_comment=True)
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             server = dns.name.from_text(token.value, origin)
             server.choose_relativity(origin, relativize)
             servers.append(server)
-        return cls(rdclass, rdtype, hit, algorithm, key, servers)
+        return cls(rdclass, rdtype, hit, algorithm, key, servers, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         lh = len(self.hit)

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -38,7 +38,7 @@ class HIP(dns.rdata.Rdata):
 
     __slots__ = ['hit', 'algorithm', 'key', 'servers']
 
-    def __init__(self, rdclass, rdtype, hit, algorithm, key, servers, 
+    def __init__(self, rdclass, rdtype, hit, algorithm, key, servers,
                  comment=None):
         super(HIP, self).__init__(rdclass, rdtype, comment)
         self.hit = hit
@@ -56,7 +56,7 @@ class HIP(dns.rdata.Rdata):
         if len(servers) > 0:
             text += (u' ' + u' '.join((x.to_unicode() for x in servers)))
         if want_comment and self.comment:
-            return u'%u %s %s%s ;%s' % (self.algorithm, hit, key, text, 
+            return u'%u %s %s%s ;%s' % (self.algorithm, hit, key, text,
                                         self.comment)
         return u'%u %s %s%s' % (self.algorithm, hit, key, text)
 

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -33,8 +33,8 @@ class ISDN(dns.rdata.Rdata):
 
     __slots__ = ['address', 'subaddress']
 
-    def __init__(self, rdclass, rdtype, address, subaddress):
-        super(ISDN, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, subaddress, comment=None):
+        super(ISDN, self).__init__(rdclass, rdtype, comment)
         if isinstance(address, text_type):
             self.address = address.encode()
         else:

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -53,7 +53,7 @@ class ISDN(dns.rdata.Rdata):
             return '"%s" "%s"' % (dns.rdata._escapify(self.address),
                                   dns.rdata._escapify(self.subaddress))
         elif want_comment and self.comment:
-            return '"%s" ;%s' % (dns.rdata._escapify(self.address), 
+            return '"%s" ;%s' % (dns.rdata._escapify(self.address),
                                  self.comment)
         else:
             return '"%s"' % dns.rdata._escapify(self.address)

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -44,10 +44,17 @@ class ISDN(dns.rdata.Rdata):
         else:
             self.subaddress = subaddress
 
-    def to_text(self, origin=None, relativize=True, **kw):
-        if self.subaddress:
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if self.subaddress and want_comment and self.comment:
+            return '"%s" "%s" ;%s' % (dns.rdata._escapify(self.address),
+                                  dns.rdata._escapify(self.subaddress),
+                                  self.comment)
+        elif self.subaddress:
             return '"%s" "%s"' % (dns.rdata._escapify(self.address),
                                   dns.rdata._escapify(self.subaddress))
+        elif want_comment and self.comment:
+            return '"%s" ;%s' % (dns.rdata._escapify(self.address), 
+                                 self.comment)
         else:
             return '"%s"' % dns.rdata._escapify(self.address)
 

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -54,15 +54,21 @@ class ISDN(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         address = tok.get_string()
-        t = tok.get()
-        if not t.is_eol_or_eof():
+        comment = None
+        t = tok.get(want_comment=True)
+        if t.is_comment():
+            comment = t.value
+        elif not t.is_eol_or_eof():
             tok.unget(t)
             subaddress = tok.get_string()
         else:
             tok.unget(t)
             subaddress = ''
-        tok.get_eol()
-        return cls(rdclass, rdtype, address, subaddress)
+        while not t.is_eol_or_eof():
+            if t.is_comment():
+                comment = t.value
+            t = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, address, subaddress, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.address)

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -261,7 +261,7 @@ class LOC(dns.rdata.Rdata):
                     if value[-1] == 'm':
                         value = value[0: -1]
                     vprec = float(value) * 100.0        # m -> cm
-                    
+
         comment = None
         while not token.is_eol_or_eof():
             if token.is_comment()

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -241,28 +241,33 @@ class LOC(dns.rdata.Rdata):
             t = t[0: -1]
         altitude = float(t) * 100.0        # m -> cm
 
-        token = tok.get().unescape()
-        if not token.is_eol_or_eof():
+        token = tok.get(want_comment=True).unescape()
+        if not token.is_eol_or_eof() and not token.is_comment():
             value = token.value
             if value[-1] == 'm':
                 value = value[0: -1]
             size = float(value) * 100.0        # m -> cm
-            token = tok.get().unescape()
-            if not token.is_eol_or_eof():
+            token = tok.get(want_comment=True).unescape()
+            if not token.is_eol_or_eof() and not token.is_comment():
                 value = token.value
                 if value[-1] == 'm':
                     value = value[0: -1]
                 hprec = float(value) * 100.0        # m -> cm
-                token = tok.get().unescape()
-                if not token.is_eol_or_eof():
+                token = tok.get(want_comment=True).unescape()
+                if not token.is_eol_or_eof() and not token.is_comment():
                     value = token.value
                     if value[-1] == 'm':
                         value = value[0: -1]
                     vprec = float(value) * 100.0        # m -> cm
-                    tok.get_eol()
+                    
+        comment = None
+        while not token.is_eol_or_eof():
+            if token.is_comment()
+                comment = token.value
+            token = tok.get(want_comment=True)
 
         return cls(rdclass, rdtype, latitude, longitude, altitude,
-                   size, hprec, vprec)
+                   size, hprec, vprec, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         milliseconds = (self.latitude[0] * 3600000 +

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -110,7 +110,7 @@ class LOC(dns.rdata.Rdata):
 
     def __init__(self, rdclass, rdtype, latitude, longitude, altitude,
                  size=_default_size, hprec=_default_hprec,
-                 vprec=_default_vprec):
+                 vprec=_default_vprec, comment=None):
         """Initialize a LOC record instance.
 
         The parameters I{latitude} and I{longitude} may be either a 4-tuple
@@ -119,7 +119,7 @@ class LOC(dns.rdata.Rdata):
         degrees. The other parameters are floats. Size, horizontal precision,
         and vertical precision are specified in centimeters."""
 
-        super(LOC, self).__init__(rdclass, rdtype)
+        super(LOC, self).__init__(rdclass, rdtype, comment)
         if isinstance(latitude, int) or isinstance(latitude, long):
             latitude = float(latitude)
         if isinstance(latitude, float):

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -135,7 +135,7 @@ class LOC(dns.rdata.Rdata):
         self.horizontal_precision = float(hprec)
         self.vertical_precision = float(vprec)
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if self.latitude[4] > 0:
             lat_hemisphere = 'N'
         else:
@@ -160,6 +160,8 @@ class LOC(dns.rdata.Rdata):
                 self.size / 100.0, self.horizontal_precision / 100.0,
                 self.vertical_precision / 100.0
             )
+        if want_comment and self.comment:
+            return '%s ;%s' % (text, self.comment)
         return text
 
     @classmethod

--- a/dns/rdtypes/ANY/NSEC.py
+++ b/dns/rdtypes/ANY/NSEC.py
@@ -33,8 +33,8 @@ class NSEC(dns.rdata.Rdata):
 
     __slots__ = ['next', 'windows']
 
-    def __init__(self, rdclass, rdtype, next, windows):
-        super(NSEC, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, next, windows, comment=None):
+        super(NSEC, self).__init__(rdclass, rdtype, comment)
         self.next = next
         self.windows = windows
 

--- a/dns/rdtypes/ANY/NSEC.py
+++ b/dns/rdtypes/ANY/NSEC.py
@@ -57,10 +57,14 @@ class NSEC(dns.rdata.Rdata):
         next = tok.get_name()
         next = next.choose_relativity(origin, relativize)
         rdtypes = []
+        comment = None
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             nrdtype = dns.rdatatype.from_text(token.value)
             if nrdtype == 0:
                 raise dns.exception.SyntaxError("NSEC with bit 0")
@@ -89,7 +93,7 @@ class NSEC(dns.rdata.Rdata):
             bitmap[byte] = bitmap[byte] | (0x80 >> bit)
 
         windows.append((window, bitmap[0:octets]))
-        return cls(rdclass, rdtype, next, windows)
+        return cls(rdclass, rdtype, next, windows, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         self.next.to_wire(file, None, origin)

--- a/dns/rdtypes/ANY/NSEC.py
+++ b/dns/rdtypes/ANY/NSEC.py
@@ -38,7 +38,7 @@ class NSEC(dns.rdata.Rdata):
         self.next = next
         self.windows = windows
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         next = self.next.choose_relativity(origin, relativize)
         text = ''
         for (window, bitmap) in self.windows:
@@ -50,6 +50,8 @@ class NSEC(dns.rdata.Rdata):
                         bits.append(dns.rdatatype.to_text(window * 256 +
                                                           i * 8 + j))
             text += (' ' + ' '.join(bits))
+        if want_comment and self.comment:
+            return '%s%s ;%s' % (next, text, self.comment)
         return '%s%s' % (next, text)
 
     @classmethod

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -75,7 +75,7 @@ class NSEC3(dns.rdata.Rdata):
         self.next = next
         self.windows = windows
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         next = base64.b32encode(self.next).translate(
             b32_normal_to_hex).lower().decode()
         if self.salt == b'':
@@ -92,6 +92,10 @@ class NSEC3(dns.rdata.Rdata):
                         bits.append(dns.rdatatype.to_text(window * 256 +
                                                           i * 8 + j))
             text += (u' ' + u' '.join(bits))
+        if want_comment and self.comment:
+            return u'%u %u %u %s %s%s ;%s' % (self.algorithm, self.flags,
+                                              self.iterations, salt, next, 
+                                              text, self.comment)
         return u'%u %u %u %s %s%s' % (self.algorithm, self.flags,
                                       self.iterations, salt, next, text)
 

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -63,8 +63,8 @@ class NSEC3(dns.rdata.Rdata):
     __slots__ = ['algorithm', 'flags', 'iterations', 'salt', 'next', 'windows']
 
     def __init__(self, rdclass, rdtype, algorithm, flags, iterations, salt,
-                 next, windows):
-        super(NSEC3, self).__init__(rdclass, rdtype)
+                 next, windows, comment=None):
+        super(NSEC3, self).__init__(rdclass, rdtype, comment)
         self.algorithm = algorithm
         self.flags = flags
         self.iterations = iterations

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -109,10 +109,14 @@ class NSEC3(dns.rdata.Rdata):
             'ascii').upper().translate(b32_hex_to_normal)
         next = base64.b32decode(next)
         rdtypes = []
+        comment = None
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             nrdtype = dns.rdatatype.from_text(token.value)
             if nrdtype == 0:
                 raise dns.exception.SyntaxError("NSEC3 with bit 0")
@@ -143,7 +147,7 @@ class NSEC3(dns.rdata.Rdata):
         if octets != 0:
             windows.append((window, bitmap[0:octets]))
         return cls(rdclass, rdtype, algorithm, flags, iterations, salt, next,
-                   windows)
+                   windows, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.salt)

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -94,7 +94,7 @@ class NSEC3(dns.rdata.Rdata):
             text += (u' ' + u' '.join(bits))
         if want_comment and self.comment:
             return u'%u %u %u %s %s%s ;%s' % (self.algorithm, self.flags,
-                                              self.iterations, salt, next, 
+                                              self.iterations, salt, next,
                                               text, self.comment)
         return u'%u %u %u %s %s%s' % (self.algorithm, self.flags,
                                       self.iterations, salt, next, text)

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -36,7 +36,7 @@ class NSEC3PARAM(dns.rdata.Rdata):
 
     __slots__ = ['algorithm', 'flags', 'iterations', 'salt']
 
-    def __init__(self, rdclass, rdtype, algorithm, flags, iterations, salt, 
+    def __init__(self, rdclass, rdtype, algorithm, flags, iterations, salt,
                  comment=None):
         super(NSEC3PARAM, self).__init__(rdclass, rdtype, comment)
         self.algorithm = algorithm
@@ -53,7 +53,7 @@ class NSEC3PARAM(dns.rdata.Rdata):
         else:
             salt = binascii.hexlify(self.salt).decode()
         if want_comment and self.comment:
-            return '%u %u %u %s ;%s' % (self.algorithm, self.flags, 
+            return '%u %u %u %s ;%s' % (self.algorithm, self.flags,
                                     self.iterations, salt, self.comment)
         return '%u %u %u %s' % (self.algorithm, self.flags, self.iterations,
                                 salt)

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -65,8 +65,13 @@ class NSEC3PARAM(dns.rdata.Rdata):
             salt = ''
         else:
             salt = binascii.unhexlify(salt.encode())
-        tok.get_eol()
-        return cls(rdclass, rdtype, algorithm, flags, iterations, salt)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, algorithm, flags, iterations, salt, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.salt)

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -47,11 +47,14 @@ class NSEC3PARAM(dns.rdata.Rdata):
         else:
             self.salt = salt
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if self.salt == b'':
             salt = '-'
         else:
             salt = binascii.hexlify(self.salt).decode()
+        if want_comment and self.comment:
+            return '%u %u %u %s ;%s' % (self.algorithm, self.flags, 
+                                    self.iterations, salt, self.comment)
         return '%u %u %u %s' % (self.algorithm, self.flags, self.iterations,
                                 salt)
 

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -36,8 +36,9 @@ class NSEC3PARAM(dns.rdata.Rdata):
 
     __slots__ = ['algorithm', 'flags', 'iterations', 'salt']
 
-    def __init__(self, rdclass, rdtype, algorithm, flags, iterations, salt):
-        super(NSEC3PARAM, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, algorithm, flags, iterations, salt, 
+                 comment=None):
+        super(NSEC3PARAM, self).__init__(rdclass, rdtype, comment)
         self.algorithm = algorithm
         self.flags = flags
         self.iterations = iterations

--- a/dns/rdtypes/ANY/OPENPGPKEY.py
+++ b/dns/rdtypes/ANY/OPENPGPKEY.py
@@ -32,7 +32,9 @@ class OPENPGPKEY(dns.rdata.Rdata):
         super(OPENPGPKEY, self).__init__(rdclass, rdtype, comment)
         self.key = key
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (dns.rdata._base64ify(self.key), self.comment)
         return dns.rdata._base64ify(self.key)
 
     @classmethod

--- a/dns/rdtypes/ANY/OPENPGPKEY.py
+++ b/dns/rdtypes/ANY/OPENPGPKEY.py
@@ -38,16 +38,20 @@ class OPENPGPKEY(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment = t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         b64 = b''.join(chunks)
         key = base64.b64decode(b64)
-        return cls(rdclass, rdtype, key)
+        return cls(rdclass, rdtype, key, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(self.key)

--- a/dns/rdtypes/ANY/OPENPGPKEY.py
+++ b/dns/rdtypes/ANY/OPENPGPKEY.py
@@ -28,8 +28,8 @@ class OPENPGPKEY(dns.rdata.Rdata):
     @see: RFC 7929
     """
 
-    def __init__(self, rdclass, rdtype, key):
-        super(OPENPGPKEY, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, key, comment=None):
+        super(OPENPGPKEY, self).__init__(rdclass, rdtype, comment)
         self.key = key
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -31,8 +31,8 @@ class RP(dns.rdata.Rdata):
 
     __slots__ = ['mbox', 'txt']
 
-    def __init__(self, rdclass, rdtype, mbox, txt):
-        super(RP, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, mbox, txt, comment=None):
+        super(RP, self).__init__(rdclass, rdtype, comment)
         self.mbox = mbox
         self.txt = txt
 

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -36,9 +36,11 @@ class RP(dns.rdata.Rdata):
         self.mbox = mbox
         self.txt = txt
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         mbox = self.mbox.choose_relativity(origin, relativize)
         txt = self.txt.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return "%s %s ;%s" % (str(mbox), str(txt), self.comment)
         return "%s %s" % (str(mbox), str(txt))
 
     @classmethod

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -47,8 +47,13 @@ class RP(dns.rdata.Rdata):
         txt = tok.get_name()
         mbox = mbox.choose_relativity(origin, relativize)
         txt = txt.choose_relativity(origin, relativize)
-        tok.get_eol()
-        return cls(rdclass, rdtype, mbox, txt)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, mbox, txt, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         self.mbox.to_wire(file, None, origin)

--- a/dns/rdtypes/ANY/RRSIG.py
+++ b/dns/rdtypes/ANY/RRSIG.py
@@ -75,8 +75,8 @@ class RRSIG(dns.rdata.Rdata):
 
     def __init__(self, rdclass, rdtype, type_covered, algorithm, labels,
                  original_ttl, expiration, inception, key_tag, signer,
-                 signature):
-        super(RRSIG, self).__init__(rdclass, rdtype)
+                 signature, comment=None):
+        super(RRSIG, self).__init__(rdclass, rdtype, comment)
         self.type_covered = type_covered
         self.algorithm = algorithm
         self.labels = labels

--- a/dns/rdtypes/ANY/RRSIG.py
+++ b/dns/rdtypes/ANY/RRSIG.py
@@ -115,10 +115,14 @@ class RRSIG(dns.rdata.Rdata):
         signer = tok.get_name()
         signer = signer.choose_relativity(origin, relativize)
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment = t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
@@ -126,7 +130,7 @@ class RRSIG(dns.rdata.Rdata):
         signature = base64.b64decode(b64)
         return cls(rdclass, rdtype, type_covered, algorithm, labels,
                    original_ttl, expiration, inception, key_tag, signer,
-                   signature)
+                   signature, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack('!HBBIIIH', self.type_covered,

--- a/dns/rdtypes/ANY/RRSIG.py
+++ b/dns/rdtypes/ANY/RRSIG.py
@@ -90,7 +90,19 @@ class RRSIG(dns.rdata.Rdata):
     def covers(self):
         return self.type_covered
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s %d %d %d %s %s %d %s %s ;%s' % (
+            dns.rdatatype.to_text(self.type_covered),
+            self.algorithm,
+            self.labels,
+            self.original_ttl,
+            posixtime_to_sigtime(self.expiration),
+            posixtime_to_sigtime(self.inception),
+            self.key_tag,
+            self.signer.choose_relativity(origin, relativize),
+            dns.rdata._base64ify(self.signature),
+            self.comment)
         return '%s %d %d %d %s %s %d %s %s' % (
             dns.rdatatype.to_text(self.type_covered),
             self.algorithm,

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -45,8 +45,8 @@ class SOA(dns.rdata.Rdata):
                  'minimum']
 
     def __init__(self, rdclass, rdtype, mname, rname, serial, refresh, retry,
-                 expire, minimum):
-        super(SOA, self).__init__(rdclass, rdtype)
+                 expire, minimum, comment=None):
+        super(SOA, self).__init__(rdclass, rdtype, comment)
         self.mname = mname
         self.rname = rname
         self.serial = serial

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -59,7 +59,7 @@ class SOA(dns.rdata.Rdata):
         mname = self.mname.choose_relativity(origin, relativize)
         rname = self.rname.choose_relativity(origin, relativize)
         if want_comment and self.comment:
-            return '%s %s %d %d %d %d %d ;%s' % (mname, rname, self.serial, 
+            return '%s %s %d %d %d %d %d ;%s' % (mname, rname, self.serial,
                                              self.refresh, self.retry,
                                              self.expire, self.minimum,
                                              self.comment)

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -73,9 +73,13 @@ class SOA(dns.rdata.Rdata):
         retry = tok.get_ttl()
         expire = tok.get_ttl()
         minimum = tok.get_ttl()
-        tok.get_eol()
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
         return cls(rdclass, rdtype, mname, rname, serial, refresh, retry,
-                   expire, minimum)
+                   expire, minimum, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         self.mname.to_wire(file, compress, origin)

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -55,9 +55,14 @@ class SOA(dns.rdata.Rdata):
         self.expire = expire
         self.minimum = minimum
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         mname = self.mname.choose_relativity(origin, relativize)
         rname = self.rname.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%s %s %d %d %d %d %d ;%s' % (mname, rname, self.serial, 
+                                             self.refresh, self.retry,
+                                             self.expire, self.minimum,
+                                             self.comment)
         return '%s %s %d %d %d %d %d' % (
             mname, rname, self.serial, self.refresh, self.retry,
             self.expire, self.minimum)

--- a/dns/rdtypes/ANY/SSHFP.py
+++ b/dns/rdtypes/ANY/SSHFP.py
@@ -35,8 +35,8 @@ class SSHFP(dns.rdata.Rdata):
     __slots__ = ['algorithm', 'fp_type', 'fingerprint']
 
     def __init__(self, rdclass, rdtype, algorithm, fp_type,
-                 fingerprint):
-        super(SSHFP, self).__init__(rdclass, rdtype)
+                 fingerprint, comment=None):
+        super(SSHFP, self).__init__(rdclass, rdtype, comment)
         self.algorithm = algorithm
         self.fp_type = fp_type
         self.fingerprint = fingerprint

--- a/dns/rdtypes/ANY/SSHFP.py
+++ b/dns/rdtypes/ANY/SSHFP.py
@@ -41,7 +41,13 @@ class SSHFP(dns.rdata.Rdata):
         self.fp_type = fp_type
         self.fingerprint = fingerprint
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%d %d %s ;%s' % (self.algorithm,
+                                 self.fp_type,
+                                 dns.rdata._hexify(self.fingerprint,
+                                                   chunksize=128),
+                                 self.comment)
         return '%d %d %s' % (self.algorithm,
                              self.fp_type,
                              dns.rdata._hexify(self.fingerprint,

--- a/dns/rdtypes/ANY/SSHFP.py
+++ b/dns/rdtypes/ANY/SSHFP.py
@@ -52,16 +52,20 @@ class SSHFP(dns.rdata.Rdata):
         algorithm = tok.get_uint8()
         fp_type = tok.get_uint8()
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment = t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         fingerprint = b''.join(chunks)
         fingerprint = binascii.unhexlify(fingerprint)
-        return cls(rdclass, rdtype, algorithm, fp_type, fingerprint)
+        return cls(rdclass, rdtype, algorithm, fp_type, fingerprint, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack("!BB", self.algorithm, self.fp_type)

--- a/dns/rdtypes/ANY/TLSA.py
+++ b/dns/rdtypes/ANY/TLSA.py
@@ -37,8 +37,8 @@ class TLSA(dns.rdata.Rdata):
     __slots__ = ['usage', 'selector', 'mtype', 'cert']
 
     def __init__(self, rdclass, rdtype, usage, selector,
-                 mtype, cert):
-        super(TLSA, self).__init__(rdclass, rdtype)
+                 mtype, cert, comment=None):
+        super(TLSA, self).__init__(rdclass, rdtype, comment)
         self.usage = usage
         self.selector = selector
         self.mtype = mtype

--- a/dns/rdtypes/ANY/TLSA.py
+++ b/dns/rdtypes/ANY/TLSA.py
@@ -44,7 +44,14 @@ class TLSA(dns.rdata.Rdata):
         self.mtype = mtype
         self.cert = cert
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%d %d %d %s ;%s' % (self.usage,
+                                self.selector,
+                                self.mtype,
+                                dns.rdata._hexify(self.cert,
+                                                  chunksize=128),
+                                self.comment)
         return '%d %d %d %s' % (self.usage,
                                 self.selector,
                                 self.mtype,

--- a/dns/rdtypes/ANY/TLSA.py
+++ b/dns/rdtypes/ANY/TLSA.py
@@ -57,16 +57,20 @@ class TLSA(dns.rdata.Rdata):
         selector = tok.get_uint8()
         mtype = tok.get_uint8()
         cert_chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment = t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             cert_chunks.append(t.value.encode())
         cert = b''.join(cert_chunks)
         cert = binascii.unhexlify(cert)
-        return cls(rdclass, rdtype, usage, selector, mtype, cert)
+        return cls(rdclass, rdtype, usage, selector, mtype, cert, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack("!BBB", self.usage, self.selector, self.mtype)

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -36,8 +36,8 @@ class URI(dns.rdata.Rdata):
 
     __slots__ = ['priority', 'weight', 'target']
 
-    def __init__(self, rdclass, rdtype, priority, weight, target):
-        super(URI, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, priority, weight, target, comment=None):
+        super(URI, self).__init__(rdclass, rdtype, comment)
         self.priority = priority
         self.weight = weight
         if len(target) < 1:

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -47,7 +47,10 @@ class URI(dns.rdata.Rdata):
         else:
             self.target = target
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%d %d "%s" ;%s' % (self.priority, self.weight,
+                                       self.target.decode(), self.comment)
         return '%d %d "%s"' % (self.priority, self.weight,
                                self.target.decode())
 

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -53,13 +53,17 @@ class URI(dns.rdata.Rdata):
 
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        comment=None
         priority = tok.get_uint16()
         weight = tok.get_uint16()
         target = tok.get().unescape()
         if not (target.is_quoted_string() or target.is_identifier()):
             raise dns.exception.SyntaxError("URI target must be a string")
-        tok.get_eol()
-        return cls(rdclass, rdtype, priority, weight, target.value)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, priority, weight, target.value, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         two_ints = struct.pack("!HH", self.priority, self.weight)

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -31,8 +31,8 @@ class X25(dns.rdata.Rdata):
 
     __slots__ = ['address']
 
-    def __init__(self, rdclass, rdtype, address):
-        super(X25, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, comment=None):
+        super(X25, self).__init__(rdclass, rdtype, comment)
         if isinstance(address, text_type):
             self.address = address.encode()
         else:

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -43,9 +43,14 @@ class X25(dns.rdata.Rdata):
 
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        comment = None
         address = tok.get_string()
-        tok.get_eol()
-        return cls(rdclass, rdtype, address)
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, address, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         l = len(self.address)

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -40,7 +40,7 @@ class X25(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if want_comment and self.comment:
-            return '"%s" ;%s' % (dns.rdata._escapify(self.address), 
+            return '"%s" ;%s' % (dns.rdata._escapify(self.address),
                                  self.comment)
         return '"%s"' % dns.rdata._escapify(self.address)
 

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -38,7 +38,10 @@ class X25(dns.rdata.Rdata):
         else:
             self.address = address
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '"%s" ;%s' % (dns.rdata._escapify(self.address), 
+                                 self.comment)
         return '"%s"' % dns.rdata._escapify(self.address)
 
     @classmethod

--- a/dns/rdtypes/IN/A.py
+++ b/dns/rdtypes/IN/A.py
@@ -28,8 +28,8 @@ class A(dns.rdata.Rdata):
 
     __slots__ = ['address']
 
-    def __init__(self, rdclass, rdtype, address):
-        super(A, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, comment=None):
+        super(A, self).__init__(rdclass, rdtype, comment)
         # check that it's OK
         dns.ipv4.inet_aton(address)
         self.address = address

--- a/dns/rdtypes/IN/A.py
+++ b/dns/rdtypes/IN/A.py
@@ -34,7 +34,9 @@ class A(dns.rdata.Rdata):
         dns.ipv4.inet_aton(address)
         self.address = address
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (self.address, self.comment)
         return self.address
 
     @classmethod

--- a/dns/rdtypes/IN/A.py
+++ b/dns/rdtypes/IN/A.py
@@ -40,8 +40,13 @@ class A(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         address = tok.get_identifier()
-        tok.get_eol()
-        return cls(rdclass, rdtype, address)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, address, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(dns.ipv4.inet_aton(self.address))

--- a/dns/rdtypes/IN/AAAA.py
+++ b/dns/rdtypes/IN/AAAA.py
@@ -28,8 +28,8 @@ class AAAA(dns.rdata.Rdata):
 
     __slots__ = ['address']
 
-    def __init__(self, rdclass, rdtype, address):
-        super(AAAA, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, comment=None):
+        super(AAAA, self).__init__(rdclass, rdtype, comment)
         # check that it's OK
         dns.inet.inet_pton(dns.inet.AF_INET6, address)
         self.address = address

--- a/dns/rdtypes/IN/AAAA.py
+++ b/dns/rdtypes/IN/AAAA.py
@@ -34,7 +34,9 @@ class AAAA(dns.rdata.Rdata):
         dns.inet.inet_pton(dns.inet.AF_INET6, address)
         self.address = address
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (self.address, self.comment)
         return self.address
 
     @classmethod

--- a/dns/rdtypes/IN/AAAA.py
+++ b/dns/rdtypes/IN/AAAA.py
@@ -40,8 +40,13 @@ class AAAA(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         address = tok.get_identifier()
-        tok.get_eol()
-        return cls(rdclass, rdtype, address)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, address, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(dns.inet.inet_pton(dns.inet.AF_INET6, self.address))

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -86,8 +86,8 @@ class APL(dns.rdata.Rdata):
 
     __slots__ = ['items']
 
-    def __init__(self, rdclass, rdtype, items):
-        super(APL, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, items, comment=None):
+        super(APL, self).__init__(rdclass, rdtype, comment)
         self.items = items
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -90,7 +90,9 @@ class APL(dns.rdata.Rdata):
         super(APL, self).__init__(rdclass, rdtype, comment)
         self.items = items
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (' '.join(map(str, self.items)), self.comment)
         return ' '.join(map(str, self.items))
 
     @classmethod

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -96,10 +96,14 @@ class APL(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         items = []
+        comment = None
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             item = token.value
             if item[0] == '!':
                 negation = True
@@ -113,7 +117,7 @@ class APL(dns.rdata.Rdata):
             item = APLItem(family, negation, address, prefix)
             items.append(item)
 
-        return cls(rdclass, rdtype, items)
+        return cls(rdclass, rdtype, items, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         for item in self.items:

--- a/dns/rdtypes/IN/DHCID.py
+++ b/dns/rdtypes/IN/DHCID.py
@@ -29,8 +29,8 @@ class DHCID(dns.rdata.Rdata):
 
     __slots__ = ['data']
 
-    def __init__(self, rdclass, rdtype, data):
-        super(DHCID, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, data, comment=None):
+        super(DHCID, self).__init__(rdclass, rdtype, comment)
         self.data = data
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdtypes/IN/DHCID.py
+++ b/dns/rdtypes/IN/DHCID.py
@@ -39,16 +39,20 @@ class DHCID(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment=t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         b64 = b''.join(chunks)
         data = base64.b64decode(b64)
-        return cls(rdclass, rdtype, data)
+        return cls(rdclass, rdtype, data, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(self.data)

--- a/dns/rdtypes/IN/DHCID.py
+++ b/dns/rdtypes/IN/DHCID.py
@@ -33,7 +33,9 @@ class DHCID(dns.rdata.Rdata):
         super(DHCID, self).__init__(rdclass, rdtype, comment)
         self.data = data
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (dns.rdata._base64ify(self.data), self.comment)
         return dns.rdata._base64ify(self.data)
 
     @classmethod

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -40,8 +40,8 @@ class IPSECKEY(dns.rdata.Rdata):
     __slots__ = ['precedence', 'gateway_type', 'algorithm', 'gateway', 'key']
 
     def __init__(self, rdclass, rdtype, precedence, gateway_type, algorithm,
-                 gateway, key):
-        super(IPSECKEY, self).__init__(rdclass, rdtype)
+                 gateway, key, comment=None):
+        super(IPSECKEY, self).__init__(rdclass, rdtype, comment)
         if gateway_type == 0:
             if gateway != '.' and gateway is not None:
                 raise SyntaxError('invalid gateway for gateway type 0')

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -88,17 +88,21 @@ class IPSECKEY(dns.rdata.Rdata):
         else:
             gateway = tok.get_string()
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment=t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         b64 = b''.join(chunks)
         key = base64.b64decode(b64)
         return cls(rdclass, rdtype, precedence, gateway_type, algorithm,
-                   gateway, key)
+                   gateway, key, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack("!BBB", self.precedence, self.gateway_type,

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -63,7 +63,7 @@ class IPSECKEY(dns.rdata.Rdata):
         self.gateway = gateway
         self.key = key
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if self.gateway_type == 0:
             gateway = '.'
         elif self.gateway_type == 1:
@@ -74,6 +74,11 @@ class IPSECKEY(dns.rdata.Rdata):
             gateway = str(self.gateway.choose_relativity(origin, relativize))
         else:
             raise ValueError('invalid gateway type')
+        if want_comment and self.comment:
+            return '%d %d %d %s %s ;%s' % (self.precedence, self.gateway_type,
+                                       self.algorithm, gateway,
+                                       dns.rdata._base64ify(self.key),
+                                       self.comment)
         return '%d %d %d %s %s' % (self.precedence, self.gateway_type,
                                    self.algorithm, gateway,
                                    dns.rdata._base64ify(self.key))

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -56,8 +56,8 @@ class NAPTR(dns.rdata.Rdata):
                  'replacement']
 
     def __init__(self, rdclass, rdtype, order, preference, flags, service,
-                 regexp, replacement):
-        super(NAPTR, self).__init__(rdclass, rdtype)
+                 regexp, replacement, comment=None):
+        super(NAPTR, self).__init__(rdclass, rdtype, comment)
         self.flags = _sanitize(flags)
         self.service = _sanitize(service)
         self.regexp = _sanitize(regexp)

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -83,9 +83,14 @@ class NAPTR(dns.rdata.Rdata):
         regexp = tok.get_string()
         replacement = tok.get_name()
         replacement = replacement.choose_relativity(origin, relativize)
-        tok.get_eol()
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
         return cls(rdclass, rdtype, order, preference, flags, service,
-                   regexp, replacement)
+                   regexp, replacement, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         two_ints = struct.pack("!HH", self.order, self.preference)

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -65,8 +65,15 @@ class NAPTR(dns.rdata.Rdata):
         self.preference = preference
         self.replacement = replacement
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         replacement = self.replacement.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%d %d "%s" "%s" "%s" %s' % \
+                   (self.order, self.preference,
+                    dns.rdata._escapify(self.flags),
+                    dns.rdata._escapify(self.service),
+                    dns.rdata._escapify(self.regexp),
+                    replacement, self.comment)
         return '%d %d "%s" "%s" "%s" %s' % \
                (self.order, self.preference,
                 dns.rdata._escapify(self.flags),

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -30,8 +30,8 @@ class NSAP(dns.rdata.Rdata):
 
     __slots__ = ['address']
 
-    def __init__(self, rdclass, rdtype, address):
-        super(NSAP, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, comment=None):
+        super(NSAP, self).__init__(rdclass, rdtype, comment)
         self.address = address
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -34,7 +34,10 @@ class NSAP(dns.rdata.Rdata):
         super(NSAP, self).__init__(rdclass, rdtype, comment)
         self.address = address
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return "0x%s ;%s" % (binascii.hexlify(self.address).decode(), 
+                                 self.comment)
         return "0x%s" % binascii.hexlify(self.address).decode()
 
     @classmethod

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -36,7 +36,7 @@ class NSAP(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if want_comment and self.comment:
-            return "0x%s ;%s" % (binascii.hexlify(self.address).decode(), 
+            return "0x%s ;%s" % (binascii.hexlify(self.address).decode(),
                                  self.comment)
         return "0x%s" % binascii.hexlify(self.address).decode()
 

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -40,14 +40,19 @@ class NSAP(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         address = tok.get_string()
-        tok.get_eol()
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
         if address[0:2] != '0x':
             raise dns.exception.SyntaxError('string does not start with 0x')
         address = address[2:].replace('.', '')
         if len(address) % 2 != 0:
             raise dns.exception.SyntaxError('hexstring has odd length')
         address = binascii.unhexlify(address.encode())
-        return cls(rdclass, rdtype, address)
+        return cls(rdclass, rdtype, address, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(self.address)

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -40,9 +40,12 @@ class PX(dns.rdata.Rdata):
         self.map822 = map822
         self.mapx400 = mapx400
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         map822 = self.map822.choose_relativity(origin, relativize)
         mapx400 = self.mapx400.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%d %s %s ;%s' % (self.preference, map822, mapx400, 
+                                     self.comment)
         return '%d %s %s' % (self.preference, map822, mapx400)
 
     @classmethod

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -52,8 +52,13 @@ class PX(dns.rdata.Rdata):
         map822 = map822.choose_relativity(origin, relativize)
         mapx400 = tok.get_name(None)
         mapx400 = mapx400.choose_relativity(origin, relativize)
-        tok.get_eol()
-        return cls(rdclass, rdtype, preference, map822, mapx400)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, preference, map822, mapx400, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         pref = struct.pack("!H", self.preference)

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -44,7 +44,7 @@ class PX(dns.rdata.Rdata):
         map822 = self.map822.choose_relativity(origin, relativize)
         mapx400 = self.mapx400.choose_relativity(origin, relativize)
         if want_comment and self.comment:
-            return '%d %s %s ;%s' % (self.preference, map822, mapx400, 
+            return '%d %s %s ;%s' % (self.preference, map822, mapx400,
                                      self.comment)
         return '%d %s %s' % (self.preference, map822, mapx400)
 

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -34,8 +34,8 @@ class PX(dns.rdata.Rdata):
 
     __slots__ = ['preference', 'map822', 'mapx400']
 
-    def __init__(self, rdclass, rdtype, preference, map822, mapx400):
-        super(PX, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, preference, map822, mapx400, comment=None):
+        super(PX, self).__init__(rdclass, rdtype, comment)
         self.preference = preference
         self.map822 = map822
         self.mapx400 = mapx400

--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -43,8 +43,11 @@ class SRV(dns.rdata.Rdata):
         self.port = port
         self.target = target
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         target = self.target.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%d %d %d %s ;%s' % (self.priority, self.weight, self.port,
+                                        target, self.comment)
         return '%d %d %d %s' % (self.priority, self.weight, self.port,
                                 target)
 

--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -55,8 +55,13 @@ class SRV(dns.rdata.Rdata):
         port = tok.get_uint16()
         target = tok.get_name(None)
         target = target.choose_relativity(origin, relativize)
-        tok.get_eol()
-        return cls(rdclass, rdtype, priority, weight, port, target)
+        comment = None
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, priority, weight, port, target, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         three_ints = struct.pack("!HHH", self.priority, self.weight, self.port)

--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -36,8 +36,8 @@ class SRV(dns.rdata.Rdata):
 
     __slots__ = ['priority', 'weight', 'port', 'target']
 
-    def __init__(self, rdclass, rdtype, priority, weight, port, target):
-        super(SRV, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, priority, weight, port, target, comment=None):
+        super(SRV, self).__init__(rdclass, rdtype, comment)
         self.priority = priority
         self.weight = weight
         self.port = port

--- a/dns/rdtypes/IN/WKS.py
+++ b/dns/rdtypes/IN/WKS.py
@@ -38,8 +38,8 @@ class WKS(dns.rdata.Rdata):
 
     __slots__ = ['address', 'protocol', 'bitmap']
 
-    def __init__(self, rdclass, rdtype, address, protocol, bitmap):
-        super(WKS, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, address, protocol, bitmap, comment=None):
+        super(WKS, self).__init__(rdclass, rdtype, comment)
         self.address = address
         self.protocol = protocol
         if not isinstance(bitmap, bytearray):

--- a/dns/rdtypes/IN/WKS.py
+++ b/dns/rdtypes/IN/WKS.py
@@ -67,9 +67,12 @@ class WKS(dns.rdata.Rdata):
             protocol = socket.getprotobyname(protocol)
         bitmap = bytearray()
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment = token.value
+                continue
             if token.value.isdigit():
                 serv = int(token.value)
             else:
@@ -87,7 +90,7 @@ class WKS(dns.rdata.Rdata):
                     bitmap.append(0)
             bitmap[i] = bitmap[i] | (0x80 >> (serv % 8))
         bitmap = dns.rdata._truncate_bitmap(bitmap)
-        return cls(rdclass, rdtype, address, protocol, bitmap)
+        return cls(rdclass, rdtype, address, protocol, bitmap, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(dns.ipv4.inet_aton(self.address))

--- a/dns/rdtypes/IN/WKS.py
+++ b/dns/rdtypes/IN/WKS.py
@@ -47,7 +47,7 @@ class WKS(dns.rdata.Rdata):
         else:
             self.bitmap = bitmap
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         bits = []
         for i in xrange(0, len(self.bitmap)):
             byte = self.bitmap[i]
@@ -55,6 +55,9 @@ class WKS(dns.rdata.Rdata):
                 if byte & (0x80 >> j):
                     bits.append(str(i * 8 + j))
         text = ' '.join(bits)
+        if want_comment and self.comment:
+            return '%s %d %s ;%s' % (self.address, self.protocol, text,
+                                     self.comment)
         return '%s %d %s' % (self.address, self.protocol, text)
 
     @classmethod

--- a/dns/rdtypes/dnskeybase.py
+++ b/dns/rdtypes/dnskeybase.py
@@ -93,7 +93,11 @@ class DNSKEYBase(dns.rdata.Rdata):
         self.algorithm = algorithm
         self.key = key
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%d %d %d %s ;%s' % (self.flags, self.protocol, 
+                                    self.algorithm,
+                                    dns.rdata._base64ify(self.key), self.comment)
         return '%d %d %d %s' % (self.flags, self.protocol, self.algorithm,
                                 dns.rdata._base64ify(self.key))
 

--- a/dns/rdtypes/dnskeybase.py
+++ b/dns/rdtypes/dnskeybase.py
@@ -103,16 +103,20 @@ class DNSKEYBase(dns.rdata.Rdata):
         protocol = tok.get_uint8()
         algorithm = dns.dnssec.algorithm_from_text(tok.get_string())
         chunks = []
+        comment=None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment=t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         b64 = b''.join(chunks)
         key = base64.b64decode(b64)
-        return cls(rdclass, rdtype, flags, protocol, algorithm, key)
+        return cls(rdclass, rdtype, flags, protocol, algorithm, key, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack("!HBB", self.flags, self.protocol, self.algorithm)

--- a/dns/rdtypes/dnskeybase.py
+++ b/dns/rdtypes/dnskeybase.py
@@ -86,8 +86,8 @@ class DNSKEYBase(dns.rdata.Rdata):
 
     __slots__ = ['flags', 'protocol', 'algorithm', 'key']
 
-    def __init__(self, rdclass, rdtype, flags, protocol, algorithm, key):
-        super(DNSKEYBase, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, flags, protocol, algorithm, key, comment=None):
+        super(DNSKEYBase, self).__init__(rdclass, rdtype, comment)
         self.flags = flags
         self.protocol = protocol
         self.algorithm = algorithm

--- a/dns/rdtypes/dnskeybase.py
+++ b/dns/rdtypes/dnskeybase.py
@@ -95,7 +95,7 @@ class DNSKEYBase(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         if want_comment and self.comment:
-            return '%d %d %d %s ;%s' % (self.flags, self.protocol, 
+            return '%d %d %d %s ;%s' % (self.flags, self.protocol,
                                     self.algorithm,
                                     dns.rdata._base64ify(self.key), self.comment)
         return '%d %d %d %s' % (self.flags, self.protocol, self.algorithm,

--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -37,8 +37,8 @@ class DSBase(dns.rdata.Rdata):
     __slots__ = ['key_tag', 'algorithm', 'digest_type', 'digest']
 
     def __init__(self, rdclass, rdtype, key_tag, algorithm, digest_type,
-                 digest):
-        super(DSBase, self).__init__(rdclass, rdtype)
+                 digest, comment=None):
+        super(DSBase, self).__init__(rdclass, rdtype, comment)
         self.key_tag = key_tag
         self.algorithm = algorithm
         self.digest_type = digest_type

--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -56,17 +56,21 @@ class DSBase(dns.rdata.Rdata):
         algorithm = tok.get_uint8()
         digest_type = tok.get_uint8()
         chunks = []
+        comment = None
         while 1:
-            t = tok.get().unescape()
+            t = tok.get(want_comment=True).unescape()
             if t.is_eol_or_eof():
                 break
+            if t.is_comment():
+                comment=t.value
+                continue
             if not t.is_identifier():
                 raise dns.exception.SyntaxError
             chunks.append(t.value.encode())
         digest = b''.join(chunks)
         digest = binascii.unhexlify(digest)
         return cls(rdclass, rdtype, key_tag, algorithm, digest_type,
-                   digest)
+                   digest, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         header = struct.pack("!HBB", self.key_tag, self.algorithm,

--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -44,7 +44,13 @@ class DSBase(dns.rdata.Rdata):
         self.digest_type = digest_type
         self.digest = digest
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%d %d %d %s ;%s' % (self.key_tag, self.algorithm,
+                                self.digest_type,
+                                dns.rdata._hexify(self.digest,
+                                                  chunksize=128),
+                                self.comment)
         return '%d %d %d %s' % (self.key_tag, self.algorithm,
                                 self.digest_type,
                                 dns.rdata._hexify(self.digest,

--- a/dns/rdtypes/euibase.py
+++ b/dns/rdtypes/euibase.py
@@ -33,8 +33,8 @@ class EUIBase(dns.rdata.Rdata):
     # byte_len = 6  # 0123456789ab (in hex)
     # text_len = byte_len * 3 - 1  # 01-23-45-67-89-ab
 
-    def __init__(self, rdclass, rdtype, eui):
-        super(EUIBase, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, eui, comment=None):
+        super(EUIBase, self).__init__(rdclass, rdtype, comment)
         if len(eui) != self.byte_len:
             raise dns.exception.FormError('EUI%s rdata has to have %s bytes'
                                           % (self.byte_len * 8, self.byte_len))

--- a/dns/rdtypes/euibase.py
+++ b/dns/rdtypes/euibase.py
@@ -40,7 +40,10 @@ class EUIBase(dns.rdata.Rdata):
                                           % (self.byte_len * 8, self.byte_len))
         self.eui = eui
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
+        if want_comment and self.comment:
+            return '%s ;%s' % (dns.rdata._hexify(self.eui, chunksize=2) \
+                                .replace(' ', '-'), self.comment)
         return dns.rdata._hexify(self.eui, chunksize=2).replace(' ', '-')
 
     @classmethod

--- a/dns/rdtypes/euibase.py
+++ b/dns/rdtypes/euibase.py
@@ -45,8 +45,13 @@ class EUIBase(dns.rdata.Rdata):
 
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        comment=None
         text = tok.get_string()
-        tok.get_eol()
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = tok.value
+            token = tok.get(want_comment=True)
         if len(text) != cls.text_len:
             raise dns.exception.SyntaxError(
                 'Input text must have %s characters' % cls.text_len)
@@ -60,7 +65,7 @@ class EUIBase(dns.rdata.Rdata):
             data = binascii.unhexlify(text.encode())
         except (ValueError, TypeError) as ex:
             raise dns.exception.SyntaxError('Hex decoding error: %s' % str(ex))
-        return cls(rdclass, rdtype, data)
+        return cls(rdclass, rdtype, data, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         file.write(self.eui)

--- a/dns/rdtypes/mxbase.py
+++ b/dns/rdtypes/mxbase.py
@@ -34,8 +34,8 @@ class MXBase(dns.rdata.Rdata):
 
     __slots__ = ['preference', 'exchange']
 
-    def __init__(self, rdclass, rdtype, preference, exchange):
-        super(MXBase, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, preference, exchange, comment=None):
+        super(MXBase, self).__init__(rdclass, rdtype, comment)
         self.preference = preference
         self.exchange = exchange
 

--- a/dns/rdtypes/mxbase.py
+++ b/dns/rdtypes/mxbase.py
@@ -45,11 +45,16 @@ class MXBase(dns.rdata.Rdata):
 
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        comment = None
         preference = tok.get_uint16()
         exchange = tok.get_name()
         exchange = exchange.choose_relativity(origin, relativize)
-        tok.get_eol()
-        return cls(rdclass, rdtype, preference, exchange)
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, preference, exchange, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         pref = struct.pack("!H", self.preference)

--- a/dns/rdtypes/mxbase.py
+++ b/dns/rdtypes/mxbase.py
@@ -39,8 +39,10 @@ class MXBase(dns.rdata.Rdata):
         self.preference = preference
         self.exchange = exchange
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         exchange = self.exchange.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%d %s ;%s' % (self.preference, exchange, self.comment)
         return '%d %s' % (self.preference, exchange)
 
     @classmethod

--- a/dns/rdtypes/nsbase.py
+++ b/dns/rdtypes/nsbase.py
@@ -35,8 +35,10 @@ class NSBase(dns.rdata.Rdata):
         super(NSBase, self).__init__(rdclass, rdtype, comment)
         self.target = target
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         target = self.target.choose_relativity(origin, relativize)
+        if want_comment and self.comment:
+            return '%s ;%s' % (str(target), self.comment)
         return str(target)
 
     @classmethod

--- a/dns/rdtypes/nsbase.py
+++ b/dns/rdtypes/nsbase.py
@@ -41,10 +41,15 @@ class NSBase(dns.rdata.Rdata):
 
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        comment=None
         target = tok.get_name()
         target = target.choose_relativity(origin, relativize)
-        tok.get_eol()
-        return cls(rdclass, rdtype, target)
+        token = tok.get(want_comment=True)
+        while not token.is_eol_or_eof():
+            if token.is_comment():
+                comment = token.value
+            token = tok.get(want_comment=True)
+        return cls(rdclass, rdtype, target, comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         self.target.to_wire(file, compress, origin)

--- a/dns/rdtypes/nsbase.py
+++ b/dns/rdtypes/nsbase.py
@@ -31,8 +31,8 @@ class NSBase(dns.rdata.Rdata):
 
     __slots__ = ['target']
 
-    def __init__(self, rdclass, rdtype, target):
-        super(NSBase, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, target, comment=None):
+        super(NSBase, self).__init__(rdclass, rdtype, comment)
         self.target = target
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -55,10 +55,14 @@ class TXTBase(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         strings = []
+        comment=None
         while 1:
-            token = tok.get().unescape()
+            token = tok.get(want_comment=True).unescape()
             if token.is_eol_or_eof():
                 break
+            if token.is_comment():
+                comment=token.value
+                continue
             if not (token.is_quoted_string() or token.is_identifier()):
                 raise dns.exception.SyntaxError("expected a string")
             if len(token.value) > 255:
@@ -70,7 +74,7 @@ class TXTBase(dns.rdata.Rdata):
                 strings.append(value.encode())
         if len(strings) == 0:
             raise dns.exception.UnexpectedEnd
-        return cls(rdclass, rdtype, strings)
+        return cls(rdclass, rdtype, strings,comment=comment)
 
     def to_wire(self, file, compress=None, origin=None):
         for s in self.strings:

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -33,8 +33,8 @@ class TXTBase(dns.rdata.Rdata):
 
     __slots__ = ['strings']
 
-    def __init__(self, rdclass, rdtype, strings):
-        super(TXTBase, self).__init__(rdclass, rdtype)
+    def __init__(self, rdclass, rdtype, strings, comment=None):
+        super(TXTBase, self).__init__(rdclass, rdtype, comment)
         if isinstance(strings, binary_type) or \
            isinstance(strings, string_types):
             strings = [strings]

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -44,12 +44,14 @@ class TXTBase(dns.rdata.Rdata):
                 string = string.encode()
             self.strings.append(string)
 
-    def to_text(self, origin=None, relativize=True, **kw):
+    def to_text(self, origin=None, relativize=True, want_comment=False, **kw):
         txt = ''
         prefix = ''
         for s in self.strings:
             txt += '%s"%s"' % (prefix, dns.rdata._escapify(s))
             prefix = ' '
+        if want_comment and self.comment:
+            txt += ' ;%s' % (self.comment)
         return txt
 
     @classmethod

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -503,7 +503,7 @@ class Zone(object):
         the output. The following mapping keys need to be used:
         ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
         @type pprint: string
-        @param want_comment: if True, stored comments will be printed 
+        @param want_comment: if True, stored comments will be printed
         behind the records
         @type want_comment: bool
         """
@@ -537,7 +537,7 @@ class Zone(object):
                 names = self.iterkeys()
             for n in names:
                 l = self[n].to_text(n, origin=self.origin,
-                                    relativize=relativize, pprint=pprint, 
+                                    relativize=relativize, pprint=pprint,
                                     want_comment=want_comment)
                 if isinstance(l, text_type):
                     l_b = l.encode(file_enc)
@@ -575,7 +575,7 @@ class Zone(object):
         the output. The following mapping keys need to be used:
         ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
         @type pprint: string
-        @param want_comment: if True, stored comments will be printed 
+        @param want_comment: if True, stored comments will be printed
         behind the records
         @type want_comment: bool
         """

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -481,7 +481,9 @@ class Zone(object):
                     for rdata in rds:
                         yield (name, rds.ttl, rdata)
 
-    def to_file(self, f, sorted=True, relativize=True, nl=None, want_comment=False):
+    def to_file(self, f, sorted=True, relativize=True, nl=None,
+                pprint=u'%(name)s%(ttl)d %(rdclass)s %(rdtype)s %(rdata)s%(rcomment)s\n',
+                want_comment=False):
         """Write a zone to a file.
 
         @param f: file or string.  If I{f} is a string, it is treated
@@ -497,6 +499,10 @@ class Zone(object):
         output will use the platform's native end-of-line marker (i.e.
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
+        @param pprint: A printf format string for pretty printing
+        the output. The following mapping keys need to be used:
+        ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
+        @type pprint: string
         @param want_comment: if True, stored comments will be printed 
         behind the records
         @type want_comment: bool
@@ -531,7 +537,7 @@ class Zone(object):
                 names = self.iterkeys()
             for n in names:
                 l = self[n].to_text(n, origin=self.origin,
-                                    relativize=relativize, 
+                                    relativize=relativize, pprint=pprint, 
                                     want_comment=want_comment)
                 if isinstance(l, text_type):
                     l_b = l.encode(file_enc)
@@ -549,7 +555,9 @@ class Zone(object):
             if want_close:
                 f.close()
 
-    def to_text(self, sorted=True, relativize=True, nl=None, want_comment=False):
+    def to_text(self, sorted=True, relativize=True, nl=None,
+                pprint=u'%(name)s%(ttl)d %(rdclass)s %(rdtype)s %(rdata)s%(rcomment)s\n',
+                want_comment=False):
         """Return a zone's text as though it were written to a file.
 
         @param sorted: if True, the file will be written with the
@@ -563,12 +571,16 @@ class Zone(object):
         output will use the platform's native end-of-line marker (i.e.
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
+        @param pprint: A printf format string for pretty printing
+        the output. The following mapping keys need to be used:
+        ``name``, ``ttl``, ``rdclass``, ``rdtype``, ``rdata`` and ``rcomment``.
+        @type pprint: string
         @param want_comment: if True, stored comments will be printed 
         behind the records
         @type want_comment: bool
         """
         temp_buffer = BytesIO()
-        self.to_file(temp_buffer, sorted, relativize, nl,
+        self.to_file(temp_buffer, sorted, relativize, nl, pprint=pprint,
                      want_comment=want_comment)
         return_value = temp_buffer.getvalue()
         temp_buffer.close()

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -481,7 +481,7 @@ class Zone(object):
                     for rdata in rds:
                         yield (name, rds.ttl, rdata)
 
-    def to_file(self, f, sorted=True, relativize=True, nl=None):
+    def to_file(self, f, sorted=True, relativize=True, nl=None, want_comment=False):
         """Write a zone to a file.
 
         @param f: file or string.  If I{f} is a string, it is treated
@@ -497,6 +497,9 @@ class Zone(object):
         output will use the platform's native end-of-line marker (i.e.
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
+        @param want_comment: if True, stored comments will be printed 
+        behind the records
+        @type want_comment: bool
         """
 
         if isinstance(f, string_types):
@@ -528,7 +531,8 @@ class Zone(object):
                 names = self.iterkeys()
             for n in names:
                 l = self[n].to_text(n, origin=self.origin,
-                                    relativize=relativize)
+                                    relativize=relativize, 
+                                    want_comment=want_comment)
                 if isinstance(l, text_type):
                     l_b = l.encode(file_enc)
                 else:
@@ -545,7 +549,7 @@ class Zone(object):
             if want_close:
                 f.close()
 
-    def to_text(self, sorted=True, relativize=True, nl=None):
+    def to_text(self, sorted=True, relativize=True, nl=None, want_comment=False):
         """Return a zone's text as though it were written to a file.
 
         @param sorted: if True, the file will be written with the
@@ -559,9 +563,13 @@ class Zone(object):
         output will use the platform's native end-of-line marker (i.e.
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
+        @param want_comment: if True, stored comments will be printed 
+        behind the records
+        @type want_comment: bool
         """
         temp_buffer = BytesIO()
-        self.to_file(temp_buffer, sorted, relativize, nl)
+        self.to_file(temp_buffer, sorted, relativize, nl,
+                     want_comment=want_comment)
         return_value = temp_buffer.getvalue()
         temp_buffer.close()
         return return_value


### PR DESCRIPTION
Hi,
I’ve added a basic comment support to comment each record line.
Comments are expected at the end of a record line in the zone file while reading and will be stored in the rdata object per record.
It is possible to print the comments by passing an argument to the zone.to_{file,string} function.

In my case I use this for documentation purpose to gain an quick overview when a specific line was changed the last time, without relaying on an change log.
This makes it possible to quickly change the zone file manually if needed without taking care to update an external change log. While it is still possible to change the file with my scripts based on your lib.

Please let me know what you think about this
best regards
Markus