### PR TITLE
fix nsec3 bitmap from text bug for multiple windows

### DIFF
--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -132,7 +132,7 @@ class NSEC3(dns.rdata.Rdata):
             new_window = nrdtype // 256
             if new_window != window:
                 if octets != 0:
-                    windows.append((window, ''.join(bitmap[0:octets])))
+                    windows.append((window, bitmap[0:octets]))
                 bitmap = bytearray(b'\0' * 32)
                 window = new_window
             offset = nrdtype % 256

--- a/tests/test_nsec3.py
+++ b/tests/test_nsec3.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2006-2017 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import dns.rdata
+import dns.rdataclass
+import dns.rdatatype
+import dns.rdtypes.ANY.TXT
+import dns.ttl
+
+class NSEC3TestCase(unittest.TestCase):
+    def test_NSEC3_bitmap(self):
+        rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.NSEC3,
+                u"1 0 100 ABCD SCBCQHKU35969L2A68P3AD59LHF30715 A CAA TYPE65534")
+        bitmap = bytearray(b'\0' * 32)
+        bitmap[31] = bitmap[31] | 2
+        self.assertEqual(rdata.windows, [(0, bytearray(b'@')),
+                                         (1, bytearray(b'@')), # CAA = 257
+                                         (255, bitmap)
+                                        ])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Example of problematic rdata: 1 0 100 ABCD SCBCQHKU35969L2A68P3AD59LHF30715 NS SOA RRSIG TYPE65534