### PR TITLE
Fix invalid escape warning

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -274,7 +274,7 @@ class GenericRdata(Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         token = tok.get()
-        if not token.is_identifier() or token.value != '\#':
+        if not token.is_identifier() or token.value != r'\#':
             raise dns.exception.SyntaxError(
                 r'generic rdata does not start with \#')
         length = tok.get_int()


### PR DESCRIPTION
a literal string '\\#' in python 3.6 causes a DeprecationWarning "invalid escape sequence" as there is no defined backslash escape that looks like that. This patch changes the string to a raw string, which makes the intent clear. The text format for unknown RR types is defined in [RFC3597](https://tools.ietf.org/html/rfc3597) Section 5, and should indeed be the two ascii characters backslash (0x5c) followed by pound sign (0x23).