### PR TITLE
convert string to bytes-like object if needed

### DIFF
--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -76,6 +76,8 @@ class TXTBase(dns.rdata.Rdata):
         for s in self.strings:
             l = len(s)
             assert l < 256
+            if not isinstance(s, bytes):
+                s = bytes(s, 'utf-8')
             file.write(struct.pack('!B', l))
             file.write(s)
 


### PR DESCRIPTION
Avoid Error "TypeError: a bytes-like object is required, not 'str'" for python3 code.