### PR TITLE
Don't use a bare except: in resolver._getaddrinfo

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1209,7 +1209,7 @@ def _getaddrinfo(host=None, service=None, family=socket.AF_UNSPEC, socktype=0,
                                 v4addrs.append(rdata.address)
                 except dns.resolver.NXDOMAIN:
                     raise socket.gaierror(socket.EAI_NONAME)
-                except:
+                except Exception:
                     raise socket.gaierror(socket.EAI_SYSTEM)
     port = None
     try:


### PR DESCRIPTION
It was catching things like `KeyboardInterrupt` and `SystemExit` that shouldn't be caught here. If you were in a loop resolving names, ctrl-C wouldn't be able to break you out of it.

