### PR TITLE
eventlet/eventlet#480: use importlib.import_module(), not __import__()

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -18,6 +18,7 @@
 from io import BytesIO
 import base64
 import binascii
+import importlib
 
 import dns.exception
 import dns.name
@@ -303,14 +304,6 @@ _module_prefix = 'dns.rdtypes'
 
 
 def get_rdata_class(rdclass, rdtype):
-
-    def import_module(name):
-        mod = __import__(name)
-        components = name.split('.')
-        for comp in components[1:]:
-            mod = getattr(mod, comp)
-        return mod
-
     mod = _rdata_modules.get((rdclass, rdtype))
     rdclass_text = dns.rdataclass.to_text(rdclass)
     rdtype_text = dns.rdatatype.to_text(rdtype)
@@ -319,12 +312,12 @@ def get_rdata_class(rdclass, rdtype):
         mod = _rdata_modules.get((dns.rdatatype.ANY, rdtype))
         if not mod:
             try:
-                mod = import_module('.'.join([_module_prefix,
+                mod = importlib.import_module('.'.join([_module_prefix,
                                               rdclass_text, rdtype_text]))
                 _rdata_modules[(rdclass, rdtype)] = mod
             except ImportError:
                 try:
-                    mod = import_module('.'.join([_module_prefix,
+                    mod = importlib.import_module('.'.join([_module_prefix,
                                                   'ANY', rdtype_text]))
                     _rdata_modules[(dns.rdataclass.ANY, rdtype)] = mod
                 except ImportError:


### PR DESCRIPTION
`dns.rdata.get_rdata_class()` presently does not honor [PEP 302](https://www.python.org/dev/peps/pep-0302/) import hooks
because `__import__()` doesn't support them. (See eventlet/eventlet#480)

Using `importlib.import_module()` allows removing its nested `import_module()`
function, which maps `__import__()` functionality to what
`importlib.import_module()` already provides.