### PR TITLE
ci: fix issues, remove unsupported Python 2.6/3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - "3.6"
   #- "nightly"
 matrix:
+  include:
+    - python: 3.7  # https://github.com/travis-ci/travis-ci/issues/9815
+      dist: xenial
+      sudo: true
   allow_failures:
     - python: nightly
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 language: python
 python:
-  #- "2.6"
   - "2.7"
-  # 3.2 make unicode literal handling difficult. 
-  # we dropped that, see https://github.com/rthalley/dnspython/pull/148
-  # for comments
-  #- "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-  #- "3.5-dev" # 3.5 development branch
-  #- "3.6-dev" # 3.6 development branch
-  #- "nightly" # currently points to 3.6-dev
+  #- "nightly"
 matrix:
   allow_failures:
     - python: nightly
@@ -22,5 +14,5 @@ branches:
 install:
  - pip install unittest2 pylint pycrypto ecdsa idna
 script:
- - if [[ ($TRAVIS_PYTHON_VERSION != '2.6') ]]; then make lint; fi
+ - make lint
  - make test

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-07-18  Tomas Krizek  <tomas.krizek@nic.cz>
+
+	* Support for obsolete Python 2.6 and 3.3 (both EOL) dropped.
+
 2017-01-02  Bob Halley  <halley@dnspython.org>
 
 	* dns/e164.py: to_e164() was returning binary instead of text,

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ XXXTBSXXX
 
 ## REQUIREMENTS
 
-Python 2.6 or later.
+Python 2.7 or 3.4+.
 
 
 ## HOME PAGE

--- a/dns/rdatatype.py
+++ b/dns/rdatatype.py
@@ -268,7 +268,7 @@ def is_singleton(rdtype):
     return False
 
 
-def register_type(rdtype, rdtype_text, is_singleton=False):
+def register_type(rdtype, rdtype_text, is_singleton=False):  # pylint: disable=redefined-outer-name
     """Dynamically register an rdatatype.
 
     *rdtype*, an ``int``, the rdatatype to register.

--- a/examples/zonediff.py
+++ b/examples/zonediff.py
@@ -238,19 +238,19 @@ The differences shown will be logical differences, not textual differences.
     if opts.use_bzr:
         old = _open(["bzr", "cat", "-r" + oldr, filename],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["bzr", "cat", "-r" + newr, filename],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     elif opts.use_git:
         old = _open(["git", "show", oldn],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["git", "show", newn],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     elif opts.use_rcs:
         old = _open(["co", "-q", "-p", "-r" + oldr, filename],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["co", "-q", "-p", "-r" + newr, filename],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     if not opts.use_vc:

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -22,7 +22,7 @@ import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
 
-import ttxt_module
+import tests.ttxt_module
 
 class RdataTestCase(unittest.TestCase):
 
@@ -36,7 +36,7 @@ class RdataTestCase(unittest.TestCase):
 
     def test_module_registration(self):
         TTXT = 64001
-        dns.rdata.register_type(ttxt_module, TTXT, 'TTXT')
+        dns.rdata.register_type(tests.ttxt_module, TTXT, 'TTXT')
         rdata = dns.rdata.from_text(dns.rdataclass.IN, TTXT, 'hello world')
         self.failUnless(rdata.strings == [b'hello', b'world'])
         self.failUnless(dns.rdatatype.to_text(TTXT) == 'TTXT')
@@ -45,7 +45,7 @@ class RdataTestCase(unittest.TestCase):
     def test_module_reregistration(self):
         def bad():
             TTXTTWO = dns.rdatatype.TXT
-            dns.rdata.register_type(ttxt_module, TTXTTWO, 'TTXTTWO')
+            dns.rdata.register_type(tests.ttxt_module, TTXTTWO, 'TTXTTWO')
         self.failUnlessRaises(dns.rdata.RdatatypeExists, bad)
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,9 @@
 [tox]
 envlist =
-    py26,
     py27,
-    py30,
-    py31,
-    py32,
-    py33,
     py34,
-#    py35,
+    py35,
+    py36,
     flake8,
     pylint,
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py34,
     py35,
     py36,
+    py37,
     flake8,
     pylint,
     coverage


### PR DESCRIPTION
Python 2.6 EOL: 2013-10-29 ([PEP 361](https://www.python.org/dev/peps/pep-0361/))
Python 3.3 EOL: 2017-09-29 ([PEP 398](https://www.python.org/dev/peps/pep-0398/#lifespan))