### PR TITLE
Try fixing TXT parsing with "binary" data

### DIFF
--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -42,7 +42,7 @@ class TXTBase(dns.rdata.Rdata):
         for string in strings:
             if isinstance(string, string_types) \
                     and not isinstance(string, binary_type):
-                string = string.encode()
+                string = string.encode('utf-8')
             self.strings.append(string)
 
     def to_text(self, origin=None, relativize=True, **kw):
@@ -68,7 +68,8 @@ class TXTBase(dns.rdata.Rdata):
             if isinstance(value, binary_type):
                 strings.append(value)
             else:
-                strings.append(value.encode())
+                strings.append(value.encode('utf-8'))
+
         if len(strings) == 0:
             raise dns.exception.UnexpectedEnd
         return cls(rdclass, rdtype, strings)

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -40,7 +40,8 @@ class TXTBase(dns.rdata.Rdata):
             strings = [strings]
         self.strings = []
         for string in strings:
-            if isinstance(string, string_types):
+            if isinstance(string, string_types) \
+                    and not isinstance(string, binary_type):
                 string = string.encode()
             self.strings.append(string)
 

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -20,7 +20,7 @@ from __future__ import generators
 import sys
 import re
 import os
-from io import BytesIO
+import io
 
 import dns.exception
 import dns.name
@@ -558,7 +558,7 @@ class Zone(object):
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
         """
-        temp_buffer = BytesIO()
+        temp_buffer = io.BytesIO()
         self.to_file(temp_buffer, sorted, relativize, nl)
         return_value = temp_buffer.getvalue()
         temp_buffer.close()
@@ -1059,15 +1059,11 @@ def from_file(f, origin=None, rdclass=dns.rdataclass.IN,
     """
 
     str_type = string_types
-    if PY3:
-        opts = 'r'
-    else:
-        opts = 'rU'
 
     if isinstance(f, str_type):
         if filename is None:
             filename = f
-        f = open(f, opts)
+        f = io.open(f, 'rU')
         want_close = True
     else:
         if filename is None:

--- a/tests/example
+++ b/tests/example
@@ -151,6 +151,9 @@ txt10			TXT	"foo bar"
 txt11			TXT	"\"foo\""
 txt12			TXT	"\"foo\""
 txt13			TXT	foo
+txt14			TXT	"unicode 🍣"
+txt15			TXT	"unicode \240\159\141\163"
+
 $TTL 300	; 5 minutes
 u			TXT	"txt-not-in-nxt"
 $ORIGIN u.example.

--- a/tests/example1.good
+++ b/tests/example1.good
@@ -121,6 +121,8 @@ txt10 3600 IN TXT "foo bar"
 txt11 3600 IN TXT "\"foo\""
 txt12 3600 IN TXT "\"foo\""
 txt13 3600 IN TXT "foo"
+txt14 3600 IN TXT "unicode \240\159\141\163"
+txt15 3600 IN TXT "unicode \240\159\141\163"
 u 300 IN TXT "txt-not-in-nxt"
 a.u 300 IN A 73.80.65.49
 b.u 300 IN A 73.80.65.49

--- a/tests/example2.good
+++ b/tests/example2.good
@@ -121,6 +121,8 @@ txt10.example. 3600 IN TXT "foo bar"
 txt11.example. 3600 IN TXT "\"foo\""
 txt12.example. 3600 IN TXT "\"foo\""
 txt13.example. 3600 IN TXT "foo"
+txt14.example. 3600 IN TXT "unicode \240\159\141\163"
+txt15.example. 3600 IN TXT "unicode \240\159\141\163"
 u.example. 300 IN TXT "txt-not-in-nxt"
 a.u.example. 300 IN A 73.80.65.49
 b.u.example. 300 IN A 73.80.65.49

--- a/tests/example3.good
+++ b/tests/example3.good
@@ -121,6 +121,8 @@ txt10 3600 IN TXT "foo bar"
 txt11 3600 IN TXT "\"foo\""
 txt12 3600 IN TXT "\"foo\""
 txt13 3600 IN TXT "foo"
+txt14 3600 IN TXT "unicode \240\159\141\163"
+txt15 3600 IN TXT "unicode \240\159\141\163"
 u 300 IN TXT "txt-not-in-nxt"
 a.u 300 IN A 73.80.65.49
 b.u 300 IN A 73.80.65.49

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -21,6 +21,7 @@ import dns.rdatatype
 
 import tests.ttxt_module
 
+
 class RdataTestCase(unittest.TestCase):
 
     def test_str(self):

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2003-2007, 2009-2011 Nominum, Inc.
 #
 # Permission to use, copy, modify, and distribute this software and its
@@ -69,6 +70,23 @@ class TokenizerTestCase(unittest.TestCase):
             tok = dns.tokenizer.Tokenizer('"foo\nbar"')
             tok.get()
         self.failUnlessRaises(dns.exception.SyntaxError, bad)
+
+    def testQuotedString8(self):
+        tok = dns.tokenizer.Tokenizer(u'"sushis 🍣"')
+        token = tok.get()
+        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, u'sushis 🍣'))
+
+    def testQuotedString9(self):
+        tok = dns.tokenizer.Tokenizer(r'"sushis \240\159\141\163"')
+        token = tok.get()
+        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, u'sushis 🍣'))
+
+    def testQuotedString10(self):
+        # This is actually a bug: only handle unicode data is handled
+        def bad():
+            tok = dns.tokenizer.Tokenizer(r'"invalid \000\255\000 utf-8"')
+            t = tok.get()
+        self.failUnlessRaises(UnicodeDecodeError, bad)
 
     def testEmpty1(self):
         tok = dns.tokenizer.Tokenizer('')


### PR DESCRIPTION
Previously a TXT containing binary string would not be correctly parsed
and would either raise an error on python2 or be wrongly decoded in
python3

fixes #321