### PR TITLE
Fix rdatatype.to_text() for TYPE0

### DIFF
--- a/dns/rdatatype.py
+++ b/dns/rdatatype.py
@@ -168,6 +168,7 @@ _by_text = {
 # would cause the mapping not to be true inverse.
 
 _by_value = dict((y, x) for x, y in _by_text.items())
+_by_value[0] = "TYPE0"
 
 _metatypes = {
     OPT: True


### PR DESCRIPTION
The rdatatype.to_text() function returns NONE instead of TYPE0. 

Original behavior:
```
dns.rdatatype.to_text(0)
'NONE'
```
Expected behavior:
```
dns.rdatatype.to_text(0)
'TYPE0'
```

Also, using invalid rdatatype value for NONE would be probably better as there would be no conflict to begin with.