### PR TITLE
setup.py: support compilation with Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,15 @@ from setuptools import setup
 
 version = '1.16.0'
 
+try:
+    sys.argv.remove("--cython-compile")
+except ValueError:
+    compile_cython = False
+else:
+    compile_cython = True
+    from Cython.Build import cythonize
+    ext_modules = cythonize(['dns/*.py', 'dns/rdtypes/*.py', 'dns/rdtypes/*/*.py'])
+
 kwargs = {
     'name' : 'dnspython',
     'version' : version,
@@ -64,6 +73,8 @@ direct manipulation of DNS zones, messages, names, and records.""",
         'IDNA': ['idna>=2.1'],
         'DNSSEC': ['pycrypto>=2.6.1', 'ecdsa>=0.13'],
         },
+    'ext_modules': ext_modules if compile_cython else None,
+    'zip_safe': False if compile_cython else None,
     }
 
 setup(**kwargs)


### PR DESCRIPTION
To provide a slight perfomrance boost, the Python code can be
compiled with Cython. Provide --cython-compile to setup.py, or
when usng pip:

pip install dnspython --install-option="--cython-compile"