### PR TITLE
hashlib fallback for DNSSEC hashes

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -491,6 +491,25 @@ except ImportError:
     validate_rrsig = _need_pycrypto
     _have_pycrypto = False
     _have_ecdsa = False
+
+    import hashlib
+
+    def _fake_hash(alias):
+        class FakeHash:
+            @staticmethod
+            def new():
+                return alias()
+
+        return FakeHash
+
+    MD5 = _fake_hash(hashlib.md5)
+    SHA1 = _fake_hash(hashlib.sha1)
+    SHA256 = _fake_hash(hashlib.sha256)
+    SHA384 = _fake_hash(hashlib.sha384)
+    SHA512 = _fake_hash(hashlib.sha512)
+
+    del _fake_hash, hashlib
+
 else:
     validate = _validate
     validate_rrsig = _validate_rrsig

--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -55,6 +55,9 @@ class Hash:
         'SHA512': '2.16.840.1.101.3.4.2.3',
     }
 
+    def __init__(self):
+        self._hash = None
+
     @classmethod
     def new(cls, name, data=b''):
         self = cls()
@@ -72,7 +75,7 @@ class Hash:
         return self._hash.hexdigest()
 
     def copy(self):
-        copy = cls()
+        copy = Hash()
         copy._hash = self._hash.copy()
 
         return copy

--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -496,9 +496,7 @@ except ImportError:
 
     def _fake_hash(alias):
         class FakeHash:
-            @staticmethod
-            def new():
-                return alias()
+            new = alias
 
         return FakeHash
 

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -188,9 +188,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
 
 
-    def testMakeExampleSHA256DS(self): # type: () -> None
-        ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA256')
-        self.failUnless(ds == example_ds_sha256)
+
 
     @unittest.skipUnless(dns.dnssec._have_ecdsa,
                          "python ECDSA cannot be imported")
@@ -230,5 +228,11 @@ class DNSSECMakeDSTestCase(unittest.TestCase):
     def testMakeExampleSHA1DS(self): # type: () -> None
         ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA1')
         self.failUnless(ds == example_ds_sha1)
+
+    def testMakeExampleSHA256DS(self): # type: () -> None
+        ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA256')
+        self.failUnless(ds == example_ds_sha256)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -177,10 +177,6 @@ class DNSSECValidatorTestCase(unittest.TestCase):
                                 abs_dnspython_org, when)
         self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
 
-    def testMakeSHA256DS(self): # type: () -> None
-        ds = dns.dnssec.make_ds(abs_dnspython_org, sep_key, 'SHA256')
-        self.failUnless(ds == good_ds)
-
     def testAbsoluteDSAGood(self): # type: () -> None
         dns.dnssec.validate(abs_dsa_soa, abs_dsa_soa_rrsig, abs_dsa_keys, None,
                             when2)
@@ -191,9 +187,6 @@ class DNSSECValidatorTestCase(unittest.TestCase):
                                 abs_dsa_keys, None, when2)
         self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
 
-    def testMakeExampleSHA1DS(self): # type: () -> None
-        ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA1')
-        self.failUnless(ds == example_ds_sha1)
 
     def testMakeExampleSHA256DS(self): # type: () -> None
         ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA256')
@@ -228,5 +221,14 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
 
 
+class DNSSECMakeDSTestCase(unittest.TestCase):
+
+    def testMakeSHA256DS(self): # type: () -> None
+        ds = dns.dnssec.make_ds(abs_dnspython_org, sep_key, 'SHA256')
+        self.failUnless(ds == good_ds)
+
+    def testMakeExampleSHA1DS(self): # type: () -> None
+        ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA1')
+        self.failUnless(ds == example_ds_sha1)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When the cryptographic modules are not available / installed, try to
fallback on Python's built-in hash methods

closes #343 