### PR TITLE
Getting the value for default TTL from SOA RDATA before checking the TTL of the record

### DIFF
--- a/dns/zone.py
+++ b/dns/zone.py
@@ -658,21 +658,7 @@ class _MasterReader(object):
         token = self.tok.get()
         if not token.is_identifier():
             raise dns.exception.SyntaxError
-        # TTL
-        try:
-            ttl = dns.ttl.from_text(token.value)
-            self.last_ttl = ttl
-            self.last_ttl_known = True
-            token = self.tok.get()
-            if not token.is_identifier():
-                raise dns.exception.SyntaxError
-        except dns.ttl.BadTTL:
-            if not (self.last_ttl_known or self.default_ttl_known):
-                raise dns.exception.SyntaxError("Missing default TTL value")
-            if self.default_ttl_known:
-                ttl = self.default_ttl
-            else:
-                ttl = self.last_ttl
+
         # Class
         try:
             rdclass = dns.rdataclass.from_text(token.value)
@@ -719,6 +705,22 @@ class _MasterReader(object):
             self.default_ttl = rd.minimum
             self.default_ttl_known = True
 
+        # TTL
+        try:
+            ttl = dns.ttl.from_text(token.value)
+            self.last_ttl = ttl
+            self.last_ttl_known = True
+            token = self.tok.get()
+            if not token.is_identifier():
+                raise dns.exception.SyntaxError
+        except dns.ttl.BadTTL:
+            if not (self.last_ttl_known or self.default_ttl_known):
+                raise dns.exception.SyntaxError("Missing default TTL value")
+            if self.default_ttl_known:
+                ttl = self.default_ttl
+            else:
+                ttl = self.last_ttl
+            
         rd.choose_relativity(self.zone.origin, self.relativize)
         covers = rd.covers()
         rds = n.find_rdataset(rdclass, rdtype, covers, True)

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -671,9 +671,9 @@ class _MasterReader(object):
         except dns.ttl.BadTTL:
             if self.default_ttl_known:
                 ttl = self.default_ttl
-            else:
+            elif self.last_ttl_known:
                 ttl = self.last_ttl
-                
+
         # Class
         try:
             rdclass = dns.rdataclass.from_text(token.value)
@@ -729,7 +729,7 @@ class _MasterReader(object):
                     ttl = self.default_ttl
                 else:
                     ttl = self.last_ttl
-            
+
         rd.choose_relativity(self.zone.origin, self.relativize)
         covers = rd.covers()
         rds = n.find_rdataset(rdclass, rdtype, covers, True)

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -814,7 +814,7 @@ class _MasterReader(object):
                 raise dns.exception.SyntaxError("Missing default TTL value")
             if self.default_ttl_known:
                 ttl = self.default_ttl
-            else:
+            elif self.last_ttl_known:
                 ttl = self.last_ttl
         # Class
         try:


### PR DESCRIPTION
By doing the TTL validity check after parsing the record data allows the TTL to be set properly from SOA RDATA even when the SOA record itself does not have TTL set.