### PR TITLE
Fix an issue with Resolver Not Trying All Nameservers

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -967,7 +967,8 @@ class Resolver(object):
                                        response))
                         raise ex
                     if rcode == dns.rcode.NOERROR or \
-                            rcode == dns.rcode.NXDOMAIN:
+                            (rcode == dns.rcode.NXDOMAIN and
+                             len(nameservers) <= 1):
                         break
                     #
                     # We got a response, but we're not happy with the


### PR DESCRIPTION
There appears to be an issue in `Resolver` when multiple nameservers are specified and the first nameserver returns `NXDOMAIN`. No other nameservers are tried and NXDOMAIN is raised.

I ran into this issue by doing the following. I'm trying to resolve a system on my LAN using my local DNS server.

```python
import dns.resolver
resolver = dns.resolver.Resolver(configure=False)
resolver.nameservers = ['8.8.8.8', '10.123.1.1']
resolver.query('server.lan', 'A', lifetime=2000)
```

The current design raises NXDOMAIN and my local DNS, `10.123.1.1` is never queried. This PR changes the behavior slightly to try the next nameserver and then raise `NoNameservers`.

The PR tries to not break anything that uses the existing behavior by still raising `NXDOMAIN` when only a single nameserver is specified.

To test the current behavior, I added `print` calls at the start of the `qnames_to_try` loop and the `nameservers` subloop. Here's the output for the *current* behavior:

```
_qname: server.lan.
trying ns: 8.8.8.8
_qname: server.lan.
trying ns: 8.8.8.8
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\repos\dnspython\dns\resolver.py", line 1003, in query
    raise NXDOMAIN(qnames=qnames_to_try, responses=nxdomain_responses)
dns.resolver.NXDOMAIN: None of DNS query names exist: server.lan., server.lan.
```

As you can see, `8.8.8.8` is tried twice, rather than trying my local nameserver.

Here's the output for the *new* behavior in this PR

```
_qname: server.lan.
trying ns: 8.8.8.8
trying ns: 10.123.1.1
<dns.resolver.Answer object at 0x0000025B94CB3E80>
```