### PR TITLE
Add support for DNS over HTTPS

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -243,7 +243,7 @@ def https(query, url, timeout=None, post=True, one_rr_per_rrset=False, ignore_tr
     response = urllib.request.urlopen(request, timeout=timeout).read()
     return dns.message.from_wire(response,
                                  keyring=query.keyring,
-                                 request_mac=query.request_mac
+                                 request_mac=query.request_mac,
                                  one_rr_per_rrset=one_rr_per_rrset,
                                  ignore_trailing=ignore_trailing)
 

--- a/dns/query.py
+++ b/dns/query.py
@@ -19,6 +19,7 @@
 
 from __future__ import generators
 
+import urllib.request
 import errno
 import select
 import socket
@@ -188,6 +189,27 @@ def _destination_and_source(af, where, port, source, source_port):
             source = (source, source_port, 0, 0)
     return (af, destination, source)
 
+
+def doh(query, nameserver):
+    """Return the response obtained after sending a query via DoH.
+
+    *query*, a ``dns.message.Message`` containing the query to send
+
+    *nameserver*, a ``str`` containing the nameserver URL.
+
+    Returns a ``dns.message.Message``.
+    """
+
+    wirequery = query.to_wire()
+    headers = {
+        'Accept': 'application/dns-message',
+        'Content-Type': 'application/dns-message',
+    }
+
+    request = urllib.request.Request(nameserver, data=wirequery, headers=headers)
+    response = urllib.request.urlopen(request).read()
+
+    return dns.message.from_wire(response)
 
 def send_udp(sock, what, destination, expiration=None):
     """Send a DNS message to the specified UDP socket.

--- a/dns/query.py
+++ b/dns/query.py
@@ -207,8 +207,8 @@ def _destination_and_source(af, where, port, source, source_port):
     return (af, destination, source)
 
 
-def doh(query, nameserver, post=True):
-    """Return the response obtained after sending a query via DoH.
+def https(query, nameserver, post=True):
+    """Return the response obtained after sending a query via DNS-over-HTTPS.
 
     *query*, a ``dns.message.Message`` containing the query to send
 

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -1,5 +1,8 @@
 from typing import Optional, Union, Dict, Generator, Any
 from . import message, tsig, rdatatype, rdataclass, name, message
+def doh(query : message.Message, nameserver : str) -> message.Message:
+    pass
+
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : int = 0,
         one_rr_per_rrset=False) -> message.Message:
     pass

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -7,7 +7,7 @@ except ImportError:
     class ssl(object):
         SSLContext = {}
 
-def https(query : message.Message, nameserver : str, post=True) -> message.Message:
+def https(query : message.Message, url : str, timeout : float = None, post : Optional[bool] = True, one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
     pass
 
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -7,7 +7,7 @@ except ImportError:
     class ssl(object):
         SSLContext = {}
 
-def doh(query : message.Message, nameserver : str, post=True) -> message.Message:
+def https(query : message.Message, nameserver : str, post=True) -> message.Message:
     pass
 
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -1,5 +1,5 @@
 from typing import Optional, Union, Dict, Generator, Any
-from . import message, tsig, rdatatype, rdataclass, name, message
+from . import tsig, rdatatype, rdataclass, name, message
 
 try:
     import ssl

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -1,6 +1,6 @@
 from typing import Optional, Union, Dict, Generator, Any
 from . import message, tsig, rdatatype, rdataclass, name, message
-def doh(query : message.Message, nameserver : str) -> message.Message:
+def doh(query : message.Message, nameserver : str, post=True) -> message.Message:
     pass
 
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : int = 0,

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -910,6 +910,8 @@ class Resolver(object):
                         if protocol == 'https':
                             tcp_attempt = True
                             response = dns.query.https(request, nameserver)
+                        elif protocol:
+                            continue
                         else:
                             tcp_attempt = tcp
                             if tcp:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -909,7 +909,7 @@ class Resolver(object):
                     try:
                         if protocol == 'https':
                             tcp_attempt = True
-                            response = dns.query.doh(request, nameserver)
+                            response = dns.query.https(request, nameserver)
                         else:
                             tcp_attempt = tcp
                             if tcp:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -909,7 +909,7 @@ class Resolver(object):
                     try:
                         if protocol == 'https':
                             tcp_attempt = True
-                            response = dns.query.https(request, nameserver)
+                            response = dns.query.https(request, nameserver, timeout)
                         elif protocol:
                             continue
                         else:


### PR DESCRIPTION
This adds support for DNS over HTTPS. It adds additional `dns.query.doh()` method which uses `urllib` to get DNS response from DoH resolver. It is used in `dns.resolver.Resolver` when a DNS nameserver starts with `https://` (so it is DoH resolver).

@rthalley Can you check this? Also, when do you plan to release stable 2.0?