### PR TITLE
Add ecs `from_text()` method

### DIFF
--- a/dns/edns.py
+++ b/dns/edns.py
@@ -232,10 +232,10 @@ class ECSOption(Option):
             ecs_text = tokens[0]
         elif len(tokens) == 2:
             if tokens[0] != optional_prefix:
-                raise ValueError(f'could not parse ECS from "{text}"')
+                raise ValueError('could not parse ECS from "{}"'.format(text))
             ecs_text = tokens[1]
         else:
-            raise ValueError(f'could not parse ECS from "{text}"')
+            raise ValueError('could not parse ECS from "{}"'.format(text))
         n_slashes = ecs_text.count('/')
         if n_slashes == 1:
             address, srclen = ecs_text.split('/')
@@ -243,15 +243,15 @@ class ECSOption(Option):
         elif n_slashes == 2:
             address, srclen, scope = ecs_text.split('/')
         else:
-            raise ValueError(f'could not parse ECS from "{text}"')
+            raise ValueError('could not parse ECS from "{}"'.format(text))
         try:
             scope = int(scope)
         except ValueError:
-            raise ValueError(f'invalid scope "{scope}": scope must be an integer')
+            raise ValueError('invalid scope "{}": scope must be an integer'.format(scope))
         try:
             srclen = int(srclen)
         except ValueError:
-            raise ValueError(f'invalid srclen "{srclen}": srclen must be an integer')
+            raise ValueError('invalid srclen "{}": srclen must be an integer'.format(srclen))
         return ECSOption(address, srclen, scope)
 
     def to_wire(self, file):

--- a/tests/test_edns.py
+++ b/tests/test_edns.py
@@ -67,3 +67,44 @@ class OptionTestCase(unittest.TestCase):
         opt.to_wire(io)
         data = io.getvalue()
         self.assertEqual(data, b'\x00\x02\x38\x00\x20\x01\x4b\x98\x00\x00\x00')
+
+    def testECSOption_from_text_valid(self):
+        ecs1 = dns.edns.ECSOption.from_text('1.2.3.4/24/0')
+        self.assertEqual(ecs1, dns.edns.ECSOption('1.2.3.4', 24, 0))
+
+        ecs2 = dns.edns.ECSOption.from_text('1.2.3.4/24')
+        self.assertEqual(ecs2, dns.edns.ECSOption('1.2.3.4', 24, 0))
+
+        ecs3 = dns.edns.ECSOption.from_text('ECS 1.2.3.4/24')
+        self.assertEqual(ecs3, dns.edns.ECSOption('1.2.3.4', 24, 0))
+
+        ecs4 = dns.edns.ECSOption.from_text('ECS 1.2.3.4/24/32')
+        self.assertEqual(ecs4, dns.edns.ECSOption('1.2.3.4', 24, 32))
+
+        ecs5 = dns.edns.ECSOption.from_text('2001:4b98::1/64/56')
+        self.assertEqual(ecs5, dns.edns.ECSOption('2001:4b98::1', 64, 56))
+
+        ecs6 = dns.edns.ECSOption.from_text('2001:4b98::1/64')
+        self.assertEqual(ecs6, dns.edns.ECSOption('2001:4b98::1', 64, 0))
+
+        ecs7 = dns.edns.ECSOption.from_text('ECS 2001:4b98::1/0')
+        self.assertEqual(ecs7, dns.edns.ECSOption('2001:4b98::1', 0, 0))
+
+        ecs8 = dns.edns.ECSOption.from_text('ECS 2001:4b98::1/64/128')
+        self.assertEqual(ecs8, dns.edns.ECSOption('2001:4b98::1', 64, 128))
+
+    def testECSOption_from_text_invalid(self):
+        with self.assertRaises(ValueError):
+            dns.edns.ECSOption.from_text('some random text 1.2.3.4/24/0 24')
+
+        with self.assertRaises(ValueError):
+            dns.edns.ECSOption.from_text('1.2.3.4/twentyfour')
+
+        with self.assertRaises(ValueError):
+            dns.edns.ECSOption.from_text('1.2.3.4/24/O') # <-- that's not a zero
+
+        with self.assertRaises(ValueError):
+            dns.edns.ECSOption.from_text('')
+
+        with self.assertRaises(ValueError):
+            dns.edns.ECSOption.from_text('1.2.3.4/2001:4b98::1/24')


### PR DESCRIPTION
This adds `dns.edns.ECSOption.from_text()` method, and some tests for it.

Here are the examples I put in the method's docstring:
```bash
>>> import dns.edns
>>>
>>> # basic example
>>> dns.edns.ECSOption.from_text('1.2.3.4/24')
>>>
>>> # also understands scope
>>> dns.edns.ECSOption.from_text('1.2.3.4/24/32')
>>>
>>> # IPv6
>>> dns.edns.ECSOption.from_text('2001:4b98::1/64/64')
>>>
>>> # it understands results from `dns.edns.ECSOption.to_text()`
>>> dns.edns.ECSOption.from_text('ECS 1.2.3.4/24/32')
```

If the ECS text is invalid, it will raise a `ValueError`. In cases like this would raising a `dns.exception.SyntaxError` be more appropriate?