### PR TITLE
Remove deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   #- "nightly"
 matrix:
   include:

--- a/dns/namedict.py
+++ b/dns/namedict.py
@@ -27,11 +27,14 @@
 
 """DNS name dictionary"""
 
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 import dns.name
 
 
-class NameDict(collections.MutableMapping):
+class NameDict(MutableMapping):
     """A dictionary whose keys are dns.name.Name objects.
 
     In addition to being like a regular Python dictionary, this

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -738,9 +738,9 @@ class _MasterReader(object):
     def _parse_modify(self, side):
         # Here we catch everything in '{' '}' in a group so we can replace it
         # with ''.
-        is_generate1 = re.compile("^.*\$({(\+|-?)(\d+),(\d+),(.)}).*$")
-        is_generate2 = re.compile("^.*\$({(\+|-?)(\d+)}).*$")
-        is_generate3 = re.compile("^.*\$({(\+|-?)(\d+),(\d+)}).*$")
+        is_generate1 = re.compile(r"^.*\$({(\+|-?)(\d+),(\d+),(.)}).*$")
+        is_generate2 = re.compile(r"^.*\$({(\+|-?)(\d+)}).*$")
+        is_generate3 = re.compile(r"^.*\$({(\+|-?)(\d+),(\d+)}).*$")
         # Sometimes there are modifiers in the hostname. These come after
         # the dollar sign. They are in the form: ${offset[,width[,base]]}.
         # Make names

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -44,7 +44,7 @@ class BugsTestCase(unittest.TestCase):
     def test_TTL_bounds_check(self):
         def bad():
             dns.ttl.from_text("2147483648")
-        self.failUnlessRaises(dns.ttl.BadTTL, bad)
+        self.assertRaises(dns.ttl.BadTTL, bad)
 
     def test_empty_NSEC3_window(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.NSEC3,

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -31,15 +31,15 @@ class BugsTestCase(unittest.TestCase):
     def test_float_LOC(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.LOC,
                                     u"30 30 0.000 N 100 30 0.000 W 10.00m 20m 2000m 20m")
-        self.failUnless(rdata.float_latitude == 30.5)
-        self.failUnless(rdata.float_longitude == -100.5)
+        self.assertTrue(rdata.float_latitude == 30.5)
+        self.assertTrue(rdata.float_longitude == -100.5)
 
     def test_SOA_BIND8_TTL(self):
         rdata1 = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.SOA,
                                      u"a b 100 1s 1m 1h 1d")
         rdata2 = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.SOA,
                                      u"a b 100 1 60 3600 86400")
-        self.failUnless(rdata1 == rdata2)
+        self.assertTrue(rdata1 == rdata2)
 
     def test_TTL_bounds_check(self):
         def bad():
@@ -49,14 +49,14 @@ class BugsTestCase(unittest.TestCase):
     def test_empty_NSEC3_window(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.NSEC3,
                                     u"1 0 100 ABCD SCBCQHKU35969L2A68P3AD59LHF30715")
-        self.failUnless(rdata.windows == [])
+        self.assertTrue(rdata.windows == [])
 
     def test_zero_size_APL(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.APL,
                                     "")
         rdata2 = dns.rdata.from_wire(dns.rdataclass.IN, dns.rdatatype.APL,
                                      "", 0, 0)
-        self.failUnless(rdata == rdata2)
+        self.assertTrue(rdata == rdata2)
 
     def test_CAA_from_wire(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.CAA,
@@ -68,19 +68,19 @@ class BugsTestCase(unittest.TestCase):
         wire += b"trailing garbage"
         rdata2 = dns.rdata.from_wire(dns.rdataclass.IN, dns.rdatatype.CAA,
                                      wire, 0, rdlen)
-        self.failUnless(rdata == rdata2)
+        self.assertTrue(rdata == rdata2)
 
     def test_trailing_zero_APL(self):
         in4 = "!1:127.0.0.0/1"
         rd4 = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.APL, in4)
         out4 = rd4.to_digestable(dns.name.from_text("test"))
         text4 = binascii.hexlify(out4).decode('ascii')
-        self.failUnless(text4 == '000101817f')
+        self.assertTrue(text4 == '000101817f')
         in6 = "!2:::1000/1"
         rd6 = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.APL, in6)
         out6 = rd6.to_digestable(dns.name.from_text("test"))
         text6 = binascii.hexlify(out6).decode('ascii')
-        self.failUnless(text6 == '0002018f000000000000000000000000000010')
+        self.assertTrue(text6 == '0002018f000000000000000000000000000010')
 
     def test_TXT_conversions(self):
         t1 = dns.rdtypes.ANY.TXT.TXT(dns.rdataclass.IN, dns.rdatatype.TXT,
@@ -91,9 +91,9 @@ class BugsTestCase(unittest.TestCase):
                                      'foo')
         t4 = dns.rdtypes.ANY.TXT.TXT(dns.rdataclass.IN, dns.rdatatype.TXT,
                                      ['foo'])
-        self.failUnless(t1 == t2)
-        self.failUnless(t1 == t2)
-        self.failUnless(t1 == t4)
+        self.assertTrue(t1 == t2)
+        self.assertTrue(t1 == t2)
+        self.assertTrue(t1 == t4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -164,7 +164,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_soa, abs_soa_rrsig, abs_keys, None,
                                 when)
-        self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
+        self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
     def testRelativeRSAGood(self):  # type: () -> None
         dns.dnssec.validate(rel_soa, rel_soa_rrsig, rel_keys,
@@ -174,7 +174,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         def bad():  # type: () -> None
             dns.dnssec.validate(rel_other_soa, rel_soa_rrsig, rel_keys,
                                 abs_dnspython_org, when)
-        self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
+        self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
     def testAbsoluteDSAGood(self):  # type: () -> None
         dns.dnssec.validate(abs_dsa_soa, abs_dsa_soa_rrsig, abs_dsa_keys, None,
@@ -184,7 +184,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_dsa_soa, abs_dsa_soa_rrsig,
                                 abs_dsa_keys, None, when2)
-        self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
+        self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
     @unittest.skipUnless(dns.dnssec._have_ecdsa,
                          "python ECDSA cannot be imported")
@@ -198,7 +198,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_ecdsa256_soa, abs_ecdsa256_soa_rrsig,
                                 abs_ecdsa256_keys, None, when3)
-        self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
+        self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
     @unittest.skipUnless(dns.dnssec._have_ecdsa,
                          "python ECDSA cannot be imported")
@@ -212,7 +212,7 @@ class DNSSECValidatorTestCase(unittest.TestCase):
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_ecdsa384_soa, abs_ecdsa384_soa_rrsig,
                                 abs_ecdsa384_keys, None, when4)
-        self.failUnlessRaises(dns.dnssec.ValidationFailure, bad)
+        self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
 
 class DNSSECMakeDSTestCase(unittest.TestCase):

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -219,15 +219,15 @@ class DNSSECMakeDSTestCase(unittest.TestCase):
 
     def testMakeExampleSHA1DS(self):  # type: () -> None
         ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA1')
-        self.failUnless(ds == example_ds_sha1)
+        self.assertTrue(ds == example_ds_sha1)
 
     def testMakeExampleSHA256DS(self):  # type: () -> None
         ds = dns.dnssec.make_ds(abs_example, example_sep_key, 'SHA256')
-        self.failUnless(ds == example_ds_sha256)
+        self.assertTrue(ds == example_ds_sha256)
 
     def testMakeSHA256DS(self):  # type: () -> None
         ds = dns.dnssec.make_ds(abs_dnspython_org, sep_key, 'SHA256')
-        self.failUnless(ds == good_ds)
+        self.assertTrue(ds == good_ds)
 
 
 if __name__ == '__main__':

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -46,7 +46,7 @@ class FlagsTestCase(unittest.TestCase):
     def test_rcode8(self):
         def bad():
             dns.rcode.to_flags(4096)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_flags1(self):
         self.assertTrue(dns.flags.from_text("RA RD AA QR") == \

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -24,24 +24,24 @@ import dns.opcode
 class FlagsTestCase(unittest.TestCase):
 
     def test_rcode1(self):
-        self.failUnless(dns.rcode.from_text('FORMERR') == dns.rcode.FORMERR)
+        self.assertTrue(dns.rcode.from_text('FORMERR') == dns.rcode.FORMERR)
 
     def test_rcode2(self):
-        self.failUnless(dns.rcode.to_text(dns.rcode.FORMERR) == "FORMERR")
+        self.assertTrue(dns.rcode.to_text(dns.rcode.FORMERR) == "FORMERR")
 
     def test_rcode3(self):
-        self.failUnless(dns.rcode.to_flags(dns.rcode.FORMERR) == (1, 0))
+        self.assertTrue(dns.rcode.to_flags(dns.rcode.FORMERR) == (1, 0))
 
     def test_rcode4(self):
-        self.failUnless(dns.rcode.to_flags(dns.rcode.BADVERS) == \
+        self.assertTrue(dns.rcode.to_flags(dns.rcode.BADVERS) == \
                         (0, 0x01000000))
 
     def test_rcode6(self):
-        self.failUnless(dns.rcode.from_flags(0, 0x01000000) == \
+        self.assertTrue(dns.rcode.from_flags(0, 0x01000000) == \
                         dns.rcode.BADVERS)
 
     def test_rcode7(self):
-        self.failUnless(dns.rcode.from_flags(5, 0) == dns.rcode.REFUSED)
+        self.assertTrue(dns.rcode.from_flags(5, 0) == dns.rcode.REFUSED)
 
     def test_rcode8(self):
         def bad():
@@ -49,12 +49,12 @@ class FlagsTestCase(unittest.TestCase):
         self.failUnlessRaises(ValueError, bad)
 
     def test_flags1(self):
-        self.failUnless(dns.flags.from_text("RA RD AA QR") == \
+        self.assertTrue(dns.flags.from_text("RA RD AA QR") == \
                         dns.flags.QR|dns.flags.AA|dns.flags.RD|dns.flags.RA)
 
     def test_flags2(self):
         flags = dns.flags.QR|dns.flags.AA|dns.flags.RD|dns.flags.RA
-        self.failUnless(dns.flags.to_text(flags) == "QR AA RD RA")
+        self.assertTrue(dns.flags.to_text(flags) == "QR AA RD RA")
 
 
 if __name__ == '__main__':

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -151,12 +151,12 @@ class GenerateTestCase(unittest.TestCase):
     def testFromText(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(example_text, 'example.', relativize=True)
-        self.failUnlessRaises(dns.zone.NoSOA, bad)
+        self.assertRaises(dns.zone.NoSOA, bad)
 
     def testFromText1(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(example_text1, 'example.', relativize=True)
-        self.failUnlessRaises(dns.zone.NoSOA, bad)
+        self.assertRaises(dns.zone.NoSOA, bad)
 
     def testIterateAllRdatas2(self): # type: () -> None
         z = dns.zone.from_text(example_text2, 'example.', relativize=True)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -200,7 +200,7 @@ class GenerateTestCase(unittest.TestCase):
                                     '10.0.0.5'))]
 
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testIterateAllRdatas3(self): # type: () -> None
         z = dns.zone.from_text(example_text3, 'example.', relativize=True)
@@ -240,7 +240,7 @@ class GenerateTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A,
                                     '10.0.0.8'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
     def testGenerate1(self): # type: () -> None
         z = dns.zone.from_text(example_text4, 'example.', relativize=True)
         l = list(z.iterate_rdatas())
@@ -328,7 +328,7 @@ class GenerateTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.CNAME,
                                     'SERVER.FOOBAR.'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testGenerate3(self): # type: () -> None
         z = dns.zone.from_text(example_text6, 'example.', relativize=True)
@@ -371,7 +371,7 @@ class GenerateTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.CNAME,
                                     'SERVER.FOOBAR.'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testGenerate4(self): # type: () -> None
         z = dns.zone.from_text(example_text7, 'example.', relativize=True)
@@ -414,7 +414,7 @@ class GenerateTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A,
                                     '10.10.16.0'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testGenerate6(self): # type: () -> None
         z = dns.zone.from_text(example_text9, 'example.', relativize=True)
@@ -464,7 +464,7 @@ class GenerateTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A,
                                     '10.10.16.0'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testGenerate7(self): # type: () -> None
         z = dns.zone.from_text(example_text10, 'example.', relativize=True)
@@ -504,7 +504,7 @@ class GenerateTestCase(unittest.TestCase):
                                     'zlb2.oob'))]
 
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testGenerate8(self): # type: () -> None
         z = dns.zone.from_text(example_text11, 'example.', relativize=True)
@@ -545,7 +545,7 @@ class GenerateTestCase(unittest.TestCase):
                                     '10.0.0.2'))]
 
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
 
 if __name__ == '__main__':

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -96,28 +96,28 @@ class MessageTestCase(unittest.TestCase):
     def test_comparison_eq1(self):
         q1 = dns.message.from_text(query_text)
         q2 = dns.message.from_text(query_text)
-        self.failUnless(q1 == q2)
+        self.assertTrue(q1 == q2)
 
     def test_comparison_ne1(self):
         q1 = dns.message.from_text(query_text)
         q2 = dns.message.from_text(query_text)
         q2.id = 10
-        self.failUnless(q1 != q2)
+        self.assertTrue(q1 != q2)
 
     def test_comparison_ne2(self):
         q1 = dns.message.from_text(query_text)
         q2 = dns.message.from_text(query_text)
         q2.question = []
-        self.failUnless(q1 != q2)
+        self.assertTrue(q1 != q2)
 
     def test_comparison_ne3(self):
         q1 = dns.message.from_text(query_text)
-        self.failUnless(q1 != 1)
+        self.assertTrue(q1 != 1)
 
     def test_EDNS_to_wire1(self):
         q = dns.message.from_text(query_text)
         w = q.to_wire()
-        self.failUnless(w == goodwire)
+        self.assertTrue(w == goodwire)
 
     def test_EDNS_from_wire1(self):
         m = dns.message.from_wire(goodwire)
@@ -126,11 +126,11 @@ class MessageTestCase(unittest.TestCase):
     def test_EDNS_to_wire2(self):
         q = dns.message.from_text(query_text_2)
         w = q.to_wire()
-        self.failUnless(w == goodwire3)
+        self.assertTrue(w == goodwire3)
 
     def test_EDNS_from_wire2(self):
         m = dns.message.from_wire(goodwire3)
-        self.failUnless(str(m) == query_text_2)
+        self.assertTrue(str(m) == query_text_2)
 
     def test_TooBig(self):
         def bad():
@@ -147,7 +147,7 @@ class MessageTestCase(unittest.TestCase):
     def test_answer1(self):
         a = dns.message.from_text(answer_text)
         wire = a.to_wire(want_shuffle=False)
-        self.failUnless(wire == goodwire2)
+        self.assertTrue(wire == goodwire2)
 
     def test_TrailingJunk(self):
         def bad():
@@ -171,34 +171,34 @@ class MessageTestCase(unittest.TestCase):
     def test_ExtendedRcodeSetting(self):
         m = dns.message.make_query('foo', 'A')
         m.set_rcode(4095)
-        self.failUnless(m.rcode() == 4095)
+        self.assertTrue(m.rcode() == 4095)
         m.set_rcode(2)
-        self.failUnless(m.rcode() == 2)
+        self.assertTrue(m.rcode() == 2)
 
     def test_EDNSVersionCoherence(self):
         m = dns.message.make_query('foo', 'A')
         m.use_edns(1)
-        self.failUnless((m.ednsflags >> 16) & 0xFF == 1)
+        self.assertTrue((m.ednsflags >> 16) & 0xFF == 1)
 
     def test_SettingNoEDNSOptionsImpliesNoEDNS(self):
         m = dns.message.make_query('foo', 'A')
-        self.failUnless(m.edns == -1)
+        self.assertTrue(m.edns == -1)
 
     def test_SettingEDNSFlagsImpliesEDNS(self):
         m = dns.message.make_query('foo', 'A', ednsflags=dns.flags.DO)
-        self.failUnless(m.edns == 0)
+        self.assertTrue(m.edns == 0)
 
     def test_SettingEDNSPayloadImpliesEDNS(self):
         m = dns.message.make_query('foo', 'A', payload=4096)
-        self.failUnless(m.edns == 0)
+        self.assertTrue(m.edns == 0)
 
     def test_SettingEDNSRequestPayloadImpliesEDNS(self):
         m = dns.message.make_query('foo', 'A', request_payload=4096)
-        self.failUnless(m.edns == 0)
+        self.assertTrue(m.edns == 0)
 
     def test_SettingOptionsImpliesEDNS(self):
         m = dns.message.make_query('foo', 'A', options=[])
-        self.failUnless(m.edns == 0)
+        self.assertTrue(m.edns == 0)
 
     def test_FindRRset(self):
         a = dns.message.from_text(answer_text)
@@ -206,7 +206,7 @@ class MessageTestCase(unittest.TestCase):
         rrs1 = a.find_rrset(a.answer, n, dns.rdataclass.IN, dns.rdatatype.SOA)
         rrs2 = a.find_rrset(dns.message.ANSWER, n, dns.rdataclass.IN,
                             dns.rdatatype.SOA)
-        self.failUnless(rrs1 == rrs2)
+        self.assertTrue(rrs1 == rrs2)
 
     def test_CleanTruncated(self):
         def bad():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -142,7 +142,7 @@ class MessageTestCase(unittest.TestCase):
                                             '10.0.0.%d' % i)
                 q.additional.append(rrset)
             q.to_wire(max_size=512)
-        self.failUnlessRaises(dns.exception.TooBig, bad)
+        self.assertRaises(dns.exception.TooBig, bad)
 
     def test_answer1(self):
         a = dns.message.from_text(answer_text)
@@ -153,20 +153,20 @@ class MessageTestCase(unittest.TestCase):
         def bad():
             badwire = goodwire + b'\x00'
             dns.message.from_wire(badwire)
-        self.failUnlessRaises(dns.message.TrailingJunk, bad)
+        self.assertRaises(dns.message.TrailingJunk, bad)
 
     def test_ShortHeader(self):
         def bad():
             badwire = b'\x00' * 11
             dns.message.from_wire(badwire)
-        self.failUnlessRaises(dns.message.ShortHeader, bad)
+        self.assertRaises(dns.message.ShortHeader, bad)
 
     def test_RespondingToResponse(self):
         def bad():
             q = dns.message.make_query('foo', 'A')
             r1 = dns.message.make_response(q)
             dns.message.make_response(r1)
-        self.failUnlessRaises(dns.exception.FormError, bad)
+        self.assertRaises(dns.exception.FormError, bad)
 
     def test_ExtendedRcodeSetting(self):
         m = dns.message.make_query('foo', 'A')
@@ -214,7 +214,7 @@ class MessageTestCase(unittest.TestCase):
             a.flags |= dns.flags.TC
             wire = a.to_wire(want_shuffle=False)
             dns.message.from_wire(wire)
-        self.failUnlessRaises(dns.message.Truncated, bad)
+        self.assertRaises(dns.message.Truncated, bad)
 
     def test_MessyTruncated(self):
         def bad():
@@ -222,7 +222,7 @@ class MessageTestCase(unittest.TestCase):
             a.flags |= dns.flags.TC
             wire = a.to_wire(want_shuffle=False)
             dns.message.from_wire(wire[:-3])
-        self.failUnlessRaises(dns.message.Truncated, bad)
+        self.assertRaises(dns.message.Truncated, bad)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -48,11 +48,11 @@ class NameTestCase(unittest.TestCase):
 
     def testFromTextRel4(self):
         n = dns.name.from_text('@', origin=None)
-        self.failUnless(n == dns.name.empty)
+        self.assertTrue(n == dns.name.empty)
 
     def testFromTextRel5(self):
         n = dns.name.from_text('@', origin=self.origin)
-        self.failUnless(n == self.origin)
+        self.assertTrue(n == self.origin)
 
     def testFromTextAbs1(self):
         n = dns.name.from_text('foo.bar.')
@@ -109,35 +109,35 @@ class NameTestCase(unittest.TestCase):
         self.failUnlessRaises(TypeError, bad)
 
     def testAbs1(self):
-        self.failUnless(dns.name.root.is_absolute())
+        self.assertTrue(dns.name.root.is_absolute())
 
     def testAbs2(self):
-        self.failUnless(not dns.name.empty.is_absolute())
+        self.assertTrue(not dns.name.empty.is_absolute())
 
     def testAbs3(self):
-        self.failUnless(self.origin.is_absolute())
+        self.assertTrue(self.origin.is_absolute())
 
     def testAbs4(self):
         n = dns.name.from_text('foo', origin=None)
-        self.failUnless(not n.is_absolute())
+        self.assertTrue(not n.is_absolute())
 
     def testWild1(self):
         n = dns.name.from_text('*.foo', origin=None)
-        self.failUnless(n.is_wild())
+        self.assertTrue(n.is_wild())
 
     def testWild2(self):
         n = dns.name.from_text('*a.foo', origin=None)
-        self.failUnless(not n.is_wild())
+        self.assertTrue(not n.is_wild())
 
     def testWild3(self):
         n = dns.name.from_text('a.*.foo', origin=None)
-        self.failUnless(not n.is_wild())
+        self.assertTrue(not n.is_wild())
 
     def testWild4(self):
-        self.failUnless(not dns.name.root.is_wild())
+        self.assertTrue(not dns.name.root.is_wild())
 
     def testWild5(self):
-        self.failUnless(not dns.name.empty.is_wild())
+        self.assertTrue(not dns.name.empty.is_wild())
 
     def testHash1(self):
         n1 = dns.name.from_text('fOo.COM')
@@ -147,57 +147,57 @@ class NameTestCase(unittest.TestCase):
     def testCompare1(self):
         n1 = dns.name.from_text('a')
         n2 = dns.name.from_text('b')
-        self.failUnless(n1 < n2)
-        self.failUnless(n2 > n1)
+        self.assertTrue(n1 < n2)
+        self.assertTrue(n2 > n1)
 
     def testCompare2(self):
         n1 = dns.name.from_text('')
         n2 = dns.name.from_text('b')
-        self.failUnless(n1 < n2)
-        self.failUnless(n2 > n1)
+        self.assertTrue(n1 < n2)
+        self.assertTrue(n2 > n1)
 
     def testCompare3(self):
-        self.failUnless(dns.name.empty < dns.name.root)
-        self.failUnless(dns.name.root > dns.name.empty)
+        self.assertTrue(dns.name.empty < dns.name.root)
+        self.assertTrue(dns.name.root > dns.name.empty)
 
     def testCompare4(self):
-        self.failUnless(dns.name.root != 1)
+        self.assertTrue(dns.name.root != 1)
 
     def testSubdomain1(self):
-        self.failUnless(not dns.name.empty.is_subdomain(dns.name.root))
+        self.assertTrue(not dns.name.empty.is_subdomain(dns.name.root))
 
     def testSubdomain2(self):
-        self.failUnless(not dns.name.root.is_subdomain(dns.name.empty))
+        self.assertTrue(not dns.name.root.is_subdomain(dns.name.empty))
 
     def testSubdomain3(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(n.is_subdomain(self.origin))
+        self.assertTrue(n.is_subdomain(self.origin))
 
     def testSubdomain4(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(n.is_subdomain(dns.name.root))
+        self.assertTrue(n.is_subdomain(dns.name.root))
 
     def testSubdomain5(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(n.is_subdomain(n))
+        self.assertTrue(n.is_subdomain(n))
 
     def testSuperdomain1(self):
-        self.failUnless(not dns.name.empty.is_superdomain(dns.name.root))
+        self.assertTrue(not dns.name.empty.is_superdomain(dns.name.root))
 
     def testSuperdomain2(self):
-        self.failUnless(not dns.name.root.is_superdomain(dns.name.empty))
+        self.assertTrue(not dns.name.root.is_superdomain(dns.name.empty))
 
     def testSuperdomain3(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(self.origin.is_superdomain(n))
+        self.assertTrue(self.origin.is_superdomain(n))
 
     def testSuperdomain4(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(dns.name.root.is_superdomain(n))
+        self.assertTrue(dns.name.root.is_superdomain(n))
 
     def testSuperdomain5(self):
         n = dns.name.from_text('foo', origin=self.origin)
-        self.failUnless(n.is_superdomain(n))
+        self.assertTrue(n.is_superdomain(n))
 
     def testCanonicalize1(self):
         n = dns.name.from_text('FOO.bar', origin=self.origin)
@@ -299,11 +299,11 @@ class NameTestCase(unittest.TestCase):
 
     def testEmptyLabel3(self):
         n = dns.name.Name(['b', ''])
-        self.failUnless(n)
+        self.assertTrue(n)
 
     def testLongLabel(self):
         n = dns.name.Name(['a' * 63])
-        self.failUnless(n)
+        self.assertTrue(n)
 
     def testLabelTooLong(self):
         def bad():
@@ -312,7 +312,7 @@ class NameTestCase(unittest.TestCase):
 
     def testLongName(self):
         n = dns.name.Name(['a' * 63, 'a' * 63, 'a' * 63, 'a' * 62])
-        self.failUnless(n)
+        self.assertTrue(n)
 
     def testNameTooLong(self):
         def bad():
@@ -324,35 +324,35 @@ class NameTestCase(unittest.TestCase):
         n2 = dns.name.Name(['c', 'd'])
         e = dns.name.Name(['a', 'b', 'c', 'd'])
         r = n1 + n2
-        self.failUnless(r == e)
+        self.assertTrue(r == e)
 
     def testConcat2(self):
         n1 = dns.name.Name(['a', 'b'])
         n2 = dns.name.Name([])
         e = dns.name.Name(['a', 'b'])
         r = n1 + n2
-        self.failUnless(r == e)
+        self.assertTrue(r == e)
 
     def testConcat3(self):
         n1 = dns.name.Name([])
         n2 = dns.name.Name(['a', 'b'])
         e = dns.name.Name(['a', 'b'])
         r = n1 + n2
-        self.failUnless(r == e)
+        self.assertTrue(r == e)
 
     def testConcat4(self):
         n1 = dns.name.Name(['a', 'b', ''])
         n2 = dns.name.Name([])
         e = dns.name.Name(['a', 'b', ''])
         r = n1 + n2
-        self.failUnless(r == e)
+        self.assertTrue(r == e)
 
     def testConcat5(self):
         n1 = dns.name.Name(['a', 'b'])
         n2 = dns.name.Name(['c', ''])
         e = dns.name.Name(['a', 'b', 'c', ''])
         r = n1 + n2
-        self.failUnless(r == e)
+        self.assertTrue(r == e)
 
     def testConcat6(self):
         def bad():
@@ -377,7 +377,7 @@ class NameTestCase(unittest.TestCase):
         n2 = dns.name.from_text('foo.BAR.')
         d1 = n1.to_digestable()
         d2 = n2.to_digestable()
-        self.failUnless(d1 == d2)
+        self.assertTrue(d1 == d2)
 
     def testDigestable3(self):
         d = dns.name.root.to_digestable()
@@ -455,28 +455,28 @@ class NameTestCase(unittest.TestCase):
         (prefix, suffix) = n.split(2)
         ep = dns.name.from_text('foo', None)
         es = dns.name.from_text('bar.', None)
-        self.failUnless(prefix == ep and suffix == es)
+        self.assertTrue(prefix == ep and suffix == es)
 
     def testSplit2(self):
         n = dns.name.from_text('foo.bar.')
         (prefix, suffix) = n.split(1)
         ep = dns.name.from_text('foo.bar', None)
         es = dns.name.from_text('.', None)
-        self.failUnless(prefix == ep and suffix == es)
+        self.assertTrue(prefix == ep and suffix == es)
 
     def testSplit3(self):
         n = dns.name.from_text('foo.bar.')
         (prefix, suffix) = n.split(0)
         ep = dns.name.from_text('foo.bar.', None)
         es = dns.name.from_text('', None)
-        self.failUnless(prefix == ep and suffix == es)
+        self.assertTrue(prefix == ep and suffix == es)
 
     def testSplit4(self):
         n = dns.name.from_text('foo.bar.')
         (prefix, suffix) = n.split(3)
         ep = dns.name.from_text('', None)
         es = dns.name.from_text('foo.bar.', None)
-        self.failUnless(prefix == ep and suffix == es)
+        self.assertTrue(prefix == ep and suffix == es)
 
     def testBadSplit1(self):
         def bad():
@@ -494,85 +494,85 @@ class NameTestCase(unittest.TestCase):
         n = dns.name.from_text('a.foo.bar.', None)
         o = dns.name.from_text('bar.', None)
         e = dns.name.from_text('a.foo', None)
-        self.failUnless(n.relativize(o) == e)
+        self.assertTrue(n.relativize(o) == e)
 
     def testRelativize2(self):
         n = dns.name.from_text('a.foo.bar.', None)
         o = n
         e = dns.name.empty
-        self.failUnless(n.relativize(o) == e)
+        self.assertTrue(n.relativize(o) == e)
 
     def testRelativize3(self):
         n = dns.name.from_text('a.foo.bar.', None)
         o = dns.name.from_text('blaz.', None)
         e = n
-        self.failUnless(n.relativize(o) == e)
+        self.assertTrue(n.relativize(o) == e)
 
     def testRelativize4(self):
         n = dns.name.from_text('a.foo', None)
         o = dns.name.root
         e = n
-        self.failUnless(n.relativize(o) == e)
+        self.assertTrue(n.relativize(o) == e)
 
     def testDerelativize1(self):
         n = dns.name.from_text('a.foo', None)
         o = dns.name.from_text('bar.', None)
         e = dns.name.from_text('a.foo.bar.', None)
-        self.failUnless(n.derelativize(o) == e)
+        self.assertTrue(n.derelativize(o) == e)
 
     def testDerelativize2(self):
         n = dns.name.empty
         o = dns.name.from_text('a.foo.bar.', None)
         e = o
-        self.failUnless(n.derelativize(o) == e)
+        self.assertTrue(n.derelativize(o) == e)
 
     def testDerelativize3(self):
         n = dns.name.from_text('a.foo.bar.', None)
         o = dns.name.from_text('blaz.', None)
         e = n
-        self.failUnless(n.derelativize(o) == e)
+        self.assertTrue(n.derelativize(o) == e)
 
     def testChooseRelativity1(self):
         n = dns.name.from_text('a.foo.bar.', None)
         o = dns.name.from_text('bar.', None)
         e = dns.name.from_text('a.foo', None)
-        self.failUnless(n.choose_relativity(o, True) == e)
+        self.assertTrue(n.choose_relativity(o, True) == e)
 
     def testChooseRelativity2(self):
         n = dns.name.from_text('a.foo.bar.', None)
         o = dns.name.from_text('bar.', None)
         e = n
-        self.failUnless(n.choose_relativity(o, False) == e)
+        self.assertTrue(n.choose_relativity(o, False) == e)
 
     def testChooseRelativity3(self):
         n = dns.name.from_text('a.foo', None)
         o = dns.name.from_text('bar.', None)
         e = dns.name.from_text('a.foo.bar.', None)
-        self.failUnless(n.choose_relativity(o, False) == e)
+        self.assertTrue(n.choose_relativity(o, False) == e)
 
     def testChooseRelativity4(self):
         n = dns.name.from_text('a.foo', None)
         o = None
         e = n
-        self.failUnless(n.choose_relativity(o, True) == e)
+        self.assertTrue(n.choose_relativity(o, True) == e)
 
     def testChooseRelativity5(self):
         n = dns.name.from_text('a.foo', None)
         o = None
         e = n
-        self.failUnless(n.choose_relativity(o, False) == e)
+        self.assertTrue(n.choose_relativity(o, False) == e)
 
     def testChooseRelativity6(self):
         n = dns.name.from_text('a.foo.', None)
         o = None
         e = n
-        self.failUnless(n.choose_relativity(o, True) == e)
+        self.assertTrue(n.choose_relativity(o, True) == e)
 
     def testChooseRelativity7(self):
         n = dns.name.from_text('a.foo.', None)
         o = None
         e = n
-        self.failUnless(n.choose_relativity(o, False) == e)
+        self.assertTrue(n.choose_relativity(o, False) == e)
 
     def testFromWire1(self):
         w = b'\x03foo\x00\xc0\x00'
@@ -582,7 +582,7 @@ class NameTestCase(unittest.TestCase):
         en2 = en1
         ecused1 = 5
         ecused2 = 2
-        self.failUnless(n1 == en1 and cused1 == ecused1 and \
+        self.assertTrue(n1 == en1 and cused1 == ecused1 and \
                         n2 == en2 and cused2 == ecused2)
 
     def testFromWire2(self):
@@ -599,7 +599,7 @@ class NameTestCase(unittest.TestCase):
         ecused1 = 5
         ecused2 = 4
         ecused3 = 4
-        self.failUnless(n1 == en1 and cused1 == ecused1 and \
+        self.assertTrue(n1 == en1 and cused1 == ecused1 and \
                         n2 == en2 and cused2 == ecused2 and \
                         n3 == en3 and cused3 == ecused3)
 
@@ -629,13 +629,13 @@ class NameTestCase(unittest.TestCase):
 
     def testParent1(self):
         n = dns.name.from_text('foo.bar.')
-        self.failUnless(n.parent() == dns.name.from_text('bar.'))
-        self.failUnless(n.parent().parent() == dns.name.root)
+        self.assertTrue(n.parent() == dns.name.from_text('bar.'))
+        self.assertTrue(n.parent().parent() == dns.name.root)
 
     def testParent2(self):
         n = dns.name.from_text('foo.bar', None)
-        self.failUnless(n.parent() == dns.name.from_text('bar', None))
-        self.failUnless(n.parent().parent() == dns.name.empty)
+        self.assertTrue(n.parent() == dns.name.from_text('bar', None))
+        self.assertTrue(n.parent().parent() == dns.name.empty)
 
     def testParent3(self):
         def bad():
@@ -783,7 +783,7 @@ class NameTestCase(unittest.TestCase):
     def testReverseIPv6MappedIpv4(self):
         e = dns.name.from_text('1.0.0.127.in-addr.arpa.')
         n = dns.reversename.from_address('::ffff:127.0.0.1')
-        self.failUnless(e == n)
+        self.assertTrue(e == n)
 
     def testBadReverseIPv4(self):
         def bad():
@@ -811,7 +811,7 @@ class NameTestCase(unittest.TestCase):
         text = '+1 650 555 1212'
         e = dns.name.from_text('2.1.2.1.5.5.5.0.5.6.1.e164.arpa.')
         n = dns.e164.from_e164(text)
-        self.failUnless(n == e)
+        self.assertTrue(n == e)
 
     def testEnumToE164(self):
         n = dns.name.from_text('2.1.2.1.5.5.5.0.5.6.1.e164.arpa.')

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -235,12 +235,12 @@ class NameTestCase(unittest.TestCase):
     def testToText7(self):
         n = dns.name.from_text(r'FOO\.bar', origin=None)
         t = n.to_text()
-        self.assertEqual(t, 'FOO\.bar')
+        self.assertEqual(t, r'FOO\.bar')
 
     def testToText8(self):
         n = dns.name.from_text(r'\070OO\.bar', origin=None)
         t = n.to_text()
-        self.assertEqual(t, 'FOO\.bar')
+        self.assertEqual(t, r'FOO\.bar')
 
     def testToText9(self):
         n = dns.name.from_text('FOO bar', origin=None)

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -101,12 +101,12 @@ class NameTestCase(unittest.TestCase):
     def testImmutable1(self):
         def bad():
             self.origin.labels = ()
-        self.failUnlessRaises(TypeError, bad)
+        self.assertRaises(TypeError, bad)
 
     def testImmutable2(self):
         def bad():
             self.origin.labels[0] = 'foo'
-        self.failUnlessRaises(TypeError, bad)
+        self.assertRaises(TypeError, bad)
 
     def testAbs1(self):
         self.assertTrue(dns.name.root.is_absolute())
@@ -290,12 +290,12 @@ class NameTestCase(unittest.TestCase):
     def testEmptyLabel1(self):
         def bad():
             dns.name.Name(['a', '', 'b'])
-        self.failUnlessRaises(dns.name.EmptyLabel, bad)
+        self.assertRaises(dns.name.EmptyLabel, bad)
 
     def testEmptyLabel2(self):
         def bad():
             dns.name.Name(['', 'b'])
-        self.failUnlessRaises(dns.name.EmptyLabel, bad)
+        self.assertRaises(dns.name.EmptyLabel, bad)
 
     def testEmptyLabel3(self):
         n = dns.name.Name(['b', ''])
@@ -308,7 +308,7 @@ class NameTestCase(unittest.TestCase):
     def testLabelTooLong(self):
         def bad():
             dns.name.Name(['a' * 64, 'b'])
-        self.failUnlessRaises(dns.name.LabelTooLong, bad)
+        self.assertRaises(dns.name.LabelTooLong, bad)
 
     def testLongName(self):
         n = dns.name.Name(['a' * 63, 'a' * 63, 'a' * 63, 'a' * 62])
@@ -317,7 +317,7 @@ class NameTestCase(unittest.TestCase):
     def testNameTooLong(self):
         def bad():
             dns.name.Name(['a' * 63, 'a' * 63, 'a' * 63, 'a' * 63])
-        self.failUnlessRaises(dns.name.NameTooLong, bad)
+        self.assertRaises(dns.name.NameTooLong, bad)
 
     def testConcat1(self):
         n1 = dns.name.Name(['a', 'b'])
@@ -359,13 +359,13 @@ class NameTestCase(unittest.TestCase):
             n1 = dns.name.Name(['a', 'b', ''])
             n2 = dns.name.Name(['c'])
             return n1 + n2
-        self.failUnlessRaises(dns.name.AbsoluteConcatenation, bad)
+        self.assertRaises(dns.name.AbsoluteConcatenation, bad)
 
     def testBadEscape(self):
         def bad():
             n = dns.name.from_text(r'a.b\0q1.c.')
             print(n)
-        self.failUnlessRaises(dns.name.BadEscape, bad)
+        self.assertRaises(dns.name.BadEscape, bad)
 
     def testDigestable1(self):
         n = dns.name.from_text('FOO.bar')
@@ -392,7 +392,7 @@ class NameTestCase(unittest.TestCase):
         def bad():
             n = dns.name.from_text('FOO.bar', None)
             n.to_digestable()
-        self.failUnlessRaises(dns.name.NeedAbsoluteNameOrOrigin, bad)
+        self.assertRaises(dns.name.NeedAbsoluteNameOrOrigin, bad)
 
     def testToWire1(self):
         n = dns.name.from_text('FOO.bar')
@@ -448,7 +448,7 @@ class NameTestCase(unittest.TestCase):
             f = BytesIO()
             compress = {} # type: Dict[dns.name.Name,int]
             n.to_wire(f, compress)
-        self.failUnlessRaises(dns.name.NeedAbsoluteNameOrOrigin, bad)
+        self.assertRaises(dns.name.NeedAbsoluteNameOrOrigin, bad)
 
     def testSplit1(self):
         n = dns.name.from_text('foo.bar.')
@@ -482,13 +482,13 @@ class NameTestCase(unittest.TestCase):
         def bad():
             n = dns.name.from_text('foo.bar.')
             n.split(-1)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def testBadSplit2(self):
         def bad():
             n = dns.name.from_text('foo.bar.')
             n.split(4)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def testRelativize1(self):
         n = dns.name.from_text('a.foo.bar.', None)
@@ -607,25 +607,25 @@ class NameTestCase(unittest.TestCase):
         def bad():
             w = b'\x03foo\xc0\x04'
             dns.name.from_wire(w, 0)
-        self.failUnlessRaises(dns.name.BadPointer, bad)
+        self.assertRaises(dns.name.BadPointer, bad)
 
     def testBadFromWire2(self):
         def bad():
             w = b'\x03foo\xc0\x05'
             dns.name.from_wire(w, 0)
-        self.failUnlessRaises(dns.name.BadPointer, bad)
+        self.assertRaises(dns.name.BadPointer, bad)
 
     def testBadFromWire3(self):
         def bad():
             w = b'\xbffoo'
             dns.name.from_wire(w, 0)
-        self.failUnlessRaises(dns.name.BadLabelType, bad)
+        self.assertRaises(dns.name.BadLabelType, bad)
 
     def testBadFromWire4(self):
         def bad():
             w = b'\x41foo'
             dns.name.from_wire(w, 0)
-        self.failUnlessRaises(dns.name.BadLabelType, bad)
+        self.assertRaises(dns.name.BadLabelType, bad)
 
     def testParent1(self):
         n = dns.name.from_text('foo.bar.')
@@ -641,13 +641,13 @@ class NameTestCase(unittest.TestCase):
         def bad():
             n = dns.name.root
             n.parent()
-        self.failUnlessRaises(dns.name.NoParent, bad)
+        self.assertRaises(dns.name.NoParent, bad)
 
     def testParent4(self):
         def bad():
             n = dns.name.empty
             n.parent()
-        self.failUnlessRaises(dns.name.NoParent, bad)
+        self.assertRaises(dns.name.NoParent, bad)
 
     def testFromUnicode1(self):
         n = dns.name.from_text('foo.bar')
@@ -701,7 +701,7 @@ class NameTestCase(unittest.TestCase):
             def bad():
                 codec = dns.name.IDNA_2008_Strict
                 return dns.name.from_unicode(t, idna_codec=codec)
-            self.failUnlessRaises(dns.name.IDNAException, bad)
+            self.assertRaises(dns.name.IDNAException, bad)
             e1 = dns.name.from_unicode(t, idna_codec=dns.name.IDNA_2008)
             self.assertEqual(str(e1), 'xn--knigsgchen-b4a3dun.')
             c2 = dns.name.IDNA_2008_Transitional
@@ -725,9 +725,9 @@ class NameTestCase(unittest.TestCase):
             def bad3():
                 codec = dns.name.IDNA_2008_Transitional
                 return dns.name.from_unicode(t, idna_codec=codec)
-            self.failUnlessRaises(dns.name.IDNAException, bad1)
-            self.failUnlessRaises(dns.name.IDNAException, bad2)
-            self.failUnlessRaises(dns.name.IDNAException, bad3)
+            self.assertRaises(dns.name.IDNAException, bad1)
+            self.assertRaises(dns.name.IDNAException, bad2)
+            self.assertRaises(dns.name.IDNAException, bad3)
             e = dns.name.from_unicode(t,
                                       idna_codec=dns.name.IDNA_2008_Practical)
             self.assertEqual(str(e), '_sip._tcp.xn--knigsgchen-b4a3dun.')
@@ -768,7 +768,7 @@ class NameTestCase(unittest.TestCase):
         def bad():
             # This throws in IDNA2003 because it doesn't "round trip".
             n.to_unicode(idna_codec=dns.name.IDNA_2003_Strict)
-        self.failUnlessRaises(dns.name.IDNAException, bad)
+        self.assertRaises(dns.name.IDNAException, bad)
 
     def testReverseIPv4(self):
         e = dns.name.from_text('1.0.0.127.in-addr.arpa.')
@@ -788,12 +788,12 @@ class NameTestCase(unittest.TestCase):
     def testBadReverseIPv4(self):
         def bad():
             dns.reversename.from_address('127.0.foo.1')
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testBadReverseIPv6(self):
         def bad():
             dns.reversename.from_address('::1::1')
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testForwardIPv4(self):
         n = dns.name.from_text('1.0.0.127.in-addr.arpa.')

--- a/tests/test_namedict.py
+++ b/tests/test_namedict.py
@@ -57,12 +57,12 @@ class NameTestCase(unittest.TestCase):
         def bad():
             n = dns.name.from_text('a.b.c.')
             self.ndict.get_deepest_match(n)
-        self.failUnlessRaises(KeyError, bad)
+        self.assertRaises(KeyError, bad)
 
     def testLookup6(self):
         def bad():
             self.ndict.get_deepest_match(dns.name.empty)
-        self.failUnlessRaises(KeyError, bad)
+        self.assertRaises(KeyError, bad)
 
     def testLookup7(self):
         self.ndict[dns.name.empty] = 100
@@ -73,7 +73,7 @@ class NameTestCase(unittest.TestCase):
     def testLookup8(self):
         def bad():
             self.ndict['foo'] = 100
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def testRelDepth(self):
         self.assertTrue(self.rndict.max_depth == 2)

--- a/tests/test_namedict.py
+++ b/tests/test_namedict.py
@@ -35,23 +35,23 @@ class NameTestCase(unittest.TestCase):
         self.rndict[n2] = 2
 
     def testDepth(self):
-        self.failUnless(self.ndict.max_depth == 3)
+        self.assertTrue(self.ndict.max_depth == 3)
 
     def testLookup1(self):
         k = dns.name.from_text('foo.bar.')
-        self.failUnless(self.ndict[k] == 1)
+        self.assertTrue(self.ndict[k] == 1)
 
     def testLookup2(self):
         k = dns.name.from_text('foo.bar.')
-        self.failUnless(self.ndict.get_deepest_match(k)[1] == 1)
+        self.assertTrue(self.ndict.get_deepest_match(k)[1] == 1)
 
     def testLookup3(self):
         k = dns.name.from_text('a.b.c.foo.bar.')
-        self.failUnless(self.ndict.get_deepest_match(k)[1] == 1)
+        self.assertTrue(self.ndict.get_deepest_match(k)[1] == 1)
 
     def testLookup4(self):
         k = dns.name.from_text('a.b.c.bar.')
-        self.failUnless(self.ndict.get_deepest_match(k)[1] == 2)
+        self.assertTrue(self.ndict.get_deepest_match(k)[1] == 2)
 
     def testLookup5(self):
         def bad():
@@ -68,7 +68,7 @@ class NameTestCase(unittest.TestCase):
         self.ndict[dns.name.empty] = 100
         n = dns.name.from_text('a.b.c.')
         v = self.ndict.get_deepest_match(n)[1]
-        self.failUnless(v == 100)
+        self.assertTrue(v == 100)
 
     def testLookup8(self):
         def bad():
@@ -76,29 +76,29 @@ class NameTestCase(unittest.TestCase):
         self.failUnlessRaises(ValueError, bad)
 
     def testRelDepth(self):
-        self.failUnless(self.rndict.max_depth == 2)
+        self.assertTrue(self.rndict.max_depth == 2)
 
     def testRelLookup1(self):
         k = dns.name.from_text('foo.bar', None)
-        self.failUnless(self.rndict[k] == 1)
+        self.assertTrue(self.rndict[k] == 1)
 
     def testRelLookup2(self):
         k = dns.name.from_text('foo.bar', None)
-        self.failUnless(self.rndict.get_deepest_match(k)[1] == 1)
+        self.assertTrue(self.rndict.get_deepest_match(k)[1] == 1)
 
     def testRelLookup3(self):
         k = dns.name.from_text('a.b.c.foo.bar', None)
-        self.failUnless(self.rndict.get_deepest_match(k)[1] == 1)
+        self.assertTrue(self.rndict.get_deepest_match(k)[1] == 1)
 
     def testRelLookup4(self):
         k = dns.name.from_text('a.b.c.bar', None)
-        self.failUnless(self.rndict.get_deepest_match(k)[1] == 2)
+        self.assertTrue(self.rndict.get_deepest_match(k)[1] == 2)
 
     def testRelLookup7(self):
         self.rndict[dns.name.empty] = 100
         n = dns.name.from_text('a.b.c', None)
         v = self.rndict.get_deepest_match(n)[1]
-        self.failUnless(v == 100)
+        self.assertTrue(v == 100)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ntoaaton.py
+++ b/tests/test_ntoaaton.py
@@ -39,19 +39,19 @@ class NtoAAtoNTestCase(unittest.TestCase):
 
     def test_aton1(self):
         a = aton6('::')
-        self.failUnless(a == b'\x00' * 16)
+        self.assertTrue(a == b'\x00' * 16)
 
     def test_aton2(self):
         a = aton6('::1')
-        self.failUnless(a == b'\x00' * 15 + b'\x01')
+        self.assertTrue(a == b'\x00' * 15 + b'\x01')
 
     def test_aton3(self):
         a = aton6('::10.0.0.1')
-        self.failUnless(a == b'\x00' * 12 + b'\x0a\x00\x00\x01')
+        self.assertTrue(a == b'\x00' * 12 + b'\x0a\x00\x00\x01')
 
     def test_aton4(self):
         a = aton6('abcd::dcba')
-        self.failUnless(a == b'\xab\xcd' + b'\x00' * 12 + b'\xdc\xba')
+        self.assertTrue(a == b'\xab\xcd' + b'\x00' * 12 + b'\xdc\xba')
 
     def test_aton5(self):
         a = aton6('1:2:3:4:5:6:7:8')
@@ -211,7 +211,7 @@ class NtoAAtoNTestCase(unittest.TestCase):
         t2 = '::ffff:127.0.0.1'
         t3 = '1::ffff:127.0.0.1'
         self.failIf(dns.ipv6.is_mapped(aton6(t1)))
-        self.failUnless(dns.ipv6.is_mapped(aton6(t2)))
+        self.assertTrue(dns.ipv6.is_mapped(aton6(t2)))
         self.failIf(dns.ipv6.is_mapped(aton6(t3)))
 
     def test_is_multicast(self):
@@ -223,10 +223,10 @@ class NtoAAtoNTestCase(unittest.TestCase):
         t6 = 'ff00::1'
         self.failIf(dns.inet.is_multicast(t1))
         self.failIf(dns.inet.is_multicast(t2))
-        self.failUnless(dns.inet.is_multicast(t3))
-        self.failUnless(dns.inet.is_multicast(t4))
+        self.assertTrue(dns.inet.is_multicast(t3))
+        self.assertTrue(dns.inet.is_multicast(t4))
         self.failIf(dns.inet.is_multicast(t5))
-        self.failUnless(dns.inet.is_multicast(t6))
+        self.assertTrue(dns.inet.is_multicast(t6))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ntoaaton.py
+++ b/tests/test_ntoaaton.py
@@ -210,9 +210,9 @@ class NtoAAtoNTestCase(unittest.TestCase):
         t1 = '2001:db8:0:1:1:1:1:1'
         t2 = '::ffff:127.0.0.1'
         t3 = '1::ffff:127.0.0.1'
-        self.failIf(dns.ipv6.is_mapped(aton6(t1)))
+        self.assertFalse(dns.ipv6.is_mapped(aton6(t1)))
         self.assertTrue(dns.ipv6.is_mapped(aton6(t2)))
-        self.failIf(dns.ipv6.is_mapped(aton6(t3)))
+        self.assertFalse(dns.ipv6.is_mapped(aton6(t3)))
 
     def test_is_multicast(self):
         t1 = '223.0.0.1'
@@ -221,11 +221,11 @@ class NtoAAtoNTestCase(unittest.TestCase):
         t4 = '239.0.0.1'
         t5 = 'fe00::1'
         t6 = 'ff00::1'
-        self.failIf(dns.inet.is_multicast(t1))
-        self.failIf(dns.inet.is_multicast(t2))
+        self.assertFalse(dns.inet.is_multicast(t1))
+        self.assertFalse(dns.inet.is_multicast(t2))
         self.assertTrue(dns.inet.is_multicast(t3))
         self.assertTrue(dns.inet.is_multicast(t4))
-        self.failIf(dns.inet.is_multicast(t5))
+        self.assertFalse(dns.inet.is_multicast(t5))
         self.assertTrue(dns.inet.is_multicast(t6))
 
 if __name__ == '__main__':

--- a/tests/test_ntoaaton.py
+++ b/tests/test_ntoaaton.py
@@ -61,17 +61,17 @@ class NtoAAtoNTestCase(unittest.TestCase):
     def test_bad_aton1(self):
         def bad():
             aton6('abcd:dcba')
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def test_bad_aton2(self):
         def bad():
             aton6('abcd::dcba::1')
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def test_bad_aton3(self):
         def bad():
             aton6('1:2:3:4:5:6:7:8:9')
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def test_aton6(self):
         a = aton6('::')
@@ -162,12 +162,12 @@ class NtoAAtoNTestCase(unittest.TestCase):
     def test_bad_ntoa1(self):
         def bad():
             ntoa6('')
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_bad_ntoa2(self):
         def bad():
             ntoa6('\x00' * 17)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_good_v4_aton(self):
         pairs = [('1.2.3.4', b'\x01\x02\x03\x04'),
@@ -186,7 +186,7 @@ class NtoAAtoNTestCase(unittest.TestCase):
             return bad
         for addr in v4_bad_addrs:
             print(addr)
-            self.failUnlessRaises(dns.exception.SyntaxError, make_bad(addr))
+            self.assertRaises(dns.exception.SyntaxError, make_bad(addr))
 
     def test_bad_v6_aton(self):
         addrs = ['+::0', '0::0::', '::0::', '1:2:3:4:5:6:7:8:9',
@@ -198,7 +198,7 @@ class NtoAAtoNTestCase(unittest.TestCase):
                 x = aton6(a)
             return bad
         for addr in addrs:
-            self.failUnlessRaises(dns.exception.SyntaxError, make_bad(addr))
+            self.assertRaises(dns.exception.SyntaxError, make_bad(addr))
 
     def test_rfc5952_section_4_2_2(self):
         addr = '2001:db8:0:1:1:1:1:1'

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -45,7 +45,7 @@ class RdataTestCase(unittest.TestCase):
         def bad():
             TTXTTWO = dns.rdatatype.TXT
             dns.rdata.register_type(tests.ttxt_module, TTXTTWO, 'TTXTTWO')
-        self.failUnlessRaises(dns.rdata.RdatatypeExists, bad)
+        self.assertRaises(dns.rdata.RdatatypeExists, bad)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -27,19 +27,19 @@ class RdataTestCase(unittest.TestCase):
 
     def test_str(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
-        self.failUnless(rdata.address == "1.2.3.4")
+        self.assertTrue(rdata.address == "1.2.3.4")
 
     def test_unicode(self):
         rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, u"1.2.3.4")
-        self.failUnless(rdata.address == "1.2.3.4")
+        self.assertTrue(rdata.address == "1.2.3.4")
 
     def test_module_registration(self):
         TTXT = 64001
         dns.rdata.register_type(tests.ttxt_module, TTXT, 'TTXT')
         rdata = dns.rdata.from_text(dns.rdataclass.IN, TTXT, 'hello world')
-        self.failUnless(rdata.strings == [b'hello', b'world'])
-        self.failUnless(dns.rdatatype.to_text(TTXT) == 'TTXT')
-        self.failUnless(dns.rdatatype.from_text('TTXT') == TTXT)
+        self.assertTrue(rdata.strings == [b'hello', b'world'])
+        self.assertTrue(dns.rdatatype.to_text(TTXT) == 'TTXT')
+        self.assertTrue(dns.rdatatype.from_text('TTXT') == TTXT)
 
     def test_module_reregistration(self):
         def bad():

--- a/tests/test_rdtypeandclass.py
+++ b/tests/test_rdtypeandclass.py
@@ -25,21 +25,21 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     # Classes
 
     def test_class_meta1(self):
-        self.failUnless(dns.rdataclass.is_metaclass(dns.rdataclass.ANY))
+        self.assertTrue(dns.rdataclass.is_metaclass(dns.rdataclass.ANY))
 
     def test_class_meta2(self):
-        self.failUnless(not dns.rdataclass.is_metaclass(dns.rdataclass.IN))
+        self.assertTrue(not dns.rdataclass.is_metaclass(dns.rdataclass.IN))
 
     def test_class_bytext1(self):
-        self.failUnless(dns.rdataclass.from_text('IN') == dns.rdataclass.IN)
+        self.assertTrue(dns.rdataclass.from_text('IN') == dns.rdataclass.IN)
 
     def test_class_bytext2(self):
-        self.failUnless(dns.rdataclass.from_text('CLASS1') ==
+        self.assertTrue(dns.rdataclass.from_text('CLASS1') ==
                         dns.rdataclass.IN)
 
     def test_class_bytext_bounds1(self):
-        self.failUnless(dns.rdataclass.from_text('CLASS0') == 0)
-        self.failUnless(dns.rdataclass.from_text('CLASS65535') == 65535)
+        self.assertTrue(dns.rdataclass.from_text('CLASS0') == 0)
+        self.assertTrue(dns.rdataclass.from_text('CLASS65535') == 65535)
 
     def test_class_bytext_bounds2(self):
         def bad():
@@ -52,10 +52,10 @@ class RdTypeAndClassTestCase(unittest.TestCase):
         self.failUnlessRaises(dns.rdataclass.UnknownRdataclass, bad)
 
     def test_class_totext1(self):
-        self.failUnless(dns.rdataclass.to_text(dns.rdataclass.IN) == 'IN')
+        self.assertTrue(dns.rdataclass.to_text(dns.rdataclass.IN) == 'IN')
 
     def test_class_totext2(self):
-        self.failUnless(dns.rdataclass.to_text(999) == 'CLASS999')
+        self.assertTrue(dns.rdataclass.to_text(999) == 'CLASS999')
 
     def test_class_totext_bounds1(self):
         def bad():
@@ -70,30 +70,30 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     # Types
 
     def test_type_meta1(self):
-        self.failUnless(dns.rdatatype.is_metatype(dns.rdatatype.ANY))
+        self.assertTrue(dns.rdatatype.is_metatype(dns.rdatatype.ANY))
 
     def test_type_meta2(self):
-        self.failUnless(dns.rdatatype.is_metatype(dns.rdatatype.OPT))
+        self.assertTrue(dns.rdatatype.is_metatype(dns.rdatatype.OPT))
 
     def test_type_meta3(self):
-        self.failUnless(not dns.rdatatype.is_metatype(dns.rdatatype.A))
+        self.assertTrue(not dns.rdatatype.is_metatype(dns.rdatatype.A))
 
     def test_type_singleton1(self):
-        self.failUnless(dns.rdatatype.is_singleton(dns.rdatatype.SOA))
+        self.assertTrue(dns.rdatatype.is_singleton(dns.rdatatype.SOA))
 
     def test_type_singleton2(self):
-        self.failUnless(not dns.rdatatype.is_singleton(dns.rdatatype.A))
+        self.assertTrue(not dns.rdatatype.is_singleton(dns.rdatatype.A))
 
     def test_type_bytext1(self):
-        self.failUnless(dns.rdatatype.from_text('A') == dns.rdatatype.A)
+        self.assertTrue(dns.rdatatype.from_text('A') == dns.rdatatype.A)
 
     def test_type_bytext2(self):
-        self.failUnless(dns.rdatatype.from_text('TYPE1') ==
+        self.assertTrue(dns.rdatatype.from_text('TYPE1') ==
                         dns.rdatatype.A)
 
     def test_type_bytext_bounds1(self):
-        self.failUnless(dns.rdatatype.from_text('TYPE0') == 0)
-        self.failUnless(dns.rdatatype.from_text('TYPE65535') == 65535)
+        self.assertTrue(dns.rdatatype.from_text('TYPE0') == 0)
+        self.assertTrue(dns.rdatatype.from_text('TYPE65535') == 65535)
 
     def test_type_bytext_bounds2(self):
         def bad():
@@ -106,10 +106,10 @@ class RdTypeAndClassTestCase(unittest.TestCase):
         self.failUnlessRaises(dns.rdatatype.UnknownRdatatype, bad)
 
     def test_type_totext1(self):
-        self.failUnless(dns.rdatatype.to_text(dns.rdatatype.A) == 'A')
+        self.assertTrue(dns.rdatatype.to_text(dns.rdatatype.A) == 'A')
 
     def test_type_totext2(self):
-        self.failUnless(dns.rdatatype.to_text(999) == 'TYPE999')
+        self.assertTrue(dns.rdatatype.to_text(999) == 'TYPE999')
 
     def test_type_totext_bounds1(self):
         def bad():
@@ -122,7 +122,7 @@ class RdTypeAndClassTestCase(unittest.TestCase):
         self.failUnlessRaises(ValueError, bad)
 
     def test_type0_totext(self):
-        self.failUnless(dns.rdatatype.to_text(0) == 'TYPE0')
+        self.assertTrue(dns.rdatatype.to_text(0) == 'TYPE0')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rdtypeandclass.py
+++ b/tests/test_rdtypeandclass.py
@@ -44,12 +44,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_class_bytext_bounds2(self):
         def bad():
             dns.rdataclass.from_text('CLASS65536')
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_class_bytext_unknown(self):
         def bad():
             dns.rdataclass.from_text('XXX')
-        self.failUnlessRaises(dns.rdataclass.UnknownRdataclass, bad)
+        self.assertRaises(dns.rdataclass.UnknownRdataclass, bad)
 
     def test_class_totext1(self):
         self.assertTrue(dns.rdataclass.to_text(dns.rdataclass.IN) == 'IN')
@@ -60,12 +60,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_class_totext_bounds1(self):
         def bad():
             dns.rdataclass.to_text(-1)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_class_totext_bounds2(self):
         def bad():
             dns.rdataclass.to_text(65536)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     # Types
 
@@ -98,12 +98,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_type_bytext_bounds2(self):
         def bad():
             dns.rdatatype.from_text('TYPE65536')
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_type_bytext_unknown(self):
         def bad():
             dns.rdatatype.from_text('XXX')
-        self.failUnlessRaises(dns.rdatatype.UnknownRdatatype, bad)
+        self.assertRaises(dns.rdatatype.UnknownRdatatype, bad)
 
     def test_type_totext1(self):
         self.assertTrue(dns.rdatatype.to_text(dns.rdatatype.A) == 'A')
@@ -114,12 +114,12 @@ class RdTypeAndClassTestCase(unittest.TestCase):
     def test_type_totext_bounds1(self):
         def bad():
             dns.rdatatype.to_text(-1)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_type_totext_bounds2(self):
         def bad():
             dns.rdatatype.to_text(65536)
-        self.failUnlessRaises(ValueError, bad)
+        self.assertRaises(ValueError, bad)
 
     def test_type0_totext(self):
         self.assertTrue(dns.rdatatype.to_text(0) == 'TYPE0')

--- a/tests/test_rdtypeanydnskey.py
+++ b/tests/test_rdtypeanydnskey.py
@@ -28,10 +28,10 @@ class RdtypeAnyDnskeyTestCase(unittest.TestCase):
         good_s = set() #type: Set[str]
         good_f = 0
         from_flags = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(good_f)
-        self.failUnless(from_flags == good_s,
+        self.assertTrue(from_flags == good_s,
                         '"{}" != "{}"'.format(from_flags, good_s))
         from_set = dns.rdtypes.ANY.DNSKEY.flags_from_text_set(good_s)
-        self.failUnless(from_set == good_f,
+        self.assertTrue(from_set == good_f,
                         '"0x{:x}" != "0x{:x}"'.format(from_set, good_f))
 
     def testFlagsAll(self): # type: () -> None
@@ -39,17 +39,17 @@ class RdtypeAnyDnskeyTestCase(unittest.TestCase):
         good_s = {'SEP', 'REVOKE', 'ZONE'}
         good_f = 0x181
         from_flags = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(good_f)
-        self.failUnless(from_flags == good_s,
+        self.assertTrue(from_flags == good_s,
                         '"{}" != "{}"'.format(from_flags, good_s))
         from_text = dns.rdtypes.ANY.DNSKEY.flags_from_text_set(good_s)
-        self.failUnless(from_text == good_f,
+        self.assertTrue(from_text == good_f,
                         '"0x{:x}" != "0x{:x}"'.format(from_text, good_f))
 
     def testFlagsUnknownToText(self): # type: () -> None
         '''Test that undefined flags are returned in hexadecimal notation.'''
         unk_s = {'0x8000'}
         flags_s = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(0x8000)
-        self.failUnless(flags_s == unk_s, '"{}" != "{}"'.format(flags_s, unk_s))
+        self.assertTrue(flags_s == unk_s, '"{}" != "{}"'.format(flags_s, unk_s))
 
     def testFlagsUnknownToFlags(self): # type: () -> None
         '''Test that conversion from undefined mnemonic raises error.'''
@@ -62,7 +62,7 @@ class RdtypeAnyDnskeyTestCase(unittest.TestCase):
         rr = dns.rrset.from_text('foo', 300, 'IN', 'DNSKEY', '257 3 8 KEY=')[0]
         rr_s = {'ZONE', 'SEP'}
         flags_s = rr.flags_to_text_set()
-        self.failUnless(flags_s == rr_s, '"{}" != "{}"'.format(flags_s, rr_s))
+        self.assertTrue(flags_s == rr_s, '"{}" != "{}"'.format(flags_s, rr_s))
 
 
 if __name__ == '__main__':

--- a/tests/test_rdtypeanydnskey.py
+++ b/tests/test_rdtypeanydnskey.py
@@ -53,7 +53,7 @@ class RdtypeAnyDnskeyTestCase(unittest.TestCase):
 
     def testFlagsUnknownToFlags(self): # type: () -> None
         '''Test that conversion from undefined mnemonic raises error.'''
-        self.failUnlessRaises(NotImplementedError,
+        self.assertRaises(NotImplementedError,
                               dns.rdtypes.ANY.DNSKEY.flags_from_text_set,
                               (['0x8000']))
 

--- a/tests/test_rdtypeanyloc.py
+++ b/tests/test_rdtypeanyloc.py
@@ -28,7 +28,7 @@ class RdtypeAnyLocTestCase(unittest.TestCase):
         r2 = dns.rrset.from_text('FOO', 600, 'in', 'loc',
                                  '49 11 42.400 N 16 36 29.600 E 227.64m '
                                  '1.00m 10000.00m 10.00m')
-        self.failUnless(r1 == r2, '"{}" != "{}"'.format(r1, r2))
+        self.assertTrue(r1 == r2, '"{}" != "{}"'.format(r1, r2))
 
     def testEqual2(self):
         '''Test default values for size, horizontal and vertical precision.'''
@@ -39,7 +39,7 @@ class RdtypeAnyLocTestCase(unittest.TestCase):
                                      (16, 36, 29, 600, 1),
                                      22764.0, # centimeters
                                      100.0, 1000000.00, 1000.0)  # centimeters
-        self.failUnless(r1 == r2, '"{}" != "{}"'.format(r1, r2))
+        self.assertTrue(r1 == r2, '"{}" != "{}"'.format(r1, r2))
 
     def testEqual3(self):
         '''Test size, horizontal and vertical precision parsers: 100 cm == 1 m.
@@ -51,7 +51,7 @@ class RdtypeAnyLocTestCase(unittest.TestCase):
         r2 = dns.rrset.from_text('FOO', 600, 'in', 'loc',
                                  '49 11 42.400 N 16 36 29.600 E 227.64m '
                                  '2.00m 10.00m 2.00m')[0]
-        self.failUnless(r1 == r2, '"{}" != "{}"'.format(r1, r2))
+        self.assertTrue(r1 == r2, '"{}" != "{}"'.format(r1, r2))
 
     def testEqual4(self):
         '''Test size, horizontal and vertical precision parsers without unit.
@@ -64,7 +64,7 @@ class RdtypeAnyLocTestCase(unittest.TestCase):
         r2 = dns.rrset.from_text('FOO', 600, 'in', 'loc',
                                  '49 11 42.400 N 16 36 29.600 E 227.64 '
                                  '2 10 2')[0] # meters without explicit unit
-        self.failUnless(r1 == r2, '"{}" != "{}"'.format(r1, r2))
+        self.assertTrue(r1 == r2, '"{}" != "{}"'.format(r1, r2))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -107,7 +107,7 @@ class BaseResolverTests(unittest.TestCase):
         def testRead(self):
             f = StringIO(resolv_conf)
             r = dns.resolver.Resolver(f)
-            self.failUnless(r.nameservers == ['10.0.0.1', '10.0.0.2'] and
+            self.assertTrue(r.nameservers == ['10.0.0.1', '10.0.0.2'] and
                             r.domain == dns.name.from_text('foo'))
 
     def testCacheExpiration(self):
@@ -118,7 +118,7 @@ class BaseResolverTests(unittest.TestCase):
         cache = dns.resolver.Cache()
         cache.put((name, dns.rdatatype.A, dns.rdataclass.IN), answer)
         time.sleep(2)
-        self.failUnless(cache.get((name, dns.rdatatype.A, dns.rdataclass.IN))
+        self.assertTrue(cache.get((name, dns.rdatatype.A, dns.rdataclass.IN))
                         is None)
 
     def testCacheCleaning(self):
@@ -129,7 +129,7 @@ class BaseResolverTests(unittest.TestCase):
         cache = dns.resolver.Cache(cleaning_interval=1.0)
         cache.put((name, dns.rdatatype.A, dns.rdataclass.IN), answer)
         time.sleep(2)
-        self.failUnless(cache.get((name, dns.rdatatype.A, dns.rdataclass.IN))
+        self.assertTrue(cache.get((name, dns.rdatatype.A, dns.rdataclass.IN))
                         is None)
 
     def testIndexErrorOnEmptyRRsetAccess(self):
@@ -157,21 +157,21 @@ class BaseResolverTests(unittest.TestCase):
         name = dns.name.from_text('www.dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')
         zname = dns.resolver.zone_for_name(name)
-        self.failUnless(zname == ezname)
+        self.assertTrue(zname == ezname)
 
     @unittest.skipIf(not _network_available, "Internet not reachable")
     def testZoneForName2(self):
         name = dns.name.from_text('a.b.www.dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')
         zname = dns.resolver.zone_for_name(name)
-        self.failUnless(zname == ezname)
+        self.assertTrue(zname == ezname)
 
     @unittest.skipIf(not _network_available, "Internet not reachable")
     def testZoneForName3(self):
         name = dns.name.from_text('dnspython.org.')
         ezname = dns.name.from_text('dnspython.org.')
         zname = dns.resolver.zone_for_name(name)
-        self.failUnless(zname == ezname)
+        self.assertTrue(zname == ezname)
 
     def testZoneForName4(self):
         def bad():
@@ -188,11 +188,11 @@ class BaseResolverTests(unittest.TestCase):
         for i in range(0, 5):
             name = dns.name.from_text('example%d.' % i)
             if i == 0:
-                self.failUnless(cache.get((name, dns.rdatatype.A,
+                self.assertTrue(cache.get((name, dns.rdatatype.A,
                                            dns.rdataclass.IN))
                                 is None)
             else:
-                self.failUnless(not cache.get((name, dns.rdatatype.A,
+                self.assertTrue(not cache.get((name, dns.rdatatype.A,
                                                dns.rdataclass.IN))
                                 is None)
 
@@ -211,11 +211,11 @@ class BaseResolverTests(unittest.TestCase):
         for i in range(0, 5):
             name = dns.name.from_text('example%d.' % i)
             if i == 1:
-                self.failUnless(cache.get((name, dns.rdatatype.A,
+                self.assertTrue(cache.get((name, dns.rdatatype.A,
                                            dns.rdataclass.IN))
                                 is None)
             else:
-                self.failUnless(not cache.get((name, dns.rdatatype.A,
+                self.assertTrue(not cache.get((name, dns.rdatatype.A,
                                                dns.rdataclass.IN))
                                 is None)
 
@@ -228,7 +228,7 @@ class BaseResolverTests(unittest.TestCase):
         time.sleep(2)
         for i in range(0, 4):
             name = dns.name.from_text('example%d.' % i)
-            self.failUnless(cache.get((name, dns.rdatatype.A,
+            self.assertTrue(cache.get((name, dns.rdatatype.A,
                                        dns.rdataclass.IN))
                             is None)
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -140,7 +140,7 @@ class BaseResolverTests(unittest.TestCase):
                                          dns.rdataclass.IN, message,
                                          False)
             return answer[0]
-        self.failUnlessRaises(IndexError, bad)
+        self.assertRaises(IndexError, bad)
 
     def testIndexErrorOnEmptyRRsetDelete(self):
         def bad():
@@ -150,7 +150,7 @@ class BaseResolverTests(unittest.TestCase):
                                          dns.rdataclass.IN, message,
                                          False)
             del answer[0]
-        self.failUnlessRaises(IndexError, bad)
+        self.assertRaises(IndexError, bad)
 
     @unittest.skipIf(not _network_available, "Internet not reachable")
     def testZoneForName1(self):
@@ -177,7 +177,7 @@ class BaseResolverTests(unittest.TestCase):
         def bad():
             name = dns.name.from_text('dnspython.org', None)
             dns.resolver.zone_for_name(name)
-        self.failUnlessRaises(dns.resolver.NotAbsolute, bad)
+        self.assertRaises(dns.resolver.NotAbsolute, bad)
 
     def testLRUReplace(self):
         cache = dns.resolver.LRUCache(4)

--- a/tests/test_rrset.py
+++ b/tests/test_rrset.py
@@ -24,33 +24,33 @@ class RRsetTestCase(unittest.TestCase):
     def testEqual1(self):
         r1 = dns.rrset.from_text('foo', 300, 'in', 'a', '10.0.0.1', '10.0.0.2')
         r2 = dns.rrset.from_text('FOO', 300, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 == r2)
+        self.assertTrue(r1 == r2)
 
     def testEqual2(self):
         r1 = dns.rrset.from_text('foo', 300, 'in', 'a', '10.0.0.1', '10.0.0.2')
         r2 = dns.rrset.from_text('FOO', 600, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 == r2)
+        self.assertTrue(r1 == r2)
 
     def testNotEqual1(self):
         r1 = dns.rrset.from_text('fooa', 30, 'in', 'a', '10.0.0.1', '10.0.0.2')
         r2 = dns.rrset.from_text('FOO', 30, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 != r2)
+        self.assertTrue(r1 != r2)
 
     def testNotEqual2(self):
         r1 = dns.rrset.from_text('foo', 30, 'in', 'a', '10.0.0.1', '10.0.0.3')
         r2 = dns.rrset.from_text('FOO', 30, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 != r2)
+        self.assertTrue(r1 != r2)
 
     def testNotEqual3(self):
         r1 = dns.rrset.from_text('foo', 30, 'in', 'a', '10.0.0.1', '10.0.0.2',
                                  '10.0.0.3')
         r2 = dns.rrset.from_text('FOO', 30, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 != r2)
+        self.assertTrue(r1 != r2)
 
     def testNotEqual4(self):
         r1 = dns.rrset.from_text('foo', 30, 'in', 'a', '10.0.0.1')
         r2 = dns.rrset.from_text('FOO', 30, 'in', 'a', '10.0.0.2', '10.0.0.1')
-        self.failUnless(r1 != r2)
+        self.assertTrue(r1 != r2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -26,153 +26,153 @@ class SimpleSetTestCase(unittest.TestCase):
 
     def testLen1(self):
         s1 = S()
-        self.failUnless(len(s1) == 0)
+        self.assertTrue(len(s1) == 0)
 
     def testLen2(self):
         s1 = S([1, 2, 3])
-        self.failUnless(len(s1) == 3)
+        self.assertTrue(len(s1) == 3)
 
     def testLen3(self):
         s1 = S([1, 2, 3, 3, 3])
-        self.failUnless(len(s1) == 3)
+        self.assertTrue(len(s1) == 3)
 
     def testUnion1(self):
         s1 = S([1, 2, 3])
         s2 = S([1, 2, 3])
         e = S([1, 2, 3])
-        self.failUnless(s1 | s2 == e)
+        self.assertTrue(s1 | s2 == e)
 
     def testUnion2(self):
         s1 = S([1, 2, 3])
         s2 = S([])
         e = S([1, 2, 3])
-        self.failUnless(s1 | s2 == e)
+        self.assertTrue(s1 | s2 == e)
 
     def testUnion3(self):
         s1 = S([1, 2, 3])
         s2 = S([3, 4])
         e = S([1, 2, 3, 4])
-        self.failUnless(s1 | s2 == e)
+        self.assertTrue(s1 | s2 == e)
 
     def testIntersection1(self):
         s1 = S([1, 2, 3])
         s2 = S([1, 2, 3])
         e = S([1, 2, 3])
-        self.failUnless(s1 & s2 == e)
+        self.assertTrue(s1 & s2 == e)
 
     def testIntersection2(self):
         s1 = S([0, 1, 2, 3])
         s2 = S([1, 2, 3, 4])
         e = S([1, 2, 3])
-        self.failUnless(s1 & s2 == e)
+        self.assertTrue(s1 & s2 == e)
 
     def testIntersection3(self):
         s1 = S([1, 2, 3])
         s2 = S([])
         e = S([])
-        self.failUnless(s1 & s2 == e)
+        self.assertTrue(s1 & s2 == e)
 
     def testIntersection4(self):
         s1 = S([1, 2, 3])
         s2 = S([5, 4])
         e = S([])
-        self.failUnless(s1 & s2 == e)
+        self.assertTrue(s1 & s2 == e)
 
     def testDifference1(self):
         s1 = S([1, 2, 3])
         s2 = S([5, 4])
         e = S([1, 2, 3])
-        self.failUnless(s1 - s2 == e)
+        self.assertTrue(s1 - s2 == e)
 
     def testDifference2(self):
         s1 = S([1, 2, 3])
         s2 = S([])
         e = S([1, 2, 3])
-        self.failUnless(s1 - s2 == e)
+        self.assertTrue(s1 - s2 == e)
 
     def testDifference3(self):
         s1 = S([1, 2, 3])
         s2 = S([3, 2])
         e = S([1])
-        self.failUnless(s1 - s2 == e)
+        self.assertTrue(s1 - s2 == e)
 
     def testDifference4(self):
         s1 = S([1, 2, 3])
         s2 = S([3, 2, 1])
         e = S([])
-        self.failUnless(s1 - s2 == e)
+        self.assertTrue(s1 - s2 == e)
 
     def testSubset1(self):
         s1 = S([1, 2, 3])
         s2 = S([3, 2, 1])
-        self.failUnless(s1.issubset(s2))
+        self.assertTrue(s1.issubset(s2))
 
     def testSubset2(self):
         s1 = S([1, 2, 3])
-        self.failUnless(s1.issubset(s1))
+        self.assertTrue(s1.issubset(s1))
 
     def testSubset3(self):
         s1 = S([])
         s2 = S([1, 2, 3])
-        self.failUnless(s1.issubset(s2))
+        self.assertTrue(s1.issubset(s2))
 
     def testSubset4(self):
         s1 = S([1])
         s2 = S([1, 2, 3])
-        self.failUnless(s1.issubset(s2))
+        self.assertTrue(s1.issubset(s2))
 
     def testSubset5(self):
         s1 = S([])
         s2 = S([])
-        self.failUnless(s1.issubset(s2))
+        self.assertTrue(s1.issubset(s2))
 
     def testSubset6(self):
         s1 = S([1, 4])
         s2 = S([1, 2, 3])
-        self.failUnless(not s1.issubset(s2))
+        self.assertTrue(not s1.issubset(s2))
 
     def testSuperset1(self):
         s1 = S([1, 2, 3])
         s2 = S([3, 2, 1])
-        self.failUnless(s1.issuperset(s2))
+        self.assertTrue(s1.issuperset(s2))
 
     def testSuperset2(self):
         s1 = S([1, 2, 3])
-        self.failUnless(s1.issuperset(s1))
+        self.assertTrue(s1.issuperset(s1))
 
     def testSuperset3(self):
         s1 = S([1, 2, 3])
         s2 = S([])
-        self.failUnless(s1.issuperset(s2))
+        self.assertTrue(s1.issuperset(s2))
 
     def testSuperset4(self):
         s1 = S([1, 2, 3])
         s2 = S([1])
-        self.failUnless(s1.issuperset(s2))
+        self.assertTrue(s1.issuperset(s2))
 
     def testSuperset5(self):
         s1 = S([])
         s2 = S([])
-        self.failUnless(s1.issuperset(s2))
+        self.assertTrue(s1.issuperset(s2))
 
     def testSuperset6(self):
         s1 = S([1, 2, 3])
         s2 = S([1, 4])
-        self.failUnless(not s1.issuperset(s2))
+        self.assertTrue(not s1.issuperset(s2))
 
     def testUpdate1(self):
         s1 = S([1, 2, 3])
         u = (4, 5, 6)
         e = S([1, 2, 3, 4, 5, 6])
         s1.update(u)
-        self.failUnless(s1 == e)
+        self.assertTrue(s1 == e)
 
     def testUpdate2(self):
         s1 = S([1, 2, 3])
         u = []
         e = S([1, 2, 3])
         s1.update(u)
-        self.failUnless(s1 == e)
+        self.assertTrue(s1 == e)
 
     def testGetitem(self):
         s1 = S([1, 2, 3])
@@ -180,31 +180,31 @@ class SimpleSetTestCase(unittest.TestCase):
         i1 = s1[1]
         i2 = s1[2]
         s2 = S([i0, i1, i2])
-        self.failUnless(s1 == s2)
+        self.assertTrue(s1 == s2)
 
     def testGetslice(self):
         s1 = S([1, 2, 3])
         slice = s1[0:2]
-        self.failUnless(len(slice) == 2)
+        self.assertTrue(len(slice) == 2)
         item = s1[2]
         slice.append(item)
         s2 = S(slice)
-        self.failUnless(s1 == s2)
+        self.assertTrue(s1 == s2)
 
     def testDelitem(self):
         s1 = S([1, 2, 3])
         del s1[0]
         i1 = s1[0]
         i2 = s1[1]
-        self.failUnless(i1 != i2)
-        self.failUnless(i1 == 1 or i1 == 2 or i1 == 3)
-        self.failUnless(i2 == 1 or i2 == 2 or i2 == 3)
+        self.assertTrue(i1 != i2)
+        self.assertTrue(i1 == 1 or i1 == 2 or i1 == 3)
+        self.assertTrue(i2 == 1 or i2 == 2 or i2 == 3)
 
     def testDelslice(self):
         s1 = S([1, 2, 3])
         del s1[0:2]
         i1 = s1[0]
-        self.failUnless(i1 == 1 or i1 == 2 or i1 == 3)
+        self.assertTrue(i1 == 1 or i1 == 2 or i1 == 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -53,19 +53,19 @@ class TokenizerTestCase(unittest.TestCase):
         def bad():
             tok = dns.tokenizer.Tokenizer(r'"foo')
             tok.get()
-        self.failUnlessRaises(dns.exception.UnexpectedEnd, bad)
+        self.assertRaises(dns.exception.UnexpectedEnd, bad)
 
     def testQuotedString6(self):
         def bad():
             tok = dns.tokenizer.Tokenizer(r'"foo\01')
             tok.get()
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testQuotedString7(self):
         def bad():
             tok = dns.tokenizer.Tokenizer('"foo\nbar"')
             tok.get()
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testEmpty1(self):
         tok = dns.tokenizer.Tokenizer('')
@@ -129,13 +129,13 @@ class TokenizerTestCase(unittest.TestCase):
         def bad():
             tok = dns.tokenizer.Tokenizer('foo)')
             list(iter(tok))
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testMultiline4(self):
         def bad():
             tok = dns.tokenizer.Tokenizer('((foo)')
             list(iter(tok))
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testUnget1(self):
         tok = dns.tokenizer.Tokenizer('foo')
@@ -151,7 +151,7 @@ class TokenizerTestCase(unittest.TestCase):
             t1 = tok.get()
             tok.unget(t1)
             tok.unget(t1)
-        self.failUnlessRaises(dns.tokenizer.UngetBufferFull, bad)
+        self.assertRaises(dns.tokenizer.UngetBufferFull, bad)
 
     def testGetEOL1(self):
         tok = dns.tokenizer.Tokenizer('\n')

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -27,27 +27,27 @@ class TokenizerTestCase(unittest.TestCase):
     def testStr(self):
         tok = dns.tokenizer.Tokenizer('foo')
         token = tok.get()
-        self.failUnless(token == Token(dns.tokenizer.IDENTIFIER, 'foo'))
+        self.assertTrue(token == Token(dns.tokenizer.IDENTIFIER, 'foo'))
 
     def testQuotedString1(self):
         tok = dns.tokenizer.Tokenizer(r'"foo"')
         token = tok.get()
-        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, 'foo'))
+        self.assertTrue(token == Token(dns.tokenizer.QUOTED_STRING, 'foo'))
 
     def testQuotedString2(self):
         tok = dns.tokenizer.Tokenizer(r'""')
         token = tok.get()
-        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, ''))
+        self.assertTrue(token == Token(dns.tokenizer.QUOTED_STRING, ''))
 
     def testQuotedString3(self):
         tok = dns.tokenizer.Tokenizer(r'"\"foo\""')
         token = tok.get()
-        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, '"foo"'))
+        self.assertTrue(token == Token(dns.tokenizer.QUOTED_STRING, '"foo"'))
 
     def testQuotedString4(self):
         tok = dns.tokenizer.Tokenizer(r'"foo\010bar"')
         token = tok.get()
-        self.failUnless(token == Token(dns.tokenizer.QUOTED_STRING, 'foo\x0abar'))
+        self.assertTrue(token == Token(dns.tokenizer.QUOTED_STRING, 'foo\x0abar'))
 
     def testQuotedString5(self):
         def bad():
@@ -70,59 +70,59 @@ class TokenizerTestCase(unittest.TestCase):
     def testEmpty1(self):
         tok = dns.tokenizer.Tokenizer('')
         token = tok.get()
-        self.failUnless(token.is_eof())
+        self.assertTrue(token.is_eof())
 
     def testEmpty2(self):
         tok = dns.tokenizer.Tokenizer('')
         token1 = tok.get()
         token2 = tok.get()
-        self.failUnless(token1.is_eof() and token2.is_eof())
+        self.assertTrue(token1.is_eof() and token2.is_eof())
 
     def testEOL(self):
         tok = dns.tokenizer.Tokenizer('\n')
         token1 = tok.get()
         token2 = tok.get()
-        self.failUnless(token1.is_eol() and token2.is_eof())
+        self.assertTrue(token1.is_eol() and token2.is_eof())
 
     def testWS1(self):
         tok = dns.tokenizer.Tokenizer(' \n')
         token1 = tok.get()
-        self.failUnless(token1.is_eol())
+        self.assertTrue(token1.is_eol())
 
     def testWS2(self):
         tok = dns.tokenizer.Tokenizer(' \n')
         token1 = tok.get(want_leading=True)
-        self.failUnless(token1.is_whitespace())
+        self.assertTrue(token1.is_whitespace())
 
     def testComment1(self):
         tok = dns.tokenizer.Tokenizer(' ;foo\n')
         token1 = tok.get()
-        self.failUnless(token1.is_eol())
+        self.assertTrue(token1.is_eol())
 
     def testComment2(self):
         tok = dns.tokenizer.Tokenizer(' ;foo\n')
         token1 = tok.get(want_comment=True)
         token2 = tok.get()
-        self.failUnless(token1 == Token(dns.tokenizer.COMMENT, 'foo') and
+        self.assertTrue(token1 == Token(dns.tokenizer.COMMENT, 'foo') and
                         token2.is_eol())
 
     def testComment3(self):
         tok = dns.tokenizer.Tokenizer(' ;foo bar\n')
         token1 = tok.get(want_comment=True)
         token2 = tok.get()
-        self.failUnless(token1 == Token(dns.tokenizer.COMMENT, 'foo bar') and
+        self.assertTrue(token1 == Token(dns.tokenizer.COMMENT, 'foo bar') and
                         token2.is_eol())
 
     def testMultiline1(self):
         tok = dns.tokenizer.Tokenizer('( foo\n\n bar\n)')
         tokens = list(iter(tok))
-        self.failUnless(tokens == [Token(dns.tokenizer.IDENTIFIER, 'foo'),
+        self.assertTrue(tokens == [Token(dns.tokenizer.IDENTIFIER, 'foo'),
                                    Token(dns.tokenizer.IDENTIFIER, 'bar')])
 
     def testMultiline2(self):
         tok = dns.tokenizer.Tokenizer('( foo\n\n bar\n)\n')
         tokens = list(iter(tok))
-        self.failUnless(tokens == [Token(dns.tokenizer.IDENTIFIER, 'foo'),
+        self.assertTrue(tokens == [Token(dns.tokenizer.IDENTIFIER, 'foo'),
                                    Token(dns.tokenizer.IDENTIFIER, 'bar'),
                                    Token(dns.tokenizer.EOL, '\n')])
     def testMultiline3(self):
@@ -142,7 +142,7 @@ class TokenizerTestCase(unittest.TestCase):
         t1 = tok.get()
         tok.unget(t1)
         t2 = tok.get()
-        self.failUnless(t1 == t2 and t1.ttype == dns.tokenizer.IDENTIFIER and \
+        self.assertTrue(t1 == t2 and t1.ttype == dns.tokenizer.IDENTIFIER and \
                         t1.value == 'foo')
 
     def testUnget2(self):
@@ -156,42 +156,42 @@ class TokenizerTestCase(unittest.TestCase):
     def testGetEOL1(self):
         tok = dns.tokenizer.Tokenizer('\n')
         t = tok.get_eol()
-        self.failUnless(t == '\n')
+        self.assertTrue(t == '\n')
 
     def testGetEOL2(self):
         tok = dns.tokenizer.Tokenizer('')
         t = tok.get_eol()
-        self.failUnless(t == '')
+        self.assertTrue(t == '')
 
     def testEscapedDelimiter1(self):
         tok = dns.tokenizer.Tokenizer(r'ch\ ld')
         t = tok.get()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\ ld')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\ ld')
 
     def testEscapedDelimiter2(self):
         tok = dns.tokenizer.Tokenizer(r'ch\032ld')
         t = tok.get()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\032ld')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\032ld')
 
     def testEscapedDelimiter3(self):
         tok = dns.tokenizer.Tokenizer(r'ch\ild')
         t = tok.get()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\ild')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch\ild')
 
     def testEscapedDelimiter1u(self):
         tok = dns.tokenizer.Tokenizer(r'ch\ ld')
         t = tok.get().unescape()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch ld')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'ch ld')
 
     def testEscapedDelimiter2u(self):
         tok = dns.tokenizer.Tokenizer(r'ch\032ld')
         t = tok.get().unescape()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == 'ch ld')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == 'ch ld')
 
     def testEscapedDelimiter3u(self):
         tok = dns.tokenizer.Tokenizer(r'ch\ild')
         t = tok.get().unescape()
-        self.failUnless(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'child')
+        self.assertTrue(t.ttype == dns.tokenizer.IDENTIFIER and t.value == r'child')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -75,7 +75,7 @@ class UpdateTestCase(unittest.TestCase):
         update.delete('bar', 'a', '10.0.0.4')
         update.delete('blaz', 'a')
         update.delete('blaz2')
-        self.failUnless(update.to_wire() == goodwire)
+        self.assertTrue(update.to_wire() == goodwire)
 
     def test_to_wire2(self): # type: () -> None
         update = dns.update.Update('example')
@@ -90,7 +90,7 @@ class UpdateTestCase(unittest.TestCase):
         update.delete('bar', 'a', '10.0.0.4')
         update.delete('blaz', 'a')
         update.delete('blaz2')
-        self.failUnless(update.to_wire() == goodwire)
+        self.assertTrue(update.to_wire() == goodwire)
 
     def test_to_wire3(self): # type: () -> None
         update = dns.update.Update('example')
@@ -105,13 +105,13 @@ class UpdateTestCase(unittest.TestCase):
         update.delete('bar', 'a', '10.0.0.4')
         update.delete('blaz', 'a')
         update.delete('blaz2')
-        self.failUnless(update.to_wire() == goodwire)
+        self.assertTrue(update.to_wire() == goodwire)
 
     def test_from_text1(self): # type: () -> None
         update = dns.message.from_text(update_text)
         w = update.to_wire(origin=dns.name.from_text('example'),
                            want_shuffle=False)
-        self.failUnless(w == goodwire)
+        self.assertTrue(w == goodwire)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -147,7 +147,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example1.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testFromFile2(self): # type: () -> None
         z = dns.zone.from_file(here('example'), 'example', relativize=False)
@@ -159,7 +159,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example2.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testToFileTextualStream(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -188,7 +188,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example3-textual.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testToFileBinary(self): # type: () -> None
         z = dns.zone.from_file(here('example'), 'example')
@@ -201,7 +201,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example3-binary.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testToFileFilename(self): # type: () -> None
         z = dns.zone.from_file(here('example'), 'example')
@@ -212,7 +212,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example3-filename.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testToText(self): # type: () -> None
         z = dns.zone.from_file(here('example'), 'example')
@@ -227,7 +227,7 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here('example3.out'))
-        self.failUnless(ok)
+        self.assertTrue(ok)
 
     def testFromText(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -258,37 +258,37 @@ class ZoneTestCase(unittest.TestCase):
                     rd2 = dns.rdata.from_wire(rds.rdclass, rds.rdtype,
                                               wire, 0, len(wire),
                                               origin=o)
-                    self.failUnless(rd == rd2)
+                    self.assertTrue(rd == rd2)
 
     def testEqual(self): # type: () -> None
         z1 = dns.zone.from_text(example_text, 'example.', relativize=True)
         z2 = dns.zone.from_text(example_text_output, 'example.',
                                 relativize=True)
-        self.failUnless(z1 == z2)
+        self.assertTrue(z1 == z2)
 
     def testNotEqual1(self): # type: () -> None
         z1 = dns.zone.from_text(example_text, 'example.', relativize=True)
         z2 = dns.zone.from_text(something_quite_similar, 'example.',
                                 relativize=True)
-        self.failUnless(z1 != z2)
+        self.assertTrue(z1 != z2)
 
     def testNotEqual2(self): # type: () -> None
         z1 = dns.zone.from_text(example_text, 'example.', relativize=True)
         z2 = dns.zone.from_text(something_different, 'example.',
                                 relativize=True)
-        self.failUnless(z1 != z2)
+        self.assertTrue(z1 != z2)
 
     def testNotEqual3(self): # type: () -> None
         z1 = dns.zone.from_text(example_text, 'example.', relativize=True)
         z2 = dns.zone.from_text(something_different, 'example2.',
                                 relativize=True)
-        self.failUnless(z1 != z2)
+        self.assertTrue(z1 != z2)
 
     def testFindRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rds = z.find_rdataset('@', 'soa')
         exrds = dns.rdataset.from_text('IN', 'SOA', 300, 'foo bar 1 2 3 4 5')
-        self.failUnless(rds == exrds)
+        self.assertTrue(rds == exrds)
 
     def testFindRdataset2(self): # type: () -> None
         def bad(): # type: () -> None
@@ -300,7 +300,7 @@ class ZoneTestCase(unittest.TestCase):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rrs = z.find_rrset('@', 'soa')
         exrrs = dns.rrset.from_text('@', 300, 'IN', 'SOA', 'foo bar 1 2 3 4 5')
-        self.failUnless(rrs == exrrs)
+        self.assertTrue(rrs == exrrs)
 
     def testFindRRset2(self): # type: () -> None
         def bad(): # type: () -> None
@@ -312,56 +312,56 @@ class ZoneTestCase(unittest.TestCase):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rds = z.get_rdataset('@', 'soa')
         exrds = dns.rdataset.from_text('IN', 'SOA', 300, 'foo bar 1 2 3 4 5')
-        self.failUnless(rds == exrds)
+        self.assertTrue(rds == exrds)
 
     def testGetRdataset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rds = z.get_rdataset('@', 'loc')
-        self.failUnless(rds is None)
+        self.assertTrue(rds is None)
 
     def testGetRRset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rrs = z.get_rrset('@', 'soa')
         exrrs = dns.rrset.from_text('@', 300, 'IN', 'SOA', 'foo bar 1 2 3 4 5')
-        self.failUnless(rrs == exrrs)
+        self.assertTrue(rrs == exrrs)
 
     def testGetRRset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rrs = z.get_rrset('@', 'loc')
-        self.failUnless(rrs is None)
+        self.assertTrue(rrs is None)
 
     def testReplaceRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rdataset = dns.rdataset.from_text('in', 'ns', 300, 'ns3', 'ns4')
         z.replace_rdataset('@', rdataset)
         rds = z.get_rdataset('@', 'ns')
-        self.failUnless(rds is rdataset)
+        self.assertTrue(rds is rdataset)
 
     def testReplaceRdataset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rdataset = dns.rdataset.from_text('in', 'txt', 300, '"foo"')
         z.replace_rdataset('@', rdataset)
         rds = z.get_rdataset('@', 'txt')
-        self.failUnless(rds is rdataset)
+        self.assertTrue(rds is rdataset)
 
     def testDeleteRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         z.delete_rdataset('@', 'ns')
         rds = z.get_rdataset('@', 'ns')
-        self.failUnless(rds is None)
+        self.assertTrue(rds is None)
 
     def testDeleteRdataset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         z.delete_rdataset('ns1', 'a')
         node = z.get_node('ns1')
-        self.failUnless(node is None)
+        self.assertTrue(node is None)
 
     def testNodeFindRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         rds = node.find_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         exrds = dns.rdataset.from_text('IN', 'SOA', 300, 'foo bar 1 2 3 4 5')
-        self.failUnless(rds == exrds)
+        self.assertTrue(rds == exrds)
 
     def testNodeFindRdataset2(self): # type: () -> None
         def bad(): # type: () -> None
@@ -375,40 +375,40 @@ class ZoneTestCase(unittest.TestCase):
         node = z['@']
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         exrds = dns.rdataset.from_text('IN', 'SOA', 300, 'foo bar 1 2 3 4 5')
-        self.failUnless(rds == exrds)
+        self.assertTrue(rds == exrds)
 
     def testNodeGetRdataset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
-        self.failUnless(rds is None)
+        self.assertTrue(rds is None)
 
     def testNodeDeleteRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
-        self.failUnless(rds is None)
+        self.assertTrue(rds is None)
 
     def testNodeDeleteRdataset2(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
-        self.failUnless(rds is None)
+        self.assertTrue(rds is None)
 
     def testIterateRdatasets(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         ns = [n for n, r in z.iterate_rdatasets('A')]
         ns.sort()
-        self.failUnless(ns == [dns.name.from_text('ns1', None),
+        self.assertTrue(ns == [dns.name.from_text('ns1', None),
                                dns.name.from_text('ns2', None)])
 
     def testIterateAllRdatasets(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         ns = [n for n, r in z.iterate_rdatasets()]
         ns.sort()
-        self.failUnless(ns == [dns.name.from_text('@', None),
+        self.assertTrue(ns == [dns.name.from_text('@', None),
                                dns.name.from_text('@', None),
                                dns.name.from_text('bar.foo', None),
                                dns.name.from_text('ns1', None),
@@ -426,7 +426,7 @@ class ZoneTestCase(unittest.TestCase):
                 3600,
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A,
                                     '10.0.0.2'))]
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testIterateAllRdatas(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -457,44 +457,44 @@ class ZoneTestCase(unittest.TestCase):
                 dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A,
                                     '10.0.0.2'))]
         exl.sort(key=_rdata_sort)
-        self.failUnless(l == exl)
+        self.assertTrue(l == exl)
 
     def testTTLs(self): # type: () -> None
         z = dns.zone.from_text(ttl_example_text, 'example.', relativize=True)
         n = z['@'] # type: dns.node.Node
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA))
-        self.failUnless(rds.ttl == 3600)
+        self.assertTrue(rds.ttl == 3600)
         n = z['ns1']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 86401)
+        self.assertTrue(rds.ttl == 86401)
         n = z['ns2']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 694861)
+        self.assertTrue(rds.ttl == 694861)
 
     def testTTLFromSOA(self): # type: () -> None
         z = dns.zone.from_text(ttl_from_soa_text, 'example.', relativize=True)
         n = z['@']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA))
-        self.failUnless(rds.ttl == 3600)
+        self.assertTrue(rds.ttl == 3600)
         soa_rd = rds[0]
         n = z['ns1']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 694861)
+        self.assertTrue(rds.ttl == 694861)
         n = z['ns2']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == soa_rd.minimum)
+        self.assertTrue(rds.ttl == soa_rd.minimum)
 
     def testTTLFromLast(self): # type: () -> None
         z = dns.zone.from_text(ttl_from_last_text, 'example.', check_origin=False)
         n = z['@']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.NS))
-        self.failUnless(rds.ttl == 3600)
+        self.assertTrue(rds.ttl == 3600)
         n = z['ns1']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 3600)
+        self.assertTrue(rds.ttl == 3600)
         n = z['ns2']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 694861)
+        self.assertTrue(rds.ttl == 694861)
 
     def testNoTTL(self): # type: () -> None
         def bad(): # type: () -> None
@@ -515,7 +515,7 @@ class ZoneTestCase(unittest.TestCase):
         z1 = dns.zone.from_text(include_text, 'example.', relativize=True,
                                 allow_include=True)
         z2 = dns.zone.from_file(here('example'), 'example.', relativize=True)
-        self.failUnless(z1 == z2)
+        self.assertTrue(z1 == z2)
 
     def testBadDirective(self): # type: () -> None
         def bad(): # type: () -> None
@@ -528,11 +528,11 @@ class ZoneTestCase(unittest.TestCase):
                                check_origin=False)
         n = z['@']
         rds = cast(dns.rdataset.Rdataset, n.get_rdataset(dns.rdataclass.IN, dns.rdatatype.A))
-        self.failUnless(rds.ttl == 300)
+        self.assertTrue(rds.ttl == 300)
 
     def testZoneOrigin(self): # type: () -> None
         z = dns.zone.Zone('example.')
-        self.failUnless(z.origin == dns.name.from_text('example.'))
+        self.assertTrue(z.origin == dns.name.from_text('example.'))
         def bad1(): # type: () -> None
             o = dns.name.from_text('example', None)
             dns.zone.Zone(o)

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -294,7 +294,7 @@ class ZoneTestCase(unittest.TestCase):
         def bad(): # type: () -> None
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
             z.find_rdataset('@', 'loc')
-        self.failUnlessRaises(KeyError, bad)
+        self.assertRaises(KeyError, bad)
 
     def testFindRRset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -306,7 +306,7 @@ class ZoneTestCase(unittest.TestCase):
         def bad(): # type: () -> None
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
             z.find_rrset('@', 'loc')
-        self.failUnlessRaises(KeyError, bad)
+        self.assertRaises(KeyError, bad)
 
     def testGetRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -368,7 +368,7 @@ class ZoneTestCase(unittest.TestCase):
             z = dns.zone.from_text(example_text, 'example.', relativize=True)
             node = z['@']
             node.find_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
-        self.failUnlessRaises(KeyError, bad)
+        self.assertRaises(KeyError, bad)
 
     def testNodeGetRdataset1(self): # type: () -> None
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -499,17 +499,17 @@ class ZoneTestCase(unittest.TestCase):
     def testNoTTL(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(no_ttl_text, 'example.', check_origin=False)
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testNoSOA(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(no_soa_text, 'example.', relativize=True)
-        self.failUnlessRaises(dns.zone.NoSOA, bad)
+        self.assertRaises(dns.zone.NoSOA, bad)
 
     def testNoNS(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(no_ns_text, 'example.', relativize=True)
-        self.failUnlessRaises(dns.zone.NoNS, bad)
+        self.assertRaises(dns.zone.NoNS, bad)
 
     def testInclude(self): # type: () -> None
         z1 = dns.zone.from_text(include_text, 'example.', relativize=True,
@@ -520,7 +520,7 @@ class ZoneTestCase(unittest.TestCase):
     def testBadDirective(self): # type: () -> None
         def bad(): # type: () -> None
             dns.zone.from_text(bad_directive_text, 'example.', relativize=True)
-        self.failUnlessRaises(dns.exception.SyntaxError, bad)
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testFirstRRStartsWithWhitespace(self): # type: () -> None
         # no name is specified, so default to the initial origin
@@ -536,10 +536,10 @@ class ZoneTestCase(unittest.TestCase):
         def bad1(): # type: () -> None
             o = dns.name.from_text('example', None)
             dns.zone.Zone(o)
-        self.failUnlessRaises(ValueError, bad1)
+        self.assertRaises(ValueError, bad1)
         def bad2(): # type: () -> None
             dns.zone.Zone(cast(str, 1.0))
-        self.failUnlessRaises(ValueError, bad2)
+        self.assertRaises(ValueError, bad2)
 
     def testZoneOriginNone(self): # type: () -> None
         dns.zone.Zone(cast(str, None))


### PR DESCRIPTION
This is a mostly mechanical set if fixes.  I found the collections import while trying to remove deprecation warnings in a different project and once I was here fixing one thing I fixed.

As a side note, just running pytest in the top level directory seems to find your test suite, that may be simpler than using Makefiles....