### PR TITLE
DoH improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ branches:
   except:
     - python3
 install:
- - pip install typing pylint pycryptodome ecdsa idna
+ - pip install typing pylint pycryptodome ecdsa idna requests requests-toolbelt
 script:
  - make test

--- a/dns/query.py
+++ b/dns/query.py
@@ -38,6 +38,7 @@ import dns.rcode
 import dns.rdataclass
 import dns.rdatatype
 
+import requests
 from requests_toolbelt.adapters.source import SourceAddressAdapter
 from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
 
@@ -210,6 +211,19 @@ def _destination_and_source(af, where, port, source, source_port):
             source = (source, source_port, 0, 0)
     return (af, destination, source)
 
+def send_https(session, what, lifetime=None):
+    """
+    :param session: a :class:`requests.sessions.Session`
+    :param what: a :class:`requests.models.Request` or
+    :class:`requests.models.PreparedRequest`.
+    If it's a :class:`requests.models.Request`, it will be converted
+     into a :class:`requests.models.PreparedRequest`.
+    :param lifetime: timeout (in seconds)
+    :return: a :class:`requests.models.Response` object.
+    """
+    if isinstance(what, requests.models.Request):
+        what = what.prepare()
+    return session.send(what, timeout=lifetime)
 
 def https(q, where, session, timeout=None, port=443, path='/dns-query', post=True,
           bootstrap_address=None, verify=True, source=None, source_port=0,

--- a/dns/query.py
+++ b/dns/query.py
@@ -257,8 +257,6 @@ def https(q, where, timeout=None, port=443, path='/dns-query', post=True,
                                                         source, source_port)
     if source is None:
         source = ('', 0)
-    if headers is None:
-        headers = {}
     with requests.Session() as session:
         # set source port and source address
         # see https://github.com/requests/toolbelt/blob/master/requests_toolbelt/adapters/source.py

--- a/dns/query.py
+++ b/dns/query.py
@@ -210,7 +210,7 @@ def _destination_and_source(af, where, port, source, source_port):
     return (af, destination, source)
 
 
-def https(q, where, timeout=None, port=443, path='/dns-query', post=True,
+def https(q, where, session, timeout=None, port=443, path='/dns-query', post=True,
           verify=True, source=None, source_port=0,
           one_rr_per_rrset=False, ignore_trailing=False):
     """Return the response obtained after sending a query via DNS-over-HTTPS.
@@ -220,6 +220,9 @@ def https(q, where, timeout=None, port=443, path='/dns-query', post=True,
     *where*, a ``str``, the nameserver IP address or the full URL. If an IP
     address is given, the URL will be constructed using the following schema:
     https:<IP-address>:<port>/<path>.
+
+    *session*, a ``requests.session.Session``, the session to use to send the
+    queries. This argument is required to allow for connection reuse.
 
     *timeout*, a ``float`` or ``None``, the number of seconds to
     wait before the query times out. If ``None``, the default, wait forever.
@@ -257,12 +260,11 @@ def https(q, where, timeout=None, port=443, path='/dns-query', post=True,
         url = 'https://{}:{}{}'.format(where, port, path)
     except ValueError:
         url = where
-    session = requests.sessions.Session()
+    # session = requests.sessions.Session()
     try:
         # set source port and source address
         # see https://github.com/requests/toolbelt/blob/master/requests_toolbelt/adapters/source.py
-        session.mount('http://', SourceAddressAdapter(source))
-        session.mount('https://', SourceAddressAdapter(source))
+        session.mount(url, SourceAddressAdapter(source))
 
         # see https://tools.ietf.org/html/rfc8484#section-4.1.1 for DoH GET and POST examples
         if post:

--- a/dns/query.py
+++ b/dns/query.py
@@ -220,7 +220,7 @@ def https(q, where, session, timeout=None, port=443, path='/dns-query', post=Tru
 
     *where*, a ``str``, the nameserver IP address or the full URL. If an IP
     address is given, the URL will be constructed using the following schema:
-    https:<IP-address>:<port>/<path>.
+    https://<IP-address>:<port>/<path>.
 
     *session*, a ``requests.session.Session``, the session to use to send the
     queries. This argument is required to allow for connection reuse.

--- a/dns/query.py
+++ b/dns/query.py
@@ -38,7 +38,7 @@ import dns.rdataclass
 import dns.rdatatype
 
 import requests
-import requests.packages.urllib3.util.connection as urllib3_cn
+import urllib3.util.connection
 from requests_toolbelt.adapters.source import SourceAddressAdapter
 
 try:
@@ -263,9 +263,10 @@ def https(q, where, timeout=None, port=443, path='/dns-query', post=True,
         session.mount('http://', SourceAddressAdapter(source))
         session.mount('https://', SourceAddressAdapter(source))
 
-        # effectively set address family
-        # see https://stackoverflow.com/a/46972341/9638991
-        urllib3_cn.allowed_gai_family = lambda: af
+        # This will effectively set the address family passed to getaddrinfo()
+        # in urllib3.util.connection.create_connection(), which is used by requests
+        if af is not None:
+            urllib3.util.connection.allowed_gai_family = lambda: af
 
         try:
             _ = ipaddress.ip_address(where)

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -8,7 +8,7 @@ except ImportError:
         SSLContext = {}
 
 def https(q : message.Message, where: str, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
-          verify : Optional[bool] = True, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,
+          verify : Optional[bool] = True, source : Optional[str] = None, source_port : Optional[int] = 0,
           one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
     pass
 

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -9,7 +9,7 @@ except ImportError:
         SSLContext = {}
 
 def https(q : message.Message, where: str, session: Session, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
-          verify : Optional[bool] = True, source : Optional[str] = None, source_port : Optional[int] = 0,
+          bootstrap_address : Optional[str] = None, verify : Optional[bool] = True, source : Optional[str] = None, source_port : Optional[int] = 0,
           one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
     pass
 

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -7,7 +7,9 @@ except ImportError:
     class ssl(object):
         SSLContext = {}
 
-def https(query : message.Message, url : str, timeout : float = None, post : Optional[bool] = True, one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
+def https(q : message.Message, where: str, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
+          verify : Optional[bool] = True, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,
+          one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
     pass
 
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -1,5 +1,6 @@
 from typing import Optional, Union, Dict, Generator, Any
 from . import tsig, rdatatype, rdataclass, name, message
+from requests.sessions import Session
 
 try:
     import ssl
@@ -7,7 +8,7 @@ except ImportError:
     class ssl(object):
         SSLContext = {}
 
-def https(q : message.Message, where: str, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
+def https(q : message.Message, where: str, session: Session, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
           verify : Optional[bool] = True, source : Optional[str] = None, source_port : Optional[int] = 0,
           one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
     pass

--- a/examples/doh.py
+++ b/examples/doh.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+#
+# This is an example of sending DNS queries over HTTPS (DoH) with dnspython.
+# Requires use of the requests module's Session object.
+#
+# See https://2.python-requests.org//en/latest/user/advanced/#session-objects
+# for more details about Session objects
+import requests
+
+import dns.message
+import dns.query
+import dns.rdatatype
+
+
+def main():
+    where = '1.1.1.1'
+    qname = 'example.com.'
+    # one method is to use context manager, session will automatically close
+    with requests.sessions.Session() as session:
+        q = dns.message.make_query(qname, dns.rdatatype.A)
+        r = dns.query.https(q, where, session)
+        for answer in r.answer:
+            print(answer)
+
+        # ... do more lookups
+
+    where = 'https://dns.google/dns-query'
+    qname = 'example.net.'
+    # second method, close session manually
+    session = requests.sessions.Session()
+    q = dns.message.make_query(qname, dns.rdatatype.A)
+    r = dns.query.https(q, where, session)
+    for answer in r.answer:
+        print(answer)
+
+    # ... do more lookups
+
+    # close the session when you're done
+    session.close()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ direct manipulation of DNS zones, messages, names, and records.""",
     'python_requires': '>=3.4',
     'test_suite': 'tests',
     'provides': ['dns'],
+    'install_requires': ['requests', 'requests-toolbelt'],
     'tests_require': ['typing ; python_version<"3.5"'],
     'extras_require': {
         'IDNA': ['idna>=2.1'],

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -14,7 +14,6 @@
 # WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 import unittest
 import random
 
@@ -43,22 +42,12 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
         self.assertTrue(q.is_response(r))
 
     def test_build_url_from_ip(self):
-        nameserver_ip = '8.8.8.8' #random.choice(KNOWN_ANYCAST_DOH_RESOLVER_IPS)
+        nameserver_ip = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_IPS)
         q = dns.message.make_query('example.com.', dns.rdatatype.A)
         # For some reason Google's DNS over HTTPS fails when you POST to https://8.8.8.8/dns-query
-        # So we're just going to do the GET request
+        # So we're just going to do GET requests here
         r = dns.query.https(q, nameserver_ip, post=False)
         self.assertTrue(q.is_response(r))
-
-    def test_custom_path(self):
-        cleanbrowsing_ip = '185.228.168.168'
-        cleanbrowsing_path = '/doh/security-filter/'
-        q = dns.message.make_query('example.com.', dns.rdatatype.A)
-        r = dns.query.https(q, cleanbrowsing_ip, path=cleanbrowsing_path, verify=False)
-        self.assertTrue(q.is_response(r))
-
-    def test_use_full_url(self):
-        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -1,0 +1,64 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+# Copyright (C) 2003-2007, 2009-2011 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import unittest
+import random
+
+import dns.query
+import dns.rdatatype
+import dns.message
+
+KNOWN_ANYCAST_DOH_RESOLVER_IPS = ['1.1.1.1', '8.8.8.8', '9.9.9.9']
+KNOWN_ANYCAST_DOH_RESOLVER_URLS = ['https://cloudflare-dns.com/dns-query',
+                                   'https://dns.google/dns-query',
+                                   'https://dns11.quad9.net/dns-query']
+
+class DNSOverHTTPSTestCase(unittest.TestCase):
+    nameserver_ip = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_IPS)
+
+    def test_get_request(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url, post=False)
+        self.assertTrue(q.is_response(r))
+
+    def test_post_request(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url, post=True)
+        self.assertTrue(q.is_response(r))
+
+    def test_build_url_from_ip(self):
+        nameserver_ip = '8.8.8.8' #random.choice(KNOWN_ANYCAST_DOH_RESOLVER_IPS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        # For some reason Google's DNS over HTTPS fails when you POST to https://8.8.8.8/dns-query
+        # So we're just going to do the GET request
+        r = dns.query.https(q, nameserver_ip, post=False)
+        self.assertTrue(q.is_response(r))
+
+    def test_custom_path(self):
+        cleanbrowsing_ip = '185.228.168.168'
+        cleanbrowsing_path = '/doh/security-filter/'
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, cleanbrowsing_ip, path=cleanbrowsing_path, verify=False)
+        self.assertTrue(q.is_response(r))
+
+    def test_use_full_url(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Here are some improvements/additions to #393.

This adds a few things that @rthalley requested to `dns.query.https()` (see [comment](https://github.com/rthalley/dnspython/pull/393#issuecomment-547487502)), as well as some other things I thought would be useful.

I added or modified for the following arguments to `dns.query.https()`:
- `q` - used to be called `url`, renamed to `q`
- `source` (source address)
- `source_port`
- `af` - address family to use
- `verify` - defaults to True, determines whether or not to verify server TLS certificates
- `where` - a URL or an IP address (used to only allow for URLs)
- `path` - default is `/dns-query`, the path to use when `where` is an IP address
- `port` - default is 443, the port to use when `where` is an IP address

About the `where` parameter, formerly called `url`. Before it had to be a URL, but now it can be either a full URL (e.g. https://dns.google/dns-query) or an IP address (e.g. 8.8.8.8). If it's the latter, the URL will be built like so: https://**\<where\>**:**\<port\>\<path\>**. If `where` is not an IP address, it is assumed that `port` and `path` and included in `where` and they will not be used to build the URL. I added this functionality because I think it makes sense for https() to have a similar API as the other functions in dns.query (`udp()`, `tcp()`, and `tls()`).

Added the [requests](https://github.com/psf/requests) package for all its goodness.
Added [requests-toolbelt](https://github.com/requests/toolbelt) to set source port/address. The only thing it uses from there is a HttpAdapter, which isn't too long and could be put directly into dnspython somewhere if that's desirable.

Also added a few tests for GET, POST, and passing in an IP address. I don't really like the idea of hard-coding in DNS resolvers for tests, so might be good to change eventually.

I haven't touched `dns.resolver` yet. Figured I'd submit this first to see if there are any thoughts about it.

This PR allows for `where` to be a plain http url. Obviously that would defeat the main purpose of DoH, but it could be useful to someone in setting up/debugging/implementing a DoH service. I don't feel strongly either way.