### PR TITLE
Fix #403: make sure Resolver.nameservers is a list or str (or None)

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -524,7 +524,7 @@ class Resolver(object):
         """
 
         self.domain = None
-        self.nameservers = None
+        self.nameservers = []
         self.nameserver_ports = None
         self.port = None
         self.search = None
@@ -1086,19 +1086,13 @@ class Resolver(object):
     @nameservers.setter
     def nameservers(self, nameservers):
         """
-        :param nameservers: can be a ``str``, ``list``, or None.
-        If it's a ``str``, it will converted to a list.
-        :raise ValueError: if `nameservers` is anything other than \
-        ``str``, ``list``, or None.
+        :param nameservers: must be a ``list``.
+        :raise ValueError: if `nameservers` is anything other than a ``list``.
         """
-        if isinstance(nameservers, str):
-            self._nameservers = [nameservers]
-        elif isinstance(nameservers, list):
+        if isinstance(nameservers, list):
             self._nameservers = nameservers
-        elif nameservers is None:
-            self._nameservers = None
         else:
-            raise ValueError('nameservers must be either a str, a list, or None'
+            raise ValueError('nameservers must be a list'
                              ' (not a {})'.format(type(nameservers)))
 
 #: The default resolver.

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1079,6 +1079,27 @@ class Resolver(object):
 
         self.flags = flags
 
+    @property
+    def nameservers(self):
+        return self._nameservers
+
+    @nameservers.setter
+    def nameservers(self, nameservers):
+        """
+        :param nameservers: can be a ``str``, ``list``, or None.
+        If it's a ``str``, it will converted to a list.
+        :raise ValueError: if `nameservers` is anything other than \
+        ``str``, ``list``, or None.
+        """
+        if isinstance(nameservers, str):
+            self._nameservers = [nameservers]
+        elif isinstance(nameservers, list):
+            self._nameservers = nameservers
+        elif nameservers is None:
+            self._nameservers = None
+        else:
+            raise ValueError('nameservers must be either a str, a list, or None'
+                             ' (not a {})'.format(type(nameservers)))
 
 #: The default resolver.
 default_resolver = None

--- a/dns/resolver.pyi
+++ b/dns/resolver.pyi
@@ -33,7 +33,7 @@ def zone_for_name(name, rdclass : int = rdataclass.IN, tcp=False, resolver : Opt
     ...
 
 class Resolver:
-    def __init__(self, configure):
+    def __init__(self, filename : Optional[str] = '/etc/resolv.conf', configure : Optional[bool] = True):
         self.nameservers : List[str]
     def query(self, qname : str, rdtype : Union[int,str] = rdatatype.A, rdclass : Union[int,str] = rdataclass.IN,
               tcp : bool = False, source : Optional[str] = None, raise_on_no_answer=True, source_port : int = 0):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -404,5 +404,28 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
         self.assertTrue(e2.canonical_name == dns.name.from_text(cname2))
 
 
+class ResolverNameserverValidTypeTestCase(unittest.TestCase):
+    def test_set_nameserver_to_string(self):
+        resolver = dns.resolver.Resolver()
+        resolver.nameservers = '1.2.3.4'
+        self.assertEqual(resolver.nameservers, ['1.2.3.4'])
+
+    def test_set_nameserver_to_list(self):
+        resolver = dns.resolver.Resolver()
+        resolver.nameservers = ['1.2.3.4']
+        self.assertEqual(resolver.nameservers, ['1.2.3.4'])
+
+    def test_set_nameserver_to_None(self):
+        resolver = dns.resolver.Resolver()
+        resolver.nameservers = None
+        self.assertEqual(resolver.nameservers, None)
+
+    def test_set_nameserver_invalid_type(self):
+        resolver = dns.resolver.Resolver()
+        invalid_nameservers = [1234, (1, 2, 3, 4), {'invalid': 'nameserver'}]
+        for invalid_nameserver in invalid_nameservers:
+            with self.assertRaises(ValueError):
+                resolver.nameservers = invalid_nameserver
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -415,6 +415,11 @@ class ResolverNameserverValidTypeTestCase(unittest.TestCase):
         resolver.nameservers = ['1.2.3.4']
         self.assertEqual(resolver.nameservers, ['1.2.3.4'])
 
+    def test_set_namservers_to_empty_list(self):
+        resolver = dns.resolver.Resolver()
+        resolver.nameservers = []
+        self.assertEqual(resolver.nameservers, [])
+
     def test_set_nameserver_to_None(self):
         resolver = dns.resolver.Resolver()
         resolver.nameservers = None

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -405,12 +405,12 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
 
 
 class ResolverNameserverValidTypeTestCase(unittest.TestCase):
-    def test_set_nameserver_to_string(self):
+    def test_set_nameservers_to_string(self):
         resolver = dns.resolver.Resolver()
         resolver.nameservers = '1.2.3.4'
         self.assertEqual(resolver.nameservers, ['1.2.3.4'])
 
-    def test_set_nameserver_to_list(self):
+    def test_set_nameservers_to_list(self):
         resolver = dns.resolver.Resolver()
         resolver.nameservers = ['1.2.3.4']
         self.assertEqual(resolver.nameservers, ['1.2.3.4'])
@@ -420,12 +420,12 @@ class ResolverNameserverValidTypeTestCase(unittest.TestCase):
         resolver.nameservers = []
         self.assertEqual(resolver.nameservers, [])
 
-    def test_set_nameserver_to_None(self):
+    def test_set_nameservers_to_None(self):
         resolver = dns.resolver.Resolver()
         resolver.nameservers = None
         self.assertEqual(resolver.nameservers, None)
 
-    def test_set_nameserver_invalid_type(self):
+    def test_set_nameservers_invalid_type(self):
         resolver = dns.resolver.Resolver()
         invalid_nameservers = [1234, (1, 2, 3, 4), {'invalid': 'nameserver'}]
         for invalid_nameserver in invalid_nameservers:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -405,11 +405,6 @@ class NXDOMAINExceptionTestCase(unittest.TestCase):
 
 
 class ResolverNameserverValidTypeTestCase(unittest.TestCase):
-    def test_set_nameservers_to_string(self):
-        resolver = dns.resolver.Resolver()
-        resolver.nameservers = '1.2.3.4'
-        self.assertEqual(resolver.nameservers, ['1.2.3.4'])
-
     def test_set_nameservers_to_list(self):
         resolver = dns.resolver.Resolver()
         resolver.nameservers = ['1.2.3.4']
@@ -420,14 +415,9 @@ class ResolverNameserverValidTypeTestCase(unittest.TestCase):
         resolver.nameservers = []
         self.assertEqual(resolver.nameservers, [])
 
-    def test_set_nameservers_to_None(self):
-        resolver = dns.resolver.Resolver()
-        resolver.nameservers = None
-        self.assertEqual(resolver.nameservers, None)
-
     def test_set_nameservers_invalid_type(self):
         resolver = dns.resolver.Resolver()
-        invalid_nameservers = [1234, (1, 2, 3, 4), {'invalid': 'nameserver'}]
+        invalid_nameservers = [None, '1.2.3.4', 1234, (1, 2, 3, 4), {'invalid': 'nameserver'}]
         for invalid_nameserver in invalid_nameservers:
             with self.assertRaises(ValueError):
                 resolver.nameservers = invalid_nameserver


### PR DESCRIPTION
validate if assignment of Resolver.nameservers is a list, a str (in which case it will be converted to a list), or None.