### PR TITLE
DoH cleanup.

### DIFF
--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -8,9 +8,8 @@ except ImportError:
     class ssl(object):
         SSLContext = {}
 
-def https(q : message.Message, where: str, session: Session, timeout : Optional[float] = None, port : Optional[int] = 443, path : Optional[str] = '/dns-query', post : Optional[bool] = True,
-          bootstrap_address : Optional[str] = None, verify : Optional[bool] = True, source : Optional[str] = None, source_port : Optional[int] = 0,
-          one_rr_per_rrset : Optional[bool] = False, ignore_trailing : Optional[bool] = False) -> message.Message:
+def https(q : message.Message, where: str, timeout : Optional[float] = None, port : Optional[int] = 443, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,
+          session: Optional[Session], path : Optional[str] = '/dns-query', post : Optional[bool] = True, bootstrap_address : Optional[str] = None, verify : Optional[bool] = True) -> message.Message:
     pass
 
 def tcp(q : message.Message, where : str, timeout : float = None, port=53, af : Optional[int] = None, source : Optional[str] = None, source_port : Optional[int] = 0,

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -909,30 +909,37 @@ class Resolver(object):
                     try:
                         if protocol == 'https':
                             tcp_attempt = True
-                            response = dns.query.https(request, nameserver, timeout)
+                            response = dns.query.https(request, nameserver,
+                                                       timeout=timeout)
                         elif protocol:
                             continue
                         else:
                             tcp_attempt = tcp
                             if tcp:
                                 response = dns.query.tcp(request, nameserver,
-                                                         timeout, port,
+                                                         timeout=timeout,
+                                                         port=port,
                                                          source=source,
-                                                         source_port=source_port)
+                                                         source_port=\
+                                                         source_port)
                             else:
                                 try:
-                                    response = dns.query.udp(request, nameserver,
-                                                             timeout, port,
+                                    response = dns.query.udp(request,
+                                                             nameserver,
+                                                             timeout=timeout,
+                                                             port=port,
                                                              source=source,
                                                              source_port=\
                                                              source_port)
                                 except dns.message.Truncated:
                                     # Response truncated; retry with TCP.
                                     tcp_attempt = True
-                                    timeout = self._compute_timeout(start, lifetime)
+                                    timeout = self._compute_timeout(start,
+                                                                    lifetime)
                                     response = \
                                         dns.query.tcp(request, nameserver,
-                                                      timeout, port,
+                                                      timeout=timeout,
+                                                      port=port,
                                                       source=source,
                                                       source_port=source_port)
                     except (socket.error, dns.exception.Timeout) as ex:

--- a/examples/doh.py
+++ b/examples/doh.py
@@ -18,7 +18,7 @@ def main():
     # one method is to use context manager, session will automatically close
     with requests.sessions.Session() as session:
         q = dns.message.make_query(qname, dns.rdatatype.A)
-        r = dns.query.https(q, where, session)
+        r = dns.query.https(q, where, session=session)
         for answer in r.answer:
             print(answer)
 
@@ -29,7 +29,7 @@ def main():
     # second method, close session manually
     session = requests.sessions.Session()
     q = dns.message.make_query(qname, dns.rdatatype.A)
-    r = dns.query.https(q, where, session)
+    r = dns.query.https(q, where, session=session)
     for answer in r.answer:
         print(answer)
 

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -40,13 +40,13 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
     def test_get_request(self):
         nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
         q = dns.message.make_query('example.com.', dns.rdatatype.A)
-        r = dns.query.https(q, nameserver_url, self.session, post=False)
+        r = dns.query.https(q, nameserver_url, session=self.session, post=False)
         self.assertTrue(q.is_response(r))
 
     def test_post_request(self):
         nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
         q = dns.message.make_query('example.com.', dns.rdatatype.A)
-        r = dns.query.https(q, nameserver_url, self.session, post=True)
+        r = dns.query.https(q, nameserver_url, session=self.session, post=True)
         self.assertTrue(q.is_response(r))
 
     def test_build_url_from_ip(self):
@@ -54,7 +54,7 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
         q = dns.message.make_query('example.com.', dns.rdatatype.A)
         # For some reason Google's DNS over HTTPS fails when you POST to https://8.8.8.8/dns-query
         # So we're just going to do GET requests here
-        r = dns.query.https(q, nameserver_ip, self.session, post=False)
+        r = dns.query.https(q, nameserver_ip, session=self.session, post=False)
         self.assertTrue(q.is_response(r))
 
     def test_bootstrap_address(self):
@@ -64,9 +64,9 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
         q = dns.message.make_query('example.com.', dns.rdatatype.A)
         # make sure CleanBrowsing's IP address will fail TLS certificate check
         with self.assertRaises(SSLError):
-            dns.query.https(q, invalid_tls_url, self.session)
+            dns.query.https(q, invalid_tls_url, session=self.session)
         # use host header
-        r = dns.query.https(q, valid_tls_url, self.session, bootstrap_address=ip)
+        r = dns.query.https(q, valid_tls_url, session=self.session, bootstrap_address=ip)
         self.assertTrue(q.is_response(r))
 
     def test_send_https(self):
@@ -78,6 +78,12 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
         response = dns.query.send_https(self.session, r)
         dns_resp = dns.message.from_wire(response.content)
         self.assertTrue(q.is_response(dns_resp))
+
+    def test_new_session(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url)
+        self.assertTrue(q.is_response(r))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This makes a few changes to the recently commited DoH code.

It updates the https() signature to more closely match the existing udp(), tcp(), and tls() signatures, and also changes the session parameter to be optional.

It updates the resolver code, which was incorrectly calling https().