### PR TITLE
Correct Message.is_response docstring

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -217,7 +217,7 @@ class Message(object):
         return not self.__eq__(other)
 
     def is_response(self, other):
-        """Is this message a response to *other*?
+        """Is *other* a response this message?
 
         Returns a ``bool``.
         """


### PR DESCRIPTION
When testing responses, I discovered that the docstring for Message.is_response had the
comparison backwards, specifically in how the `QR` flag is checked. The documentation
was incorrectly updated in fc7db7da4284eedaa951e6acc34e6e6f94da1c64