### PR TITLE
Add a reverse_lookup function to Resolver.

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1030,37 +1030,22 @@ class Resolver(object):
             self.cache.put((_qname, rdtype, rdclass), answer)
         return answer
 
-    def reverse_lookup(self, ipaddr, tcp=False, source=None, 
-                       raise_on_no_answer=True, source_port=0,
-                       lifetime=None):
-        """Use a resolver to run a Reverse IP Lookup for PTR records.
+    def reverse_query(self, ipaddr, *args, **kwargs):
+        """Use a resolver to run a Reverse IP Query for PTR records.
         
-        This utilizes the in-built query function to perform a PTR lookup and 
-        tests to make sure that the entered string is in fact an IP address.
+        This utilizes the in-built query function to perform a PTR lookup on the 
+        specified IP address.
         
         *ipaddr*, a ``str``, the IP address you want to get the PTR record for.
         
-        *tcp*, a ``bool``.  If ``True``, use TCP to make the query.
-        
-        *source*, a ``text`` or ``None``.  If not ``None``, bind to this IP
-        address when making queries.
-        
-        *raise_on_no_answer*, a ``bool``.  If ``True``, raise
-        ``dns.resolver.NoAnswer`` if there's no answer to the question.
-        
-        *source_port*, an ``int``, the port from which to send the message.
-        
-        *lifetime*, a ``float``, how many seconds a query should run before timing out.
+        All other arguments that can be passed to the query function except for
+        rdtype and rdclass are also supported by this function.
         """
                 
         return self.query(dns.reversename.from_address(address), 
                           rdtype=dns.rdatatype.PTR,
                           rdclass=dns.rdataclass.IN,
-                          tcp=tcp,
-                          source=source,
-                          raise_on_no_answer=raise_on_no_answer,
-                          source_port=source_port,
-                          lifetime=lifetime)
+                          *args, **kwargs)
 
     def use_tsig(self, keyring, keyname=None,
                  algorithm=dns.tsig.default_algorithm):

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -18,7 +18,6 @@
 """DNS stub resolver."""
 
 from urllib.parse import urlparse
-import ipaddress
 import socket
 import sys
 import time
@@ -1031,30 +1030,25 @@ class Resolver(object):
             self.cache.put((_qname, rdtype, rdclass), answer)
         return answer
 
-    def reverse_lookup(self, ipaddr):
+    def reverse_lookup(self, ipaddr, tcp=False, source=None, 
+                       raise_on_no_answer=True, source_port=0,
+                       lifetime=None):
         """Use a resolver to run a Reverse IP Lookup for PTR records.
         
         This utilizes the in-built query function to perform a PTR lookup and 
         tests to make sure that the entered string is in fact an IP address.
         
-        This utilizes the in-built ipaddress library for Python to validate that
-        the address is an IPv4 or IPv6 address, and errors if the specified 
-        value is not a valid IPv4 or IPv6 address. It also uses the same library
-        to get the in-addr.arpa string to query to get the PTR record.
-        
         *ipaddr*, a ``str``, the IP address you want to get the PTR record for.
         """
-        try:
-            ip = ipaddress.IPv4Address(ipaddr)
-        except ipaddress.AddressValueError:
-            try:
-                ip = ipaddress.IPv6Address(ipaddr)
-            except ipaddress.AddressValueError:
-                raise ipaddress.AddressValueError("The specified string does not "
-                                                  "appear to be any known type of"
-                                                  "IP Address.")
                 
-        return self.query(ip.reverse_pointer, dns.rdatatype.PTR)
+        return self.query(dns.reversename.from_address(address), 
+                          rdtype=dns.rdatatype.PTR,
+                          rdclass=dns.rdataclass.IN,
+                          tcp=tcp,
+                          source=source,
+                          raise_on_no_answer=raise_on_no_answer,
+                          source_port=source_port,
+                          lifetime=lifetime)
 
     def use_tsig(self, keyring, keyname=None,
                  algorithm=dns.tsig.default_algorithm):

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1039,6 +1039,18 @@ class Resolver(object):
         tests to make sure that the entered string is in fact an IP address.
         
         *ipaddr*, a ``str``, the IP address you want to get the PTR record for.
+        
+        *tcp*, a ``bool``.  If ``True``, use TCP to make the query.
+        
+        *source*, a ``text`` or ``None``.  If not ``None``, bind to this IP
+        address when making queries.
+        
+        *raise_on_no_answer*, a ``bool``.  If ``True``, raise
+        ``dns.resolver.NoAnswer`` if there's no answer to the question.
+        
+        *source_port*, an ``int``, the port from which to send the message.
+        
+        *lifetime*, a ``float``, how many seconds a query should run before timing out.
         """
                 
         return self.query(dns.reversename.from_address(address), 


### PR DESCRIPTION
Utilize the inbuilt ipaddress library and in-built resolver query libraries to provide a reverse_lookup function.  This could make it easier for users to set up their own Resolver instances which continue to behave as stub resolvers but also more easily make PTR record lookups, which would be able to be used as a direct result.

This had been written by me as part of an extension of the Resolver class in my own private class (called DNSResolver, which I only use internally on a few private applications) which extended the init file to define the nameservers if not specified (default: google DNS) and then extended to add the reverse_lookup function call as well.

Feel free to reject if it doesn't make sense, but it would be a nifty function to have (because `dig` for instance has a `-x` flag you can pass which accepts an IP address and will auto-reverse it to get the in-addr.arpa lookup result from nameservers, whether they're stub resolvers or not, which is a nifty function to have here.)