### PR TITLE
reverse_query: BUGFIX - ipaddr, not address!

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1042,7 +1042,7 @@ class Resolver(object):
         rdtype and rdclass are also supported by this function.
         """
                 
-        return self.query(dns.reversename.from_address(address), 
+        return self.query(dns.reversename.from_address(ipaddr), 
                           rdtype=dns.rdatatype.PTR,
                           rdclass=dns.rdataclass.IN,
                           *args, **kwargs)


### PR DESCRIPTION
I made a **code breaking** mistake in the pull req and didn't catch it (OOPS!).

`dns.reversename.from_address(address)` is what was in the code block introduced by #418.  Unfortunately, that causes a nice, fat `NameError: name 'address' is not defined` error.  This fixes that.