### PR TITLE
Use PyCryptodome for ECDSA.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ branches:
   except:
     - python3
 install:
- - pip install typing pylint pycryptodome ecdsa idna requests requests-toolbelt
+ - pip install typing pylint pycryptodome idna requests requests-toolbelt
 script:
  - make test

--- a/dns/dnssec.pyi
+++ b/dns/dnssec.pyi
@@ -3,7 +3,6 @@ from . import rdataset, rrset, exception, name, rdtypes, rdata, node
 import dns.rdtypes.ANY.DS as DS
 import dns.rdtypes.ANY.DNSKEY as DNSKEY
 
-_have_ecdsa : bool
 _have_pycrypto : bool
 
 def validate_rrsig(rrset : Union[Tuple[name.Name, rdataset.Rdataset], rrset.RRset], rrsig : rdata.Rdata, keys : Dict[name.Name, Union[node.Node, rdataset.Rdataset]], origin : Optional[name.Name] = None, now : Optional[int] = None) -> None:

--- a/doc/dnssec.rst
+++ b/doc/dnssec.rst
@@ -6,8 +6,7 @@ DNSSEC
 
 Dnspython can do simple DNSSEC signature validation, but currently has no
 facilities for signing.  In order to use DNSSEC functions, you must have
-``pycryptodome`` or ``pycryptodomex`` installed.  If you want to do elliptic
-curves, you must also have ``ecdsa`` installed.
+``pycryptodome`` or ``pycryptodomex`` installed.
 
 DNSSEC Functions
 ----------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -46,9 +46,6 @@ Optional Modules
 The following modules are optional, but recommended for full functionality.
 
 If ``pycryptodome`` / ``pycryptodomex`` is installed, then dnspython will be
-able to do low-level DNSSEC RSA and DSA signature validation.
-
-If ``ecdsa`` is installed, then Elliptic Curve signature algorithms will
-be available for low-level DNSSEC signature validation.
+able to do low-level DNSSEC RSA, DSA, and ECDSA signature validation.
 
 If ``idna`` is installed, then IDNA 2008 will be available.

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ direct manipulation of DNS zones, messages, names, and records.""",
     'tests_require': ['typing ; python_version<"3.5"'],
     'extras_require': {
         'IDNA': ['idna>=2.1'],
-        'DNSSEC': ['pycryptodome', 'ecdsa>=0.13'],
+        'DNSSEC': ['pycryptodome>=3.4'],
         },
     'ext_modules': ext_modules if compile_cython else None,
     'zip_safe': False if compile_cython else None,

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -186,28 +186,20 @@ class DNSSECValidatorTestCase(unittest.TestCase):
                                 abs_dsa_keys, None, when2)
         self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
-    @unittest.skipUnless(dns.dnssec._have_ecdsa,
-                         "python ECDSA cannot be imported")
     def testAbsoluteECDSA256Good(self):  # type: () -> None
         dns.dnssec.validate(abs_ecdsa256_soa, abs_ecdsa256_soa_rrsig,
                             abs_ecdsa256_keys, None, when3)
 
-    @unittest.skipUnless(dns.dnssec._have_ecdsa,
-                         "python ECDSA cannot be imported")
     def testAbsoluteECDSA256Bad(self):  # type: () -> None
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_ecdsa256_soa, abs_ecdsa256_soa_rrsig,
                                 abs_ecdsa256_keys, None, when3)
         self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
-    @unittest.skipUnless(dns.dnssec._have_ecdsa,
-                         "python ECDSA cannot be imported")
     def testAbsoluteECDSA384Good(self):  # type: () -> None
         dns.dnssec.validate(abs_ecdsa384_soa, abs_ecdsa384_soa_rrsig,
                             abs_ecdsa384_keys, None, when4)
 
-    @unittest.skipUnless(dns.dnssec._have_ecdsa,
-                         "python ECDSA cannot be imported")
     def testAbsoluteECDSA384Bad(self):  # type: () -> None
         def bad():  # type: () -> None
             dns.dnssec.validate(abs_other_ecdsa384_soa, abs_ecdsa384_soa_rrsig,


### PR DESCRIPTION
PyCryptodome has supported ECDSA for about 4 years, so we don't need to use a separate module for it.