### PR TITLE
Set _have_ecpy=False if pycryptodome isn't found.

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -538,6 +538,7 @@ except ImportError:
     validate = _need_pycrypto
     validate_rrsig = _need_pycrypto
     _have_pycrypto = False
+    _have_ecpy = False
 else:
     validate = _validate
     validate_rrsig = _validate_rrsig


### PR DESCRIPTION
The tests would fail if neither pycryptodome nor ecpy were installed, as the the variable used to check for ecpy wasn't being set properly in that case.