### PR TITLE
Remove choose_relativity() from zone.from_xfr()

### DIFF
--- a/dns/zone.py
+++ b/dns/zone.py
@@ -1117,7 +1117,6 @@ def from_xfr(xfr, zone_factory=Zone, relativize=True, check_origin=True):
                                        rrset.covers, True)
             zrds.update_ttl(rrset.ttl)
             for rd in rrset:
-                rd.choose_relativity(z.origin, relativize)
                 zrds.add(rd)
     if check_origin:
         z.check_origin()


### PR DESCRIPTION
The comment states that relativize must be consistent between
dns.query.xfr() and dns.zone.from_xfr(), and the code fails if they're
not (if check_origin is True, at least).  This means that the rdata is
already correctly relativized (or not).

This also adds a test of creating zones from xfrs, both relativized and
not.