### PR TITLE
Add relativize_to to from_text().

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -245,7 +245,8 @@ class Rdata(object):
         return hash(self.to_digestable(dns.name.root))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         raise NotImplementedError
 
     @classmethod
@@ -275,7 +276,8 @@ class GenericRdata(Rdata):
         return r'\# %d ' % len(self.data) + _hexify(self.data)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         token = tok.get()
         if not token.is_identifier() or token.value != r'\#':
             raise dns.exception.SyntaxError(
@@ -340,7 +342,8 @@ def get_rdata_class(rdclass, rdtype):
     return cls
 
 
-def from_text(rdclass, rdtype, tok, origin=None, relativize=True):
+def from_text(rdclass, rdtype, tok, origin=None, relativize=True,
+              relativize_to=None):
     """Build an rdata object from text format.
 
     This function attempts to dynamically load a class which
@@ -363,8 +366,10 @@ def from_text(rdclass, rdtype, tok, origin=None, relativize=True):
     *origin*, a ``dns.name.Name`` (or ``None``), the
     origin to use for relative names.
 
-    *relativize*, a ``bool``.  If true, name will be relativized to
-    the specified origin.
+    *relativize*, a ``bool``.  If true, name will be relativized.
+
+    *relativize_to*, a ``dns.name.Name`` (or ``None``), the origin to use
+    when relativizing names.  If not set, the *origin* value will be used.
 
     Returns an instance of the chosen Rdata subclass.
     """
@@ -384,10 +389,11 @@ def from_text(rdclass, rdtype, tok, origin=None, relativize=True):
             # from_wire on it.
             #
             rdata = GenericRdata.from_text(rdclass, rdtype, tok, origin,
-                                           relativize)
+                                           relativize, relativize_to)
             return from_wire(rdclass, rdtype, rdata.data, 0, len(rdata.data),
                              origin)
-    return cls.from_text(rdclass, rdtype, tok, origin, relativize)
+    return cls.from_text(rdclass, rdtype, tok, origin, relativize,
+                         relativize_to)
 
 
 def from_wire(rdclass, rdtype, wire, current, rdlen, origin=None):

--- a/dns/rdata.pyi
+++ b/dns/rdata.pyi
@@ -10,7 +10,7 @@ class Rdata:
         ...
 _rdata_modules : Dict[Tuple[Any,Rdata],Any]
 
-def from_text(rdclass : int, rdtype : int, tok : Optional[str], origin : Optional[Name] = None, relativize : bool = True):
+def from_text(rdclass : int, rdtype : int, tok : Optional[str], origin : Optional[Name] = None, relativize : bool = True, relativize_to : Optional[Name] = None):
     ...
 
 def from_wire(rdclass : int, rdtype : int, wire : bytes, current : int, rdlen : int, origin : Optional[Name] = None):

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -48,7 +48,8 @@ class CAA(dns.rdata.Rdata):
                                dns.rdata._escapify(self.value))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         flags = tok.get_uint8()
         tag = tok.get_string().encode()
         if len(tag) > 255:

--- a/dns/rdtypes/ANY/CERT.py
+++ b/dns/rdtypes/ANY/CERT.py
@@ -85,7 +85,8 @@ class CERT(dns.rdata.Rdata):
                                 dns.rdata._base64ify(self.certificate))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         certificate_type = _ctype_from_text(tok.get_string())
         key_tag = tok.get_uint16()
         algorithm = dns.dnssec.algorithm_from_text(tok.get_string())

--- a/dns/rdtypes/ANY/CSYNC.py
+++ b/dns/rdtypes/ANY/CSYNC.py
@@ -54,7 +54,8 @@ class CSYNC(dns.rdata.Rdata):
         return '%d %d%s' % (self.serial, self.flags, text)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         serial = tok.get_uint32()
         flags = tok.get_uint16()
         rdtypes = []

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -83,7 +83,8 @@ class GPOS(dns.rdata.Rdata):
                              self.altitude.decode())
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         latitude = tok.get_string()
         longitude = tok.get_string()
         altitude = tok.get_string()

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -50,7 +50,8 @@ class HINFO(dns.rdata.Rdata):
                                   dns.rdata._escapify(self.os))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         cpu = tok.get_string()
         os = tok.get_string()
         tok.get_eol()

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -59,7 +59,8 @@ class HIP(dns.rdata.Rdata):
         return '%u %s %s%s' % (self.algorithm, hit, key, text)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         algorithm = tok.get_uint8()
         hit = binascii.unhexlify(tok.get_string().encode())
         if len(hit) > 255:

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -53,7 +53,8 @@ class ISDN(dns.rdata.Rdata):
             return '"%s"' % dns.rdata._escapify(self.address)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_string()
         t = tok.get()
         if not t.is_eol_or_eof():

--- a/dns/rdtypes/ANY/LOC.py
+++ b/dns/rdtypes/ANY/LOC.py
@@ -164,7 +164,8 @@ class LOC(dns.rdata.Rdata):
         return text
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         latitude = [0, 0, 0, 0, 1]
         longitude = [0, 0, 0, 0, 1]
         size = _default_size

--- a/dns/rdtypes/ANY/NSEC.py
+++ b/dns/rdtypes/ANY/NSEC.py
@@ -53,9 +53,9 @@ class NSEC(dns.rdata.Rdata):
         return '{}{}'.format(next, text)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
-        next = tok.get_name()
-        next = next.choose_relativity(origin, relativize)
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        next = tok.get_name(origin, relativize, relativize_to)
         rdtypes = []
         while 1:
             token = tok.get().unescape()

--- a/dns/rdtypes/ANY/NSEC3.py
+++ b/dns/rdtypes/ANY/NSEC3.py
@@ -88,7 +88,8 @@ class NSEC3(dns.rdata.Rdata):
                                      self.iterations, salt, next, text)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         algorithm = tok.get_uint8()
         flags = tok.get_uint8()
         iterations = tok.get_uint16()

--- a/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -56,7 +56,8 @@ class NSEC3PARAM(dns.rdata.Rdata):
                                 salt)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         algorithm = tok.get_uint8()
         flags = tok.get_uint8()
         iterations = tok.get_uint16()

--- a/dns/rdtypes/ANY/OPENPGPKEY.py
+++ b/dns/rdtypes/ANY/OPENPGPKEY.py
@@ -38,7 +38,8 @@ class OPENPGPKEY(dns.rdata.Rdata):
         return dns.rdata._base64ify(self.key)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         chunks = []
         while 1:
             t = tok.get().unescape()

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -44,11 +44,10 @@ class RP(dns.rdata.Rdata):
         return "{} {}".format(str(mbox), str(txt))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
-        mbox = tok.get_name()
-        txt = tok.get_name()
-        mbox = mbox.choose_relativity(origin, relativize)
-        txt = txt.choose_relativity(origin, relativize)
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        mbox = tok.get_name(origin, relativize, relativize_to)
+        txt = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, mbox, txt)
 

--- a/dns/rdtypes/ANY/RRSIG.py
+++ b/dns/rdtypes/ANY/RRSIG.py
@@ -108,7 +108,8 @@ class RRSIG(dns.rdata.Rdata):
         )
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         type_covered = dns.rdatatype.from_text(tok.get_string())
         algorithm = dns.dnssec.algorithm_from_text(tok.get_string())
         labels = tok.get_int()
@@ -116,8 +117,7 @@ class RRSIG(dns.rdata.Rdata):
         expiration = sigtime_to_posixtime(tok.get_string())
         inception = sigtime_to_posixtime(tok.get_string())
         key_tag = tok.get_int()
-        signer = tok.get_name()
-        signer = signer.choose_relativity(origin, relativize)
+        signer = tok.get_name(origin, relativize, relativize_to)
         chunks = []
         while 1:
             t = tok.get().unescape()

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -65,11 +65,10 @@ class SOA(dns.rdata.Rdata):
             self.expire, self.minimum)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
-        mname = tok.get_name()
-        rname = tok.get_name()
-        mname = mname.choose_relativity(origin, relativize)
-        rname = rname.choose_relativity(origin, relativize)
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        mname = tok.get_name(origin, relativize, relativize_to)
+        rname = tok.get_name(origin, relativize, relativize_to)
         serial = tok.get_uint32()
         refresh = tok.get_ttl()
         retry = tok.get_ttl()

--- a/dns/rdtypes/ANY/SSHFP.py
+++ b/dns/rdtypes/ANY/SSHFP.py
@@ -50,7 +50,8 @@ class SSHFP(dns.rdata.Rdata):
                                                chunksize=128))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         algorithm = tok.get_uint8()
         fp_type = tok.get_uint8()
         chunks = []

--- a/dns/rdtypes/ANY/TLSA.py
+++ b/dns/rdtypes/ANY/TLSA.py
@@ -54,7 +54,8 @@ class TLSA(dns.rdata.Rdata):
                                                   chunksize=128))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         usage = tok.get_uint8()
         selector = tok.get_uint8()
         mtype = tok.get_uint8()

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -53,7 +53,8 @@ class URI(dns.rdata.Rdata):
                                self.target.decode())
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         priority = tok.get_uint16()
         weight = tok.get_uint16()
         target = tok.get().unescape()

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -43,7 +43,8 @@ class X25(dns.rdata.Rdata):
         return '"%s"' % dns.rdata._escapify(self.address)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_string()
         tok.get_eol()
         return cls(rdclass, rdtype, address)

--- a/dns/rdtypes/CH/A.py
+++ b/dns/rdtypes/CH/A.py
@@ -38,10 +38,10 @@ class A(dns.rdtypes.mxbase.MXBase):
         return '%s %o' % (domain, self.address)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
-        domain = tok.get_name()
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        domain = tok.get_name(origin, relativize, relativize_to)
         address = tok.get_uint16(base=8)
-        domain = domain.choose_relativity(origin, relativize)
         tok.get_eol()
         return cls(rdclass, rdtype, address, domain)
 

--- a/dns/rdtypes/IN/A.py
+++ b/dns/rdtypes/IN/A.py
@@ -40,7 +40,8 @@ class A(dns.rdata.Rdata):
         return self.address
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_identifier()
         tok.get_eol()
         return cls(rdclass, rdtype, address)

--- a/dns/rdtypes/IN/AAAA.py
+++ b/dns/rdtypes/IN/AAAA.py
@@ -40,7 +40,8 @@ class AAAA(dns.rdata.Rdata):
         return self.address
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_identifier()
         tok.get_eol()
         return cls(rdclass, rdtype, address)

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -95,7 +95,8 @@ class APL(dns.rdata.Rdata):
         return ' '.join(map(str, self.items))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         items = []
         while 1:
             token = tok.get().unescape()

--- a/dns/rdtypes/IN/DHCID.py
+++ b/dns/rdtypes/IN/DHCID.py
@@ -39,7 +39,8 @@ class DHCID(dns.rdata.Rdata):
         return dns.rdata._base64ify(self.data)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         chunks = []
         while 1:
             t = tok.get().unescape()

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -81,12 +81,13 @@ class IPSECKEY(dns.rdata.Rdata):
                                    dns.rdata._base64ify(self.key))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         precedence = tok.get_uint8()
         gateway_type = tok.get_uint8()
         algorithm = tok.get_uint8()
         if gateway_type == 3:
-            gateway = tok.get_name().choose_relativity(origin, relativize)
+            gateway = tok.get_name(origin, relativize, relativize_to)
         else:
             gateway = tok.get_string()
         chunks = []

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -76,14 +76,14 @@ class NAPTR(dns.rdata.Rdata):
                 replacement)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         order = tok.get_uint16()
         preference = tok.get_uint16()
         flags = tok.get_string()
         service = tok.get_string()
         regexp = tok.get_string()
-        replacement = tok.get_name()
-        replacement = replacement.choose_relativity(origin, relativize)
+        replacement = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, order, preference, flags, service,
                    regexp, replacement)

--- a/dns/rdtypes/IN/NSAP.py
+++ b/dns/rdtypes/IN/NSAP.py
@@ -40,7 +40,8 @@ class NSAP(dns.rdata.Rdata):
         return "0x%s" % binascii.hexlify(self.address).decode()
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_string()
         tok.get_eol()
         if address[0:2] != '0x':

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -48,12 +48,11 @@ class PX(dns.rdata.Rdata):
         return '%d %s %s' % (self.preference, map822, mapx400)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         preference = tok.get_uint16()
-        map822 = tok.get_name()
-        map822 = map822.choose_relativity(origin, relativize)
-        mapx400 = tok.get_name(None)
-        mapx400 = mapx400.choose_relativity(origin, relativize)
+        map822 = tok.get_name(origin, relativize, relativize_to)
+        mapx400 = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, preference, map822, mapx400)
 

--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -51,12 +51,12 @@ class SRV(dns.rdata.Rdata):
                                 target)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         priority = tok.get_uint16()
         weight = tok.get_uint16()
         port = tok.get_uint16()
-        target = tok.get_name(None)
-        target = target.choose_relativity(origin, relativize)
+        target = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, priority, weight, port, target)
 

--- a/dns/rdtypes/IN/WKS.py
+++ b/dns/rdtypes/IN/WKS.py
@@ -59,7 +59,8 @@ class WKS(dns.rdata.Rdata):
         return '%s %d %s' % (self.address, self.protocol, text)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         address = tok.get_string()
         protocol = tok.get_string()
         if protocol.isdigit():

--- a/dns/rdtypes/dnskeybase.py
+++ b/dns/rdtypes/dnskeybase.py
@@ -100,7 +100,8 @@ class DNSKEYBase(dns.rdata.Rdata):
                                 dns.rdata._base64ify(self.key))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         flags = tok.get_uint16()
         protocol = tok.get_uint8()
         algorithm = dns.dnssec.algorithm_from_text(tok.get_string())

--- a/dns/rdtypes/dnskeybase.pyi
+++ b/dns/rdtypes/dnskeybase.pyi
@@ -23,7 +23,8 @@ class DNSKEYBase(rdata.Rdata):
         ...
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         ...
 
     def to_wire(self, file, compress=None, origin=None):

--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -53,7 +53,8 @@ class DSBase(dns.rdata.Rdata):
                                                   chunksize=128))
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         key_tag = tok.get_uint16()
         algorithm = tok.get_uint8()
         digest_type = tok.get_uint8()

--- a/dns/rdtypes/euibase.py
+++ b/dns/rdtypes/euibase.py
@@ -43,7 +43,8 @@ class EUIBase(dns.rdata.Rdata):
         return dns.rdata._hexify(self.eui, chunksize=2).replace(' ', '-')
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         text = tok.get_string()
         tok.get_eol()
         if len(text) != cls.text_len:

--- a/dns/rdtypes/mxbase.py
+++ b/dns/rdtypes/mxbase.py
@@ -46,10 +46,10 @@ class MXBase(dns.rdata.Rdata):
         return '%d %s' % (self.preference, exchange)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         preference = tok.get_uint16()
-        exchange = tok.get_name()
-        exchange = exchange.choose_relativity(origin, relativize)
+        exchange = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, preference, exchange)
 

--- a/dns/rdtypes/nsbase.py
+++ b/dns/rdtypes/nsbase.py
@@ -42,9 +42,9 @@ class NSBase(dns.rdata.Rdata):
         return str(target)
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
-        target = tok.get_name()
-        target = target.choose_relativity(origin, relativize)
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        target = tok.get_name(origin, relativize, relativize_to)
         tok.get_eol()
         return cls(rdclass, rdtype, target)
 

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -54,7 +54,8 @@ class TXTBase(dns.rdata.Rdata):
         return txt
 
     @classmethod
-    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
         strings = []
         while 1:
             token = tok.get().unescape()

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -528,7 +528,7 @@ class Tokenizer(object):
             raise dns.exception.SyntaxError('expecting an identifier')
         return token.value
 
-    def get_name(self, origin=None):
+    def get_name(self, origin=None, relativize=False, relativize_to=None):
         """Read the next token and interpret it as a DNS name.
 
         Raises dns.exception.SyntaxError if not a name.
@@ -539,7 +539,8 @@ class Tokenizer(object):
         token = self.get()
         if not token.is_identifier():
             raise dns.exception.SyntaxError('expecting an identifier')
-        return dns.name.from_text(token.value, origin)
+        name = dns.name.from_text(token.value, origin)
+        return name.choose_relativity(relativize_to or origin, relativize)
 
     def get_eol(self):
         """Read the next token and raise an exception if it isn't EOL or

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -698,7 +698,8 @@ class _MasterReader(object):
             self.zone.nodes[name] = n
         try:
             rd = dns.rdata.from_text(rdclass, rdtype, self.tok,
-                                     self.current_origin, False)
+                                     self.current_origin, self.relativize,
+                                     self.zone.origin)
         except dns.exception.SyntaxError:
             # Catch and reraise.
             (ty, va) = sys.exc_info()[:2]
@@ -730,7 +731,6 @@ class _MasterReader(object):
                 else:
                     ttl = self.last_ttl
 
-        rd.choose_relativity(self.zone.origin, self.relativize)
         covers = rd.covers()
         rds = n.find_rdataset(rdclass, rdtype, covers, True)
         rds.add(rd, ttl)
@@ -879,7 +879,8 @@ class _MasterReader(object):
                 self.zone.nodes[name] = n
             try:
                 rd = dns.rdata.from_text(rdclass, rdtype, rdata,
-                                         self.current_origin, False)
+                                         self.current_origin, self.relativize,
+                                         self.zone.origin)
             except dns.exception.SyntaxError:
                 # Catch and reraise.
                 (ty, va) = sys.exc_info()[:2]
@@ -894,7 +895,6 @@ class _MasterReader(object):
                 raise dns.exception.SyntaxError("caught exception %s: %s" %
                                                 (str(ty), str(va)))
 
-            rd.choose_relativity(self.zone.origin, self.relativize)
             covers = rd.covers()
             rds = n.find_rdataset(rdclass, rdtype, covers, True)
             rds.add(rd, ttl)


### PR DESCRIPTION
When calling from_text, the zone code needs to apply the current origin
(which may or may not be the zone origin, if sub-zone $ORIGIN statements
are present), and may also want to relativize the contents to the zone
origin.

Previously, this was done by explicitly reading records as absolute, and
then relativizing them laster.  With this change, the work is moved to
the tokenizer.

This gets rid of the remaining internal uses of
dns.rdata.choose_relativity(), which prevents rdata from being
immutable.