### PR TITLE
zone.to_text() should return a string.

### DIFF
--- a/dns/zone.py
+++ b/dns/zone.py
@@ -22,7 +22,7 @@ from __future__ import generators
 import sys
 import re
 import os
-from io import BytesIO
+from io import StringIO
 
 import dns.exception
 import dns.name
@@ -553,7 +553,7 @@ class Zone(object):
         LF on POSIX, CRLF on Windows, CR on Macintosh).
         @type nl: string or None
         """
-        temp_buffer = BytesIO()
+        temp_buffer = StringIO()
         self.to_file(temp_buffer, sorted, relativize, nl)
         return_value = temp_buffer.getvalue()
         temp_buffer.close()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -242,8 +242,8 @@ class ZoneTestCase(unittest.TestCase):
         z = dns.zone.from_file(here('example'), 'example')
         ok = False
         try:
-            text_zone = z.to_text(nl=b'\x0a')
-            f = open(here('example3.out'), 'wb')
+            text_zone = z.to_text(nl='\x0a')
+            f = open(here('example3.out'), 'w')
             f.write(text_zone)
             f.close()
             ok = filecmp.cmp(here('example3.out'),


### PR DESCRIPTION
As part of the Python 3 conversion, the result of dns.zone.to_text()
changed from str to bytes.  This was likely unintentional, as a method
with text in its name should be returning text.