### PR TITLE
Remove dns.rdata.choose_relativity().

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -253,11 +253,6 @@ class Rdata(object):
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         raise NotImplementedError
 
-    def choose_relativity(self, origin=None, relativize=True):
-        """Convert any domain names in the rdata to the specified
-        relativization.
-        """
-
 class GenericRdata(Rdata):
 
     """Generic Rdata Class

--- a/dns/rdtypes/ANY/HIP.py
+++ b/dns/rdtypes/ANY/HIP.py
@@ -107,10 +107,3 @@ class HIP(dns.rdata.Rdata):
                 server = server.relativize(origin)
             servers.append(server)
         return cls(rdclass, rdtype, hit, algorithm, key, servers)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        servers = []
-        for server in self.servers:
-            server = server.choose_relativity(origin, relativize)
-            servers.append(server)
-        self.servers = servers

--- a/dns/rdtypes/ANY/NSEC.py
+++ b/dns/rdtypes/ANY/NSEC.py
@@ -121,6 +121,3 @@ class NSEC(dns.rdata.Rdata):
         if origin is not None:
             next = next.relativize(origin)
         return cls(rdclass, rdtype, next, windows)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.next = self.next.choose_relativity(origin, relativize)

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -75,7 +75,3 @@ class RP(dns.rdata.Rdata):
             mbox = mbox.relativize(origin)
             txt = txt.relativize(origin)
         return cls(rdclass, rdtype, mbox, txt)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.mbox = self.mbox.choose_relativity(origin, relativize)
-        self.txt = self.txt.choose_relativity(origin, relativize)

--- a/dns/rdtypes/ANY/RRSIG.py
+++ b/dns/rdtypes/ANY/RRSIG.py
@@ -155,6 +155,3 @@ class RRSIG(dns.rdata.Rdata):
         return cls(rdclass, rdtype, header[0], header[1], header[2],
                    header[3], header[4], header[5], header[6], signer,
                    signature)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.signer = self.signer.choose_relativity(origin, relativize)

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -109,7 +109,3 @@ class SOA(dns.rdata.Rdata):
         return cls(rdclass, rdtype, mname, rname,
                    five_ints[0], five_ints[1], five_ints[2], five_ints[3],
                    five_ints[4])
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.mname = self.mname.choose_relativity(origin, relativize)
-        self.rname = self.rname.choose_relativity(origin, relativize)

--- a/dns/rdtypes/CH/A.py
+++ b/dns/rdtypes/CH/A.py
@@ -65,6 +65,3 @@ class A(dns.rdtypes.mxbase.MXBase):
         if origin is not None:
             domain = domain.relativize(origin)
         return cls(rdclass, rdtype, address, domain)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.domain = self.domain.choose_relativity(origin, relativize)

--- a/dns/rdtypes/IN/IPSECKEY.py
+++ b/dns/rdtypes/IN/IPSECKEY.py
@@ -151,7 +151,3 @@ class IPSECKEY(dns.rdata.Rdata):
             gateway = gateway.relativize(origin)
         return cls(rdclass, rdtype, header[0], gateway_type, header[2],
                    gateway, key)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        if self.gateway_type == 3:
-            self.gateway = self.gateway.choose_relativity(origin, relativize)

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -120,7 +120,3 @@ class NAPTR(dns.rdata.Rdata):
             replacement = replacement.relativize(origin)
         return cls(rdclass, rdtype, order, preference, strings[0], strings[1],
                    strings[2], replacement)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.replacement = self.replacement.choose_relativity(origin,
-                                                              relativize)

--- a/dns/rdtypes/IN/PX.py
+++ b/dns/rdtypes/IN/PX.py
@@ -82,7 +82,3 @@ class PX(dns.rdata.Rdata):
         if origin is not None:
             mapx400 = mapx400.relativize(origin)
         return cls(rdclass, rdtype, preference, map822, mapx400)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.map822 = self.map822.choose_relativity(origin, relativize)
-        self.mapx400 = self.mapx400.choose_relativity(origin, relativize)

--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -78,6 +78,3 @@ class SRV(dns.rdata.Rdata):
         if origin is not None:
             target = target.relativize(origin)
         return cls(rdclass, rdtype, priority, weight, port, target)
-
-    def choose_relativity(self, origin=None, relativize=True):
-        self.target = self.target.choose_relativity(origin, relativize)

--- a/dns/rdtypes/mxbase.py
+++ b/dns/rdtypes/mxbase.py
@@ -75,9 +75,6 @@ class MXBase(dns.rdata.Rdata):
             exchange = exchange.relativize(origin)
         return cls(rdclass, rdtype, preference, exchange)
 
-    def choose_relativity(self, origin=None, relativize=True):
-        self.exchange = self.exchange.choose_relativity(origin, relativize)
-
 
 class UncompressedMX(MXBase):
 

--- a/dns/rdtypes/nsbase.py
+++ b/dns/rdtypes/nsbase.py
@@ -64,9 +64,6 @@ class NSBase(dns.rdata.Rdata):
             target = target.relativize(origin)
         return cls(rdclass, rdtype, target)
 
-    def choose_relativity(self, origin=None, relativize=True):
-        self.target = self.target.choose_relativity(origin, relativize)
-
 
 class UncompressedNS(NSBase):
 


### PR DESCRIPTION
This method changes rdata in place, so prevents rdata from becoming
immutable.  There are no in-tree users, and if there are out of tree
users, they are rate and hard to find.