### PR TITLE
Improve rdataset/rrset repr to include rdata.

### DIFF
--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -143,13 +143,22 @@ class Rdataset(dns.set.Set):
         self.update_ttl(other.ttl)
         super(Rdataset, self).update(other)
 
+    def _rdata_repr(self):
+        def maybe_truncate(s):
+            if len(s) > 100:
+                return s[:100] + '...'
+            return s
+        return '[%s]' % ', '.join('<%s>' % maybe_truncate(str(rr))
+                                  for rr in self)
+
     def __repr__(self):
         if self.covers == 0:
             ctext = ''
         else:
             ctext = '(' + dns.rdatatype.to_text(self.covers) + ')'
         return '<DNS ' + dns.rdataclass.to_text(self.rdclass) + ' ' + \
-               dns.rdatatype.to_text(self.rdtype) + ctext + ' rdataset>'
+               dns.rdatatype.to_text(self.rdtype) + ctext + \
+               ' rdataset: ' + self._rdata_repr() + '>'
 
     def __str__(self):
         return self.to_text()

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -62,7 +62,8 @@ class RRset(dns.rdataset.Rdataset):
             dtext = ''
         return '<DNS ' + str(self.name) + ' ' + \
                dns.rdataclass.to_text(self.rdclass) + ' ' + \
-               dns.rdatatype.to_text(self.rdtype) + ctext + dtext + ' RRset>'
+               dns.rdatatype.to_text(self.rdtype) + ctext + dtext + \
+               ' RRset: ' + self._rdata_repr() + '>'
 
     def __str__(self):
         return self.to_text()


### PR DESCRIPTION
Previously, repr() of rdataset/rrset looked like this:
<DNS IN A rdataset>
<DNS IN TXT rdataset>
<DNS IN RRSIG rdataset>

<DNS example. IN A RRset>
<DNS example. IN TXT RRset>
<DNS example. IN RRSIG(NSEC) RRset>

With this patch, it they look like:
<DNS IN A rdataset: [<1.2.3.4>, <5.6.7.8>]>
<DNS IN TXT rdataset: [<"foo" "bar">, <"baz">]>
<DNS IN RRSIG(NSEC) rdataset: [<NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWC...>]>

<DNS example. IN A RRset: [<1.2.3.4>, <5.6.7.8>]>
<DNS example. IN TXT RRset: [<"foo" "bar">, <"baz">]>
<DNS example. IN RRSIG(NSEC) RRset: [<NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWC...>]>

Note that each rdata is truncated to 100 characters.