### PR TITLE
Compare two domain name for their canonical order

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -565,7 +565,7 @@ def compare_canonical_order(name1, name2):
     """
     This method compares two domain names for their canonical order
     as described in: https://tools.ietf.org/html/rfc4034#section-6.1.
-    It can be used to implement NSEC validation.
+    It can be used to check whether an NSEC record covers a domain name.
 
     returns 0 if both are equal
     returns -1 if name1 < name2

--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -561,6 +561,45 @@ def nsec3_hash(domain, salt, iterations, algo):
     return output
 
 
+def compare_canonical_order(name1, name2):
+    """
+    This method compares two domain names for their canonical order
+    as described in: https://tools.ietf.org/html/rfc4034#section-6.1.
+    It can be used to implement NSEC validation.
+
+    returns 0 if both are equal
+    returns -1 if name1 < name2
+    returns 1 if name1 > name2
+
+    :param name1:
+    :type name1: dns.name.Name
+    :param name2:
+    :type name2: dns.name.Name
+    """
+    lower = bytes.maketrans(
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ", b"abcdefghijklmnopqrstuvwxyz"
+    )
+
+    l = min(len(name1), len(name2))
+    d_n1 = len(name1) - l
+    d_n2 = len(name2) - l
+
+    for i in range(l - 1, -1, -1):
+        n1 = bytes(name1[i + d_n1]).translate(lower)
+        n2 = bytes(name2[i + d_n2]).translate(lower)
+        if n1 < n2:
+            return -1
+        elif n1 > n2:
+            return 1
+
+    if len(name1) > len(name2):
+        return 1
+    elif len(name1) < len(name2):
+        return -1
+
+    return 0
+
+
 def _need_pycrypto(*args, **kwargs):
     raise ImportError("DNSSEC validation requires pycryptodome/pycryptodomex")
 

--- a/dns/dnssec.pyi
+++ b/dns/dnssec.pyi
@@ -2,6 +2,7 @@ from typing import Union, Dict, Tuple, Optional
 from . import rdataset, rrset, exception, name, rdtypes, rdata, node
 import dns.rdtypes.ANY.DS as DS
 import dns.rdtypes.ANY.DNSKEY as DNSKEY
+import dns.name
 
 _have_pycrypto : bool
 
@@ -18,4 +19,7 @@ def make_ds(name : name.Name, key : DNSKEY.DNSKEY, algorithm : str, origin : Opt
     ...
 
 def nsec3_hash(domain: str, salt: Optional[str, bytes], iterations: int, algo: int) -> str:
+    ...
+
+def compare_canonical_order(name1: dns.name.Name, name2: dns.name.Name) -> int:
     ...

--- a/tests/test_nsec_canonical_order.py
+++ b/tests/test_nsec_canonical_order.py
@@ -1,0 +1,47 @@
+import unittest
+
+from random import randint
+import dns.name
+import dns.dnssec
+
+
+class NSECCanonicalOrder(unittest.TestCase):
+    # Source: https://tools.ietf.org/html/rfc4034#section-6.1
+    DATA = (
+        dns.name.from_text(b"example"),
+        dns.name.from_text(b"a.example"),
+        dns.name.from_text(b"yljkjljk.a.example"),
+        dns.name.from_text(b"Z.a.example"),
+        dns.name.from_text(b"zABC.a.EXAMPLE"),
+        dns.name.from_text(b"z.example"),
+        dns.name.from_text(b"\001.z.example"),
+        dns.name.from_text(b"*.z.example"),
+        dns.name.from_text(b"\200.z.example"),
+    )
+
+    TEST_ORDER = [
+        (0, 1, -1),
+        (5, 6, -1),
+        (4, 5, -1),
+        (1, 1, 0),
+        (8, 8, 0),
+        (5, 4, 1),
+        (8, 3, 1),
+        (7, 6, 1),
+    ]
+
+    def test_order_function(self):
+        for test_order in self.TEST_ORDER:
+            order = dns.dnssec.compare_canonical_order(
+                self.DATA[test_order[0]], self.DATA[test_order[1]]
+            )
+            self.assertEqual(test_order[2], order, test_order)
+
+    def test_order_function_random(self):
+        for _ in range(1000):
+            i = randint(0, len(self.DATA) - 1)
+            j = randint(0, len(self.DATA) - 1)
+
+            result = (i > j) - (i < j)
+            order = dns.dnssec.compare_canonical_order(self.DATA[i], self.DATA[j])
+            self.assertEqual(result, order, f"{i}, {j}")


### PR DESCRIPTION
I wrote a function for my [DNSSEC Scanner](https://github.com/fabian-hk/dnssec_scanner) project to compare two domain names in the canonical order defined in [RFC 4034](https://tools.ietf.org/html/rfc4034#section-6.1). I thought you are maybe interested since dnspython already contains a few basic DNSSEC operations. This PR already contains tests for the function ;)