### PR TITLE
Use python cryptography for DNSSEC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ branches:
   except:
     - python3
 install:
- - pip install typing pylint pycryptodome ecpy idna requests requests-toolbelt
+ - pip install typing pylint cryptography idna requests requests-toolbelt
 script:
  - make test

--- a/dns/dnssec.pyi
+++ b/dns/dnssec.pyi
@@ -3,8 +3,7 @@ from . import rdataset, rrset, exception, name, rdtypes, rdata, node
 import dns.rdtypes.ANY.DS as DS
 import dns.rdtypes.ANY.DNSKEY as DNSKEY
 
-_have_pycrypto : bool
-_have_ecpy : bool
+_have_pyca : bool
 
 def validate_rrsig(rrset : Union[Tuple[name.Name, rdataset.Rdataset], rrset.RRset], rrsig : rdata.Rdata, keys : Dict[name.Name, Union[node.Node, rdataset.Rdataset]], origin : Optional[name.Name] = None, now : Optional[int] = None) -> None:
     ...

--- a/doc/dnssec.rst
+++ b/doc/dnssec.rst
@@ -6,9 +6,7 @@ DNSSEC
 
 Dnspython can do simple DNSSEC signature validation, but currently has no
 facilities for signing.  In order to use DNSSEC functions, you must have
-``pycryptodome`` or ``pycryptodomex`` installed.  In order to use the EdDSA
-algorithms, you must also be running Python 3.6 or later and have
-``ecpy`` installed.
+``python cryptography`` installed.
 
 DNSSEC Functions
 ----------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -45,10 +45,7 @@ Optional Modules
 
 The following modules are optional, but recommended for full functionality.
 
-If ``pycryptodome`` / ``pycryptodomex`` is installed, then dnspython will be
-able to do low-level DNSSEC RSA, DSA, and ECDSA signature validation.
-
-If using Python 3.6 or later and ``ecpy`` is installed as well, then dnspython
-will be able to do low-level EdDSA signature verification.
+If ``python cryptography`` is installed, then dnspython will be
+able to do low-level DNSSEC RSA, DSA, ECDSA and EdDSA signature validation.
 
 If ``idna`` is installed, then IDNA 2008 will be available.

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ direct manipulation of DNS zones, messages, names, and records.""",
     'tests_require': ['typing ; python_version<"3.5"'],
     'extras_require': {
         'IDNA': ['idna>=2.1'],
-        'DNSSEC': ['pycryptodome>=3.4', 'ecpy'],
+        'DNSSEC': ['cryptography>=2.6'],
         },
     'ext_modules': ext_modules if compile_cython else None,
     'zip_safe': False if compile_cython else None,

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -197,8 +197,8 @@ abs_ed448_mx_rrsig_2 = dns.rrset.from_text('example.com.', 3600, 'IN', 'RRSIG',
 when5 = 1440021600
 
 
-@unittest.skipUnless(dns.dnssec._have_pycrypto,
-                     "Pycryptodome cannot be imported")
+@unittest.skipUnless(dns.dnssec._have_pyca,
+                     "Python Cryptography cannot be imported")
 class DNSSECValidatorTestCase(unittest.TestCase):
 
     def testAbsoluteRSAGood(self):  # type: () -> None
@@ -253,20 +253,12 @@ class DNSSECValidatorTestCase(unittest.TestCase):
                                 abs_ecdsa384_keys, None, when4)
         self.assertRaises(dns.dnssec.ValidationFailure, bad)
 
-    @unittest.skipUnless(dns.dnssec._have_ecpy,
-                         "python EDDSA cannot be imported")
-    @unittest.skipUnless(sys.version_info >= (3, 6),
-                         "Python 3.6 or later is needed")
     def testAbsoluteED25519Good(self):  # type: () -> None
         dns.dnssec.validate(abs_ed25519_mx, abs_ed25519_mx_rrsig_1,
                             abs_ed25519_keys_1, None, when5)
         dns.dnssec.validate(abs_ed25519_mx, abs_ed25519_mx_rrsig_2,
                             abs_ed25519_keys_2, None, when5)
 
-    @unittest.skipUnless(dns.dnssec._have_ecpy,
-                         "python EDDSA cannot be imported")
-    @unittest.skipUnless(sys.version_info >= (3, 6),
-                         "Python 3.6 or later is needed")
     def testAbsoluteED25519Bad(self):  # type: () -> None
         with self.assertRaises(dns.dnssec.ValidationFailure):
             dns.dnssec.validate(abs_other_ed25519_mx, abs_ed25519_mx_rrsig_1,
@@ -275,20 +267,12 @@ class DNSSECValidatorTestCase(unittest.TestCase):
             dns.dnssec.validate(abs_other_ed25519_mx, abs_ed25519_mx_rrsig_2,
                                 abs_ed25519_keys_2, None, when5)
 
-    @unittest.skipUnless(dns.dnssec._have_ecpy,
-                         "python EDDSA cannot be imported")
-    @unittest.skipUnless(sys.version_info >= (3, 6),
-                         "Python 3.6 or later is needed")
     def testAbsoluteED448Good(self):  # type: () -> None
         dns.dnssec.validate(abs_ed448_mx, abs_ed448_mx_rrsig_1,
                             abs_ed448_keys_1, None, when5)
         dns.dnssec.validate(abs_ed448_mx, abs_ed448_mx_rrsig_2,
                             abs_ed448_keys_2, None, when5)
 
-    @unittest.skipUnless(dns.dnssec._have_ecpy,
-                         "python EDDSA cannot be imported")
-    @unittest.skipUnless(sys.version_info >= (3, 6),
-                         "Python 3.6 or later is needed")
     def testAbsoluteED448Bad(self):  # type: () -> None
         with self.assertRaises(dns.dnssec.ValidationFailure):
             dns.dnssec.validate(abs_other_ed448_mx, abs_ed448_mx_rrsig_1,


### PR DESCRIPTION
Replaces the need to use pycryptodome and ecpy with the much better python cryptography.

Python cryptograpy depends on the much more common and vetted openssl library for cryptography functions. This means algorithms are properly hardened against side channel attacks unlike other implementations.

Fixes #448