### PR TITLE
Add dns.rdata.Rdata.to_generic()

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -21,6 +21,7 @@ from importlib import import_module
 from io import BytesIO
 import base64
 import binascii
+import io
 import inspect
 
 import dns.exception
@@ -165,6 +166,15 @@ class Rdata(object):
         """
 
         raise NotImplementedError
+
+    def to_generic(self, origin=None):
+        """Creates a dns.rdata.GenericRdata equivalent of this rdata.
+
+        Returns a ``dns.rdata.GenericRdata``.
+        """
+        f = io.BytesIO()
+        self.to_wire(f, origin=origin)
+        return dns.rdata.GenericRdata(self.rdclass, self.rdtype, f.getvalue())
 
     def to_digestable(self, origin=None):
         """Convert rdata to a format suitable for digesting in hashes.  This

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -64,5 +64,18 @@ class RdataTestCase(unittest.TestCase):
             with self.assertRaises(AttributeError):
                 mx.replace(invalid_parameter=1)
 
+    def test_to_generic(self):
+        a = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
+        self.assertEqual(str(a.to_generic()), r'\# 4 01020304')
+
+        mx = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.MX, "10 foo.")
+        self.assertEqual(str(mx.to_generic()), r'\# 7 000a03666f6f00')
+
+        origin = dns.name.from_text('example')
+        ns = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.NS,
+                                 "foo.example.", relativize_to=origin)
+        self.assertEqual(str(ns.to_generic(origin=origin)),
+                         r'\# 13 03666f6f076578616d706c6500')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a helper method that creates a GenericRdata equivalent of an rdata.

This could be useful when dnspython knows the text format of a type, and some other software doesn't.