### PR TITLE
Add alternate origin support to dns.reversename.

### DIFF
--- a/dns/reversename.py
+++ b/dns/reversename.py
@@ -27,12 +27,21 @@ ipv4_reverse_domain = dns.name.from_text('in-addr.arpa.')
 ipv6_reverse_domain = dns.name.from_text('ip6.arpa.')
 
 
-def from_address(text):
+def from_address(text, v4_origin=ipv4_reverse_domain,
+                 v6_origin=ipv6_reverse_domain):
     """Convert an IPv4 or IPv6 address in textual form into a Name object whose
     value is the reverse-map domain name of the address.
 
     *text*, a ``text``, is an IPv4 or IPv6 address in textual form
     (e.g. '127.0.0.1', '::1')
+
+    *v4_origin*, a ``dns.name.Name`` to append to the labels corresponding to
+    the address if the address is an IPv4 address, instead of the default
+    (in-addr.arpa.)
+
+    *v6_origin*, a ``dns.name.Name`` to append to the labels corresponding to
+    the address if the address is an IPv6 address, instead of the default
+    (ip6.arpa.)
 
     Raises ``dns.exception.SyntaxError`` if the address is badly formed.
 
@@ -43,23 +52,29 @@ def from_address(text):
         v6 = dns.ipv6.inet_aton(text)
         if dns.ipv6.is_mapped(v6):
             parts = ['%d' % byte for byte in v6[12:]]
-            origin = ipv4_reverse_domain
+            origin = v4_origin
         else:
             parts = [x for x in str(binascii.hexlify(v6).decode())]
-            origin = ipv6_reverse_domain
+            origin = v6_origin
     except Exception:
         parts = ['%d' %
                  byte for byte in dns.ipv4.inet_aton(text)]
-        origin = ipv4_reverse_domain
-    parts.reverse()
-    return dns.name.from_text('.'.join(parts), origin=origin)
+        origin = v4_origin
+    return dns.name.from_text('.'.join(reversed(parts)), origin=origin)
 
 
-def to_address(name):
+def to_address(name, v4_origin=ipv4_reverse_domain,
+               v6_origin=ipv6_reverse_domain):
     """Convert a reverse map domain name into textual address form.
 
     *name*, a ``dns.name.Name``, an IPv4 or IPv6 address in reverse-map name
     form.
+
+    *v4_origin*, a ``dns.name.Name`` representing the top-level domain for
+    IPv4 addresses, instead of the default (in-addr.arpa.)
+
+    *v6_origin*, a ``dns.name.Name`` representing the top-level domain for
+    IPv4 addresses, instead of the default (ip6.arpa.)
 
     Raises ``dns.exception.SyntaxError`` if the name does not have a
     reverse-map form.
@@ -67,25 +82,19 @@ def to_address(name):
     Returns a ``text``.
     """
 
-    if name.is_subdomain(ipv4_reverse_domain):
-        name = name.relativize(ipv4_reverse_domain)
-        labels = list(name.labels)
-        labels.reverse()
-        text = b'.'.join(labels)
-        # run through inet_aton() to check syntax and make pretty.
+    if name.is_subdomain(v4_origin):
+        name = name.relativize(v4_origin)
+        text = b'.'.join(reversed(name.labels))
+        # run through inet_ntoa() to check syntax and make pretty.
         return dns.ipv4.inet_ntoa(dns.ipv4.inet_aton(text))
-    elif name.is_subdomain(ipv6_reverse_domain):
-        name = name.relativize(ipv6_reverse_domain)
-        labels = list(name.labels)
-        labels.reverse()
+    elif name.is_subdomain(v6_origin):
+        name = name.relativize(v6_origin)
+        labels = list(reversed(name.labels))
         parts = []
-        i = 0
-        l = len(labels)
-        while i < l:
+        for i in range(0, len(labels), 4):
             parts.append(b''.join(labels[i:i + 4]))
-            i += 4
         text = b':'.join(parts)
-        # run through inet_aton() to check syntax and make pretty.
+        # run through inet_ntoa() to check syntax and make pretty.
         return dns.ipv6.inet_ntoa(dns.ipv6.inet_aton(text))
     else:
         raise dns.exception.SyntaxError('unknown reverse-map address family')

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -804,6 +804,18 @@ class NameTestCase(unittest.TestCase):
             dns.reversename.from_address('::1::1')
         self.assertRaises(dns.exception.SyntaxError, bad)
 
+    def testReverseIPv4AlternateOrigin(self):
+        e = dns.name.from_text('1.0.0.127.foo.bar.')
+        origin = dns.name.from_text('foo.bar')
+        n = dns.reversename.from_address('127.0.0.1', v4_origin=origin)
+        self.assertEqual(e, n)
+
+    def testReverseIPv6AlternateOrigin(self):
+        e = dns.name.from_text('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.foo.bar.')
+        origin = dns.name.from_text('foo.bar')
+        n = dns.reversename.from_address(b'::1', v6_origin=origin)
+        self.assertEqual(e, n)
+
     def testForwardIPv4(self):
         n = dns.name.from_text('1.0.0.127.in-addr.arpa.')
         e = '127.0.0.1'
@@ -814,6 +826,20 @@ class NameTestCase(unittest.TestCase):
         n = dns.name.from_text('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.')
         e = '::1'
         text = dns.reversename.to_address(n)
+        self.assertEqual(text, e)
+
+    def testForwardIPv4AlternateOrigin(self):
+        n = dns.name.from_text('1.0.0.127.foo.bar.')
+        e = '127.0.0.1'
+        origin = dns.name.from_text('foo.bar')
+        text = dns.reversename.to_address(n, v4_origin=origin)
+        self.assertEqual(text, e)
+
+    def testForwardIPv6AlternateOrigin(self):
+        n = dns.name.from_text('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.foo.bar.')
+        e = '::1'
+        origin = dns.name.from_text('foo.bar')
+        text = dns.reversename.to_address(n, v6_origin=origin)
         self.assertEqual(text, e)
 
     def testE164ToEnum(self):


### PR DESCRIPTION
Adds v4_origin and v6_origin to dns.reversename.to_address/from_address.  Also simplifies some code.