### PR TITLE
make dnspython installable with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "2.0.0"
 description = "DNS toolkit"
 authors = ["Bob Halley <halley@dnspython.org>"]
 license = "ISC"
+packages = [
+    {include = "dns"}
+]
 
 [tool.poetry.dependencies]
 python = "^3.5"


### PR DESCRIPTION
I tried installing dnspython from the master branch and it did not work.
The error I got was
```
poetry.masonry.utils.module.ModuleOrPackageNotFound: No file/folder
found for package dnspython
```
Turns out there have been some changes made to pip involving the build
system (see https://www.python.org/dev/peps/pep-0517).
Basically pip is using poetry to install your package.
Poetry has some requirements about how you structure your project (see
https://python-poetry.org/docs/basic-usage/#project-setup and
https://python-poetry.org/docs/pyproject/#packages).
This change allows you to install dnspython without running into that
particular issue.

Note that another possible way to "fix" the installation would be to rename the dns directory to dnspython, but I imagine that would break all kinds of things in the process.