### PR TITLE
WIP: Convert constants to enums

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -41,66 +41,26 @@ class ValidationFailure(dns.exception.DNSException):
     """The DNSSEC signature is invalid."""
 
 
-#: RSAMD5
-RSAMD5 = 1
-#: DH
-DH = 2
-#: DSA
-DSA = 3
-#: ECC
-ECC = 4
-#: RSASHA1
-RSASHA1 = 5
-#: DSANSEC3SHA1
-DSANSEC3SHA1 = 6
-#: RSASHA1NSEC3SHA1
-RSASHA1NSEC3SHA1 = 7
-#: RSASHA256
-RSASHA256 = 8
-#: RSASHA512
-RSASHA512 = 10
-#: ECC-GOST
-ECCGOST = 12
-#: ECDSAP256SHA256
-ECDSAP256SHA256 = 13
-#: ECDSAP384SHA384
-ECDSAP384SHA384 = 14
-#: ED25519
-ED25519 = 15
-#: ED448
-ED448 = 16
-#: INDIRECT
-INDIRECT = 252
-#: PRIVATEDNS
-PRIVATEDNS = 253
-#: PRIVATEOID
-PRIVATEOID = 254
+class Algorithm(enum.IntEnum):
+    RSAMD5 = 1
+    DH = 2
+    DSA = 3
+    ECC = 4
+    RSASHA1 = 5
+    DSANSEC3SHA1 = 6
+    RSASHA1NSEC3SHA1 = 7
+    RSASHA256 = 8
+    RSASHA512 = 10
+    ECCGOST = 12
+    ECDSAP256SHA256 = 13
+    ECDSAP384SHA384 = 14
+    ED25519 = 15
+    ED448 = 16
+    INDIRECT = 252
+    PRIVATEDNS = 253
+    PRIVATEOID = 254
 
-_algorithm_by_text = {
-    'RSAMD5': RSAMD5,
-    'DH': DH,
-    'DSA': DSA,
-    'ECC': ECC,
-    'RSASHA1': RSASHA1,
-    'DSANSEC3SHA1': DSANSEC3SHA1,
-    'RSASHA1NSEC3SHA1': RSASHA1NSEC3SHA1,
-    'RSASHA256': RSASHA256,
-    'RSASHA512': RSASHA512,
-    'ECCGOST': ECCGOST,
-    'ECDSAP256SHA256': ECDSAP256SHA256,
-    'ECDSAP384SHA384': ECDSAP384SHA384,
-    'ED25519': ED25519,
-    'ED448': ED448,
-    'INDIRECT': INDIRECT,
-    'PRIVATEDNS': PRIVATEDNS,
-    'PRIVATEOID': PRIVATEOID,
-}
-
-# We construct the inverse mapping programmatically to ensure that we
-# cannot make any mistakes (e.g. omissions, cut-and-paste errors) that
-# would cause the mapping not to be true inverse.
-
-_algorithm_by_value = {y: x for x, y in _algorithm_by_text.items()}
+globals().update(Algorithm.__members__)
 
 
 def algorithm_from_text(text):
@@ -111,10 +71,10 @@ def algorithm_from_text(text):
     Returns an ``int``.
     """
 
-    value = _algorithm_by_text.get(text.upper())
-    if value is None:
-        value = int(text)
-    return value
+    try:
+        return Algorithm[text.upper()]
+    except KeyError:
+        return int(text)
 
 
 def algorithm_to_text(value):
@@ -125,10 +85,10 @@ def algorithm_to_text(value):
     Returns a ``str``, the name of a DNSSEC algorithm.
     """
 
-    text = _algorithm_by_value.get(value)
-    if text is None:
-        text = str(value)
-    return text
+    try:
+        return Algorithm(value).name
+    except ValueError:
+        return str(value)
 
 
 def _to_rdata(record, origin):

--- a/dns/flags.py
+++ b/dns/flags.py
@@ -17,76 +17,52 @@
 
 """DNS Message Flags."""
 
+import enum
+
 # Standard DNS flags
 
-#: Query Response
-QR = 0x8000
-#: Authoritative Answer
-AA = 0x0400
-#: Truncated Response
-TC = 0x0200
-#: Recursion Desired
-RD = 0x0100
-#: Recursion Available
-RA = 0x0080
-#: Authentic Data
-AD = 0x0020
-#: Checking Disabled
-CD = 0x0010
+class Flag(enum.IntFlag):
+    #: Query Response
+    QR = 0x8000
+    #: Authoritative Answer
+    AA = 0x0400
+    #: Truncated Response
+    TC = 0x0200
+    #: Recursion Desired
+    RD = 0x0100
+    #: Recursion Available
+    RA = 0x0080
+    #: Authentic Data
+    AD = 0x0020
+    #: Checking Disabled
+    CD = 0x0010
+
+globals().update(Flag.__members__)
+
 
 # EDNS flags
 
-#: DNSSEC answer OK
-DO = 0x8000
-
-_by_text = {
-    'QR': QR,
-    'AA': AA,
-    'TC': TC,
-    'RD': RD,
-    'RA': RA,
-    'AD': AD,
-    'CD': CD
-}
-
-_edns_by_text = {
-    'DO': DO
-}
+class EDNSFlag(enum.IntFlag):
+    #: DNSSEC answer OK
+    DO = 0x8000
 
 
-# We construct the inverse mappings programmatically to ensure that we
-# cannot make any mistakes (e.g. omissions, cut-and-paste errors) that
-# would cause the mappings not to be true inverses.
-
-_by_value = {y: x for x, y in _by_text.items()}
-
-_edns_by_value = {y: x for x, y in _edns_by_text.items()}
+globals().update(EDNSFlag.__members__)
 
 
-def _order_flags(table):
-    order = list(table.items())
-    order.sort()
-    order.reverse()
-    return order
-
-_flags_order = _order_flags(_by_value)
-
-_edns_flags_order = _order_flags(_edns_by_value)
-
-
-def _from_text(text, table):
+def _from_text(text, enum_class):
     flags = 0
     tokens = text.split()
     for t in tokens:
-        flags = flags | table[t.upper()]
+        flags |= enum_class[t.upper()]
     return flags
 
 
-def _to_text(flags, table, order):
+def _to_text(flags, enum_class):
     text_flags = []
-    for k, v in order:
-        if flags & k != 0:
-            text_flags.append(v)
+    for k, v in enum_class.__members__.items():
+        if flags & v != 0:
+            text_flags.append(k)
     return ' '.join(text_flags)
 
 
@@ -97,7 +73,7 @@ def from_text(text):
     Returns an ``int``
     """
 
-    return _from_text(text, _by_text)
+    return _from_text(text, Flag)
 
 
 def to_text(flags):
@@ -107,7 +83,7 @@ def to_text(flags):
     Returns a ``str``.
     """
 
-    return _to_text(flags, _by_value, _flags_order)
+    return _to_text(flags, Flag)
 
 
 def edns_from_text(text):
@@ -117,7 +93,7 @@ def edns_from_text(text):
     Returns an ``int``
     """
 
-    return _from_text(text, _edns_by_text)
+    return _from_text(text, EDNSFlag)
 
 
 def edns_to_text(flags):
@@ -127,4 +103,4 @@ def edns_to_text(flags):
     Returns a ``str``.
     """
 
-    return _to_text(flags, _edns_by_value, _edns_flags_order)
+    return _to_text(flags, EDNSFlag)

--- a/dns/message.py
+++ b/dns/message.py
@@ -1110,10 +1110,8 @@ def make_query(qname, rdtype, rdclass=dns.rdataclass.IN, use_edns=None,
 
     if isinstance(qname, str):
         qname = dns.name.from_text(qname, idna_codec=idna_codec)
-    if isinstance(rdtype, str):
-        rdtype = dns.rdatatype.from_text(rdtype)
-    if isinstance(rdclass, str):
-        rdclass = dns.rdataclass.from_text(rdclass)
+    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdclass = dns.rdataclass.to_enum(rdclass)
     m = Message()
     m.flags |= dns.flags.RD
     m.find_rrset(m.question, qname, rdclass, rdtype, create=True,

--- a/dns/opcode.py
+++ b/dns/opcode.py
@@ -17,32 +17,23 @@
 
 """DNS Opcodes."""
 
+import enum
+
 import dns.exception
 
-#: Query
-QUERY = 0
-#: Inverse Query (historical)
-IQUERY = 1
-#: Server Status (unspecified and unimplemented anywhere)
-STATUS = 2
-#: Notify
-NOTIFY = 4
-#: Dynamic Update
-UPDATE = 5
+class Opcode(enum.IntEnum):
+    #: Query
+    QUERY = 0
+    #: Inverse Query (historical)
+    IQUERY = 1
+    #: Server Status (unspecified and unimplemented anywhere)
+    STATUS = 2
+    #: Notify
+    NOTIFY = 4
+    #: Dynamic Update
+    UPDATE = 5
 
-_by_text = {
-    'QUERY': QUERY,
-    'IQUERY': IQUERY,
-    'STATUS': STATUS,
-    'NOTIFY': NOTIFY,
-    'UPDATE': UPDATE
-}
-
-# We construct the inverse mapping programmatically to ensure that we
-# cannot make any mistakes (e.g. omissions, cut-and-paste errors) that
-# would cause the mapping not to be true inverse.
-
-_by_value = {y: x for x, y in _by_text.items()}
+globals().update(Opcode.__members__)
 
 
 class UnknownOpcode(dns.exception.DNSException):
@@ -62,11 +53,14 @@ def from_text(text):
     if text.isdigit():
         value = int(text)
         if value >= 0 and value <= 15:
-            return value
-    value = _by_text.get(text.upper())
-    if value is None:
+            try:
+                return Opcode(value)
+            except ValueError:
+                return value
+    try:
+        return Opcode[text.upper()]
+    except:
         raise UnknownOpcode
-    return value
 
 
 def from_flags(flags):
@@ -102,10 +96,10 @@ def to_text(value):
     Returns a ``str``.
     """
 
-    text = _by_value.get(value)
-    if text is None:
-        text = str(value)
-    return text
+    try:
+        return Opcode(value).name
+    except ValueError:
+        return str(value)
 
 
 def is_update(flags):

--- a/dns/query.py
+++ b/dns/query.py
@@ -817,8 +817,7 @@ def xfr(where, zone, rdtype=dns.rdatatype.AXFR, rdclass=dns.rdataclass.IN,
 
     if isinstance(zone, str):
         zone = dns.name.from_text(zone)
-    if isinstance(rdtype, str):
-        rdtype = dns.rdatatype.from_text(rdtype)
+    rdtype = dns.rdatatype.to_enum(rdtype)
     q = dns.message.make_query(zone, rdtype, rdclass)
     if rdtype == dns.rdatatype.IXFR:
         rrset = dns.rrset.from_text(zone, 0, 'IN', 'SOA',

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -433,6 +433,8 @@ def from_text(rdclass, rdtype, tok, origin=None, relativize=True,
 
     if isinstance(tok, str):
         tok = dns.tokenizer.Tokenizer(tok, idna_codec=idna_codec)
+    rdclass = dns.rdataclass.to_enum(rdclass)
+    rdtype = dns.rdatatype.to_enum(rdtype)
     cls = get_rdata_class(rdclass, rdtype)
     if cls != GenericRdata:
         # peek at first token
@@ -482,6 +484,8 @@ def from_wire(rdclass, rdtype, wire, current, rdlen, origin=None):
     """
 
     wire = dns.wiredata.maybe_wrap(wire)
+    rdclass = dns.rdataclass.to_enum(rdclass)
+    rdtype = dns.rdatatype.to_enum(rdtype)
     cls = get_rdata_class(rdclass, rdtype)
     return cls.from_wire(rdclass, rdtype, wire, current, rdlen, origin)
 

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -516,8 +516,13 @@ def register_type(implementation, rdtype, rdtype_text, is_singleton=False,
     """
 
     existing_cls = get_rdata_class(rdclass, rdtype)
-    if existing_cls != GenericRdata:
+    if existing_cls != GenericRdata or dns.rdatatype.is_metatype(rdtype):
         raise RdatatypeExists(rdclass=rdclass, rdtype=rdtype)
+    try:
+        if dns.rdatatype.RdataType(rdtype).name != rdtype_text:
+            raise RdatatypeExists(rdclass=rdclass, rdtype=rdtype)
+    except ValueError:
+        pass
     _rdata_classes[(rdclass, rdtype)] = getattr(implementation,
                                                 rdtype_text.replace('-', '_'))
     dns.rdatatype.register_type(rdtype, rdtype_text, is_singleton)

--- a/dns/rdataclass.py
+++ b/dns/rdataclass.py
@@ -34,8 +34,7 @@ class RdataClass(enum.IntEnum):
     NONE = 254
     ANY = 255
 
-for (name, value) in RdataClass.__members__.items():
-    globals()[name] = value
+globals().update(RdataClass.__members__)
 
 _metaclasses = {
     NONE: True,

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -309,10 +309,8 @@ def from_text_list(rdclass, rdtype, ttl, text_rdatas, idna_codec=None):
     Returns a ``dns.rdataset.Rdataset`` object.
     """
 
-    if isinstance(rdclass, str):
-        rdclass = dns.rdataclass.from_text(rdclass)
-    if isinstance(rdtype, str):
-        rdtype = dns.rdatatype.from_text(rdtype)
+    rdclass = dns.rdataclass.to_enum(rdclass)
+    rdtype = dns.rdatatype.to_enum(rdtype)
     r = Rdataset(rdclass, rdtype)
     r.update_ttl(ttl)
     for t in text_rdatas:

--- a/dns/rdatatype.py
+++ b/dns/rdatatype.py
@@ -17,164 +17,95 @@
 
 """DNS Rdata Types."""
 
+import enum
 import re
 
 import dns.exception
 
-NONE = 0
-A = 1
-NS = 2
-MD = 3
-MF = 4
-CNAME = 5
-SOA = 6
-MB = 7
-MG = 8
-MR = 9
-NULL = 10
-WKS = 11
-PTR = 12
-HINFO = 13
-MINFO = 14
-MX = 15
-TXT = 16
-RP = 17
-AFSDB = 18
-X25 = 19
-ISDN = 20
-RT = 21
-NSAP = 22
-NSAP_PTR = 23
-SIG = 24
-KEY = 25
-PX = 26
-GPOS = 27
-AAAA = 28
-LOC = 29
-NXT = 30
-SRV = 33
-NAPTR = 35
-KX = 36
-CERT = 37
-A6 = 38
-DNAME = 39
-OPT = 41
-APL = 42
-DS = 43
-SSHFP = 44
-IPSECKEY = 45
-RRSIG = 46
-NSEC = 47
-DNSKEY = 48
-DHCID = 49
-NSEC3 = 50
-NSEC3PARAM = 51
-TLSA = 52
-HIP = 55
-NINFO = 56
-CDS = 59
-CDNSKEY = 60
-OPENPGPKEY = 61
-CSYNC = 62
-SPF = 99
-UNSPEC = 103
-EUI48 = 108
-EUI64 = 109
-TKEY = 249
-TSIG = 250
-IXFR = 251
-AXFR = 252
-MAILB = 253
-MAILA = 254
-ANY = 255
-URI = 256
-CAA = 257
-AVC = 258
-TA = 32768
-DLV = 32769
+class RdataType(enum.IntEnum):
+    """DNS Rdata Type"""
+    TYPE0 = 0
+    NONE = 0
+    A = 1
+    NS = 2
+    MD = 3
+    MF = 4
+    CNAME = 5
+    SOA = 6
+    MB = 7
+    MG = 8
+    MR = 9
+    NULL = 10
+    WKS = 11
+    PTR = 12
+    HINFO = 13
+    MINFO = 14
+    MX = 15
+    TXT = 16
+    RP = 17
+    AFSDB = 18
+    X25 = 19
+    ISDN = 20
+    RT = 21
+    NSAP = 22
+    NSAP_PTR = 23
+    SIG = 24
+    KEY = 25
+    PX = 26
+    GPOS = 27
+    AAAA = 28
+    LOC = 29
+    NXT = 30
+    SRV = 33
+    NAPTR = 35
+    KX = 36
+    CERT = 37
+    A6 = 38
+    DNAME = 39
+    OPT = 41
+    APL = 42
+    DS = 43
+    SSHFP = 44
+    IPSECKEY = 45
+    RRSIG = 46
+    NSEC = 47
+    DNSKEY = 48
+    DHCID = 49
+    NSEC3 = 50
+    NSEC3PARAM = 51
+    TLSA = 52
+    HIP = 55
+    NINFO = 56
+    CDS = 59
+    CDNSKEY = 60
+    OPENPGPKEY = 61
+    CSYNC = 62
+    SPF = 99
+    UNSPEC = 103
+    EUI48 = 108
+    EUI64 = 109
+    TKEY = 249
+    TSIG = 250
+    IXFR = 251
+    AXFR = 252
+    MAILB = 253
+    MAILA = 254
+    ANY = 255
+    URI = 256
+    CAA = 257
+    AVC = 258
+    TA = 32768
+    DLV = 32769
 
-_by_text = {
-    'NONE': NONE,
-    'A': A,
-    'NS': NS,
-    'MD': MD,
-    'MF': MF,
-    'CNAME': CNAME,
-    'SOA': SOA,
-    'MB': MB,
-    'MG': MG,
-    'MR': MR,
-    'NULL': NULL,
-    'WKS': WKS,
-    'PTR': PTR,
-    'HINFO': HINFO,
-    'MINFO': MINFO,
-    'MX': MX,
-    'TXT': TXT,
-    'RP': RP,
-    'AFSDB': AFSDB,
-    'X25': X25,
-    'ISDN': ISDN,
-    'RT': RT,
-    'NSAP': NSAP,
-    'NSAP-PTR': NSAP_PTR,
-    'SIG': SIG,
-    'KEY': KEY,
-    'PX': PX,
-    'GPOS': GPOS,
-    'AAAA': AAAA,
-    'LOC': LOC,
-    'NXT': NXT,
-    'SRV': SRV,
-    'NAPTR': NAPTR,
-    'KX': KX,
-    'CERT': CERT,
-    'A6': A6,
-    'DNAME': DNAME,
-    'OPT': OPT,
-    'APL': APL,
-    'DS': DS,
-    'SSHFP': SSHFP,
-    'IPSECKEY': IPSECKEY,
-    'RRSIG': RRSIG,
-    'NSEC': NSEC,
-    'DNSKEY': DNSKEY,
-    'DHCID': DHCID,
-    'NSEC3': NSEC3,
-    'NSEC3PARAM': NSEC3PARAM,
-    'TLSA': TLSA,
-    'HIP': HIP,
-    'NINFO': NINFO,
-    'CDS': CDS,
-    'CDNSKEY': CDNSKEY,
-    'OPENPGPKEY': OPENPGPKEY,
-    'CSYNC': CSYNC,
-    'SPF': SPF,
-    'UNSPEC': UNSPEC,
-    'EUI48': EUI48,
-    'EUI64': EUI64,
-    'TKEY': TKEY,
-    'TSIG': TSIG,
-    'IXFR': IXFR,
-    'AXFR': AXFR,
-    'MAILB': MAILB,
-    'MAILA': MAILA,
-    'ANY': ANY,
-    'URI': URI,
-    'CAA': CAA,
-    'AVC': AVC,
-    'TA': TA,
-    'DLV': DLV,
-}
+_by_text = {}
+_by_value = {}
 
-# We construct the inverse mapping programmatically to ensure that we
-# cannot make any mistakes (e.g. omissions, cut-and-paste errors) that
-# would cause the mapping not to be true inverse.
-
-_by_value = {y: x for x, y in _by_text.items()}
-# Render type 0 as "TYPE0" not "NONE", as NONE is a dnspython-ism and not
-# an official mnemonic.
-_by_value[0] = 'TYPE0'
+for (name, value) in RdataType.__members__.items():
+    globals()[name] = value
+    real_name = name.replace('_', '-')
+    _by_text[real_name] = value
+    if value not in _by_value:
+        _by_value[value] = real_name
 
 _metatypes = {
     OPT: True
@@ -238,6 +169,24 @@ def to_text(value):
     if text is None:
         text = 'TYPE' + repr(value)
     return text
+
+
+def to_enum(value):
+    """Convert a DNS rdata type value to an enumerated type, if possible.
+
+    *value*, an ``int`` or ``str``, the rdata type.
+
+    Returns an ``int``.
+    """
+
+    if isinstance(value, str):
+        return from_text(value)
+    if value < 0 or value > 65535:
+        raise ValueError("type must be between >= 0 and <= 65535")
+    try:
+        return RdataType(value)
+    except ValueError:
+        return value
 
 
 def is_metatype(rdtype):

--- a/dns/rdtypes/ANY/CDNSKEY.py
+++ b/dns/rdtypes/ANY/CDNSKEY.py
@@ -16,10 +16,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import dns.rdtypes.dnskeybase
-from dns.rdtypes.dnskeybase import flags_to_text_set, flags_from_text_set
-
-
-__all__ = ['flags_to_text_set', 'flags_from_text_set']
+from dns.rdtypes.dnskeybase import SEP, REVOKE, ZONE
 
 
 class CDNSKEY(dns.rdtypes.dnskeybase.DNSKEYBase):

--- a/dns/rdtypes/ANY/DNSKEY.py
+++ b/dns/rdtypes/ANY/DNSKEY.py
@@ -16,10 +16,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import dns.rdtypes.dnskeybase
-from dns.rdtypes.dnskeybase import flags_to_text_set, flags_from_text_set
-
-
-__all__ = ['flags_to_text_set', 'flags_from_text_set']
+from dns.rdtypes.dnskeybase import SEP, REVOKE, ZONE
 
 
 class DNSKEY(dns.rdtypes.dnskeybase.DNSKEYBase):

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -140,10 +140,8 @@ def from_text_list(name, ttl, rdclass, rdtype, text_rdatas,
 
     if isinstance(name, str):
         name = dns.name.from_text(name, None, idna_codec=idna_codec)
-    if isinstance(rdclass, str):
-        rdclass = dns.rdataclass.from_text(rdclass)
-    if isinstance(rdtype, str):
-        rdtype = dns.rdatatype.from_text(rdtype)
+    rdclass = dns.rdataclass.to_enum(rdclass)
+    rdtype = dns.rdatatype.to_enum(rdtype)
     r = RRset(name, rdclass, rdtype)
     r.update_ttl(ttl)
     for t in text_rdatas:

--- a/dns/update.py
+++ b/dns/update.py
@@ -58,8 +58,7 @@ class Update(dns.message.Message):
         if isinstance(zone, str):
             zone = dns.name.from_text(zone)
         self.origin = zone
-        if isinstance(rdclass, str):
-            rdclass = dns.rdataclass.from_text(rdclass)
+        rdclass = dns.rdataclass.to_enum(rdclass)
         self.zone_rdclass = rdclass
         self.find_rrset(self.question, self.origin, rdclass, dns.rdatatype.SOA,
                         create=True, force_unique=True)
@@ -109,9 +108,7 @@ class Update(dns.message.Message):
                 for rd in args:
                     self._add_rr(name, ttl, rd, section=section)
             else:
-                rdtype = args.pop(0)
-                if isinstance(rdtype, str):
-                    rdtype = dns.rdatatype.from_text(rdtype)
+                rdtype = dns.rdatatype.to_enum(args.pop(0))
                 if replace:
                     self.delete(name, rdtype)
                 for s in args:
@@ -165,9 +162,7 @@ class Update(dns.message.Message):
                 for rd in args:
                     self._add_rr(name, 0, rd, dns.rdataclass.NONE)
             else:
-                rdtype = args.pop(0)
-                if isinstance(rdtype, str):
-                    rdtype = dns.rdatatype.from_text(rdtype)
+                rdtype = dns.rdatatype.to_enum(args.pop(0))
                 if len(args) == 0:
                     self.find_rrset(self.authority, name,
                                     self.zone_rdclass, rdtype,
@@ -229,9 +224,7 @@ class Update(dns.message.Message):
                 args.insert(0, 0)
             self._add(False, self.answer, name, *args)
         else:
-            rdtype = args[0]
-            if isinstance(rdtype, str):
-                rdtype = dns.rdatatype.from_text(rdtype)
+            rdtype = dns.rdatatype.to_enum(args[0])
             self.find_rrset(self.answer, name,
                             dns.rdataclass.ANY, rdtype,
                             dns.rdatatype.NONE, None,
@@ -249,8 +242,7 @@ class Update(dns.message.Message):
                             dns.rdatatype.NONE, None,
                             True, True)
         else:
-            if isinstance(rdtype, str):
-                rdtype = dns.rdatatype.from_text(rdtype)
+            rdtype = dns.rdatatype.to_enum(rdtype)
             self.find_rrset(self.answer, name,
                             dns.rdataclass.NONE, rdtype,
                             dns.rdatatype.NONE, None,

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -270,10 +270,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        if isinstance(rdtype, str):
-            rdtype = dns.rdatatype.from_text(rdtype)
-        if isinstance(covers, str):
-            covers = dns.rdatatype.from_text(covers)
+        rdtype = dns.rdatatype.to_enum(rdtype)
+        if covers is not None:
+            covers = dns.rdatatype.to_enum(covers)
         node = self.find_node(name, create)
         return node.find_rdataset(self.rdclass, rdtype, covers, create)
 
@@ -349,10 +348,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        if isinstance(rdtype, str):
-            rdtype = dns.rdatatype.from_text(rdtype)
-        if isinstance(covers, str):
-            covers = dns.rdatatype.from_text(covers)
+        rdtype = dns.rdatatype.to_enum(rdtype)
+        if covers is not None:
+            covers = dns.rdatatype.to_enum(covers)
         node = self.get_node(name)
         if node is not None:
             node.delete_rdataset(self.rdclass, rdtype, covers)
@@ -423,10 +421,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        if isinstance(rdtype, str):
-            rdtype = dns.rdatatype.from_text(rdtype)
-        if isinstance(covers, str):
-            covers = dns.rdatatype.from_text(covers)
+        rdtype = dns.rdatatype.to_enum(rdtype)
+        if covers is not None:
+            covers = dns.rdatatype.to_enum(covers)
         rdataset = self.nodes[name].find_rdataset(self.rdclass, rdtype, covers)
         rrset = dns.rrset.RRset(name, self.rdclass, rdtype, covers)
         rrset.update(rdataset)
@@ -496,10 +493,9 @@ class Zone(object):
         RRSIG rdataset.
         """
 
-        if isinstance(rdtype, str):
-            rdtype = dns.rdatatype.from_text(rdtype)
-        if isinstance(covers, str):
-            covers = dns.rdatatype.from_text(covers)
+        rdtype = dns.rdatatype.to_enum(rdtype)
+        if covers is not None:
+            covers = dns.rdatatype.to_enum(covers)
         for (name, node) in self.items():
             for rds in node:
                 if rdtype == dns.rdatatype.ANY or \
@@ -526,10 +522,9 @@ class Zone(object):
         RRSIG rdataset.
         """
 
-        if isinstance(rdtype, str):
-            rdtype = dns.rdatatype.from_text(rdtype)
-        if isinstance(covers, str):
-            covers = dns.rdatatype.from_text(covers)
+        rdtype = dns.rdatatype.to_enum(rdtype)
+        if covers is not None:
+            covers = dns.rdatatype.to_enum(covers)
         for (name, node) in self.items():
             for rds in node:
                 if rdtype == dns.rdatatype.ANY or \

--- a/tests/test_rdtypeanydnskey.py
+++ b/tests/test_rdtypeanydnskey.py
@@ -23,46 +23,20 @@ from typing import Set # pylint: disable=unused-import
 
 class RdtypeAnyDnskeyTestCase(unittest.TestCase):
 
-    def testFlagsEmpty(self): # type: () -> None
-        '''Test DNSKEY flag to/from text conversion for zero flag/empty set.'''
-        good_s = set() #type: Set[str]
-        good_f = 0
-        from_flags = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(good_f)
-        self.assertEqual(from_flags, good_s,
-                         '"{}" != "{}"'.format(from_flags, good_s))
-        from_set = dns.rdtypes.ANY.DNSKEY.flags_from_text_set(good_s)
-        self.assertEqual(from_set, good_f,
-                         '"0x{:x}" != "0x{:x}"'.format(from_set, good_f))
-
     def testFlagsAll(self): # type: () -> None
         '''Test that all defined flags are recognized.'''
         good_s = {'SEP', 'REVOKE', 'ZONE'}
         good_f = 0x181
-        from_flags = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(good_f)
-        self.assertEqual(from_flags, good_s,
-                         '"{}" != "{}"'.format(from_flags, good_s))
-        from_text = dns.rdtypes.ANY.DNSKEY.flags_from_text_set(good_s)
-        self.assertEqual(from_text, good_f,
-                         '"0x{:x}" != "0x{:x}"'.format(from_text, good_f))
-
-    def testFlagsUnknownToText(self): # type: () -> None
-        '''Test that undefined flags are returned in hexadecimal notation.'''
-        unk_s = {'0x8000'}
-        flags_s = dns.rdtypes.ANY.DNSKEY.flags_to_text_set(0x8000)
-        self.assertEqual(flags_s, unk_s, '"{}" != "{}"'.format(flags_s, unk_s))
-
-    def testFlagsUnknownToFlags(self): # type: () -> None
-        '''Test that conversion from undefined mnemonic raises error.'''
-        self.assertRaises(NotImplementedError,
-                              dns.rdtypes.ANY.DNSKEY.flags_from_text_set,
-                              (['0x8000']))
+        self.assertEqual(dns.rdtypes.ANY.DNSKEY.SEP |
+                         dns.rdtypes.ANY.DNSKEY.REVOKE |
+                         dns.rdtypes.ANY.DNSKEY.ZONE, good_f)
 
     def testFlagsRRToText(self): # type: () -> None
         '''Test that RR method returns correct flags.'''
         rr = dns.rrset.from_text('foo', 300, 'IN', 'DNSKEY', '257 3 8 KEY=')[0]
-        rr_s = {'ZONE', 'SEP'}
-        flags_s = rr.flags_to_text_set()
-        self.assertEqual(flags_s, rr_s, '"{}" != "{}"'.format(flags_s, rr_s))
+        self.assertEqual(dns.rdtypes.ANY.DNSKEY.ZONE |
+                         dns.rdtypes.ANY.DNSKEY.SEP,
+                         rr.flags)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Create RdataType and RdataClass enums, and change the constants in the dns.rdatatype and rdataclass modules to use them.

In rdataclass, remove `_by_text` and `_by_value`, and just use the enum methods directly.  In rdatatype, this doesn't completely work, because of type registration and the inconveniently named NSAP-PTR type, so keep the existing arrays that mostly duplicate the enum mapping for now.

Add `to_enum` methods to both, which take either an int or a string, and convert to an enumerated value, if possible (that is, if the type or class is known).

Change existing callers that support both `int` or `str` to use `to_enum`, and also add this to other places, like `dns.rdata.from_wire` and `dns.rdata.from_text`.  This doesn't touch the `dns.resolver` or `dns.trio.resolver` calls, to avoid conflicts.

Marking this as WIP, since while the tests pass, there could still be something missing.  Also, it might be possible to remove the duplicate arrays from rdatatype, or do other things in better ways.

