### PR TITLE
Remove dns.rdata{type,class}.to_enum.

### DIFF
--- a/dns/enum.py
+++ b/dns/enum.py
@@ -51,7 +51,20 @@ class IntEnum(enum.IntEnum):
             return f"{cls._prefix()}{value}"
 
     @classmethod
-    def to_enum(cls, value):
+    def make(cls, value):
+        """Convert text or a value into an enumerated type, if possible.
+
+        *value*, the ``int`` or ``str`` to convert.
+
+        Raises a class-specific exception if a ``str`` is provided that
+        cannot be converted.
+
+        Raises ``ValueError`` if the value is out of range.
+
+        Returns an enumeration from the calling class corresponding to the
+        value, if one is defined, or an ``int`` otherwise.
+        """
+
         if isinstance(value, str):
             return cls.from_text(value)
         cls._check_value(value)

--- a/dns/message.py
+++ b/dns/message.py
@@ -1110,8 +1110,8 @@ def make_query(qname, rdtype, rdclass=dns.rdataclass.IN, use_edns=None,
 
     if isinstance(qname, str):
         qname = dns.name.from_text(qname, idna_codec=idna_codec)
-    rdtype = dns.rdatatype.to_enum(rdtype)
-    rdclass = dns.rdataclass.to_enum(rdclass)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
+    rdclass = dns.rdataclass.RdataClass.make(rdclass)
     m = Message()
     m.flags |= dns.flags.RD
     m.find_rrset(m.question, qname, rdclass, rdtype, create=True,

--- a/dns/query.py
+++ b/dns/query.py
@@ -786,7 +786,7 @@ def xfr(where, zone, rdtype=dns.rdatatype.AXFR, rdclass=dns.rdataclass.IN,
 
     if isinstance(zone, str):
         zone = dns.name.from_text(zone)
-    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
     q = dns.message.make_query(zone, rdtype, rdclass)
     if rdtype == dns.rdatatype.IXFR:
         rrset = dns.rrset.from_text(zone, 0, 'IN', 'SOA',

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -433,8 +433,8 @@ def from_text(rdclass, rdtype, tok, origin=None, relativize=True,
 
     if isinstance(tok, str):
         tok = dns.tokenizer.Tokenizer(tok, idna_codec=idna_codec)
-    rdclass = dns.rdataclass.to_enum(rdclass)
-    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdclass = dns.rdataclass.RdataClass.make(rdclass)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
     cls = get_rdata_class(rdclass, rdtype)
     if cls != GenericRdata:
         # peek at first token
@@ -484,8 +484,8 @@ def from_wire(rdclass, rdtype, wire, current, rdlen, origin=None):
     """
 
     wire = dns.wiredata.maybe_wrap(wire)
-    rdclass = dns.rdataclass.to_enum(rdclass)
-    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdclass = dns.rdataclass.RdataClass.make(rdclass)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
     cls = get_rdata_class(rdclass, rdtype)
     return cls.from_wire(rdclass, rdtype, wire, current, rdlen, origin)
 

--- a/dns/rdataclass.py
+++ b/dns/rdataclass.py
@@ -89,17 +89,6 @@ def to_text(value):
     return RdataClass.to_text(value)
 
 
-def to_enum(value):
-    """Convert a DNS rdata class value to an enumerated type, if possible.
-
-    *value*, an ``int`` or ``str``, the rdata class.
-
-    Returns an ``int``.
-    """
-
-    return RdataClass.to_enum(value)
-
-
 def is_metaclass(rdclass):
     """True if the specified class is a metaclass.
 

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -309,8 +309,8 @@ def from_text_list(rdclass, rdtype, ttl, text_rdatas, idna_codec=None):
     Returns a ``dns.rdataset.Rdataset`` object.
     """
 
-    rdclass = dns.rdataclass.to_enum(rdclass)
-    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdclass = dns.rdataclass.RdataClass.make(rdclass)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
     r = Rdataset(rdclass, rdtype)
     r.update_ttl(ttl)
     for t in text_rdatas:

--- a/dns/rdatatype.py
+++ b/dns/rdatatype.py
@@ -170,17 +170,6 @@ def to_text(value):
     return text.replace('_', '-')
 
 
-def to_enum(value):
-    """Convert a DNS rdata type value to an enumerated type, if possible.
-
-    *value*, an ``int`` or ``str``, the rdata type.
-
-    Returns an ``int``.
-    """
-
-    return RdataType.to_enum(value)
-
-
 def is_metatype(rdtype):
     """True if the specified type is a metatype.
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -501,10 +501,10 @@ class _Resolution(object):
                  raise_on_no_answer, search):
         if isinstance(qname, str):
             qname = dns.name.from_text(qname, None)
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if dns.rdatatype.is_metatype(rdtype):
             raise NoMetaqueries
-        rdclass = dns.rdataclass.to_enum(rdclass)
+        rdclass = dns.rdataclass.RdataClass.make(rdclass)
         if dns.rdataclass.is_metaclass(rdclass):
             raise NoMetaqueries
         self.resolver = resolver

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -140,8 +140,8 @@ def from_text_list(name, ttl, rdclass, rdtype, text_rdatas,
 
     if isinstance(name, str):
         name = dns.name.from_text(name, None, idna_codec=idna_codec)
-    rdclass = dns.rdataclass.to_enum(rdclass)
-    rdtype = dns.rdatatype.to_enum(rdtype)
+    rdclass = dns.rdataclass.RdataClass.make(rdclass)
+    rdtype = dns.rdatatype.RdataType.make(rdtype)
     r = RRset(name, rdclass, rdtype)
     r.update_ttl(ttl)
     for t in text_rdatas:

--- a/dns/update.py
+++ b/dns/update.py
@@ -58,7 +58,7 @@ class Update(dns.message.Message):
         if isinstance(zone, str):
             zone = dns.name.from_text(zone)
         self.origin = zone
-        rdclass = dns.rdataclass.to_enum(rdclass)
+        rdclass = dns.rdataclass.RdataClass.make(rdclass)
         self.zone_rdclass = rdclass
         self.find_rrset(self.question, self.origin, rdclass, dns.rdatatype.SOA,
                         create=True, force_unique=True)
@@ -108,7 +108,7 @@ class Update(dns.message.Message):
                 for rd in args:
                     self._add_rr(name, ttl, rd, section=section)
             else:
-                rdtype = dns.rdatatype.to_enum(args.pop(0))
+                rdtype = dns.rdatatype.RdataType.make(args.pop(0))
                 if replace:
                     self.delete(name, rdtype)
                 for s in args:
@@ -162,7 +162,7 @@ class Update(dns.message.Message):
                 for rd in args:
                     self._add_rr(name, 0, rd, dns.rdataclass.NONE)
             else:
-                rdtype = dns.rdatatype.to_enum(args.pop(0))
+                rdtype = dns.rdatatype.RdataType.make(args.pop(0))
                 if len(args) == 0:
                     self.find_rrset(self.authority, name,
                                     self.zone_rdclass, rdtype,
@@ -224,7 +224,7 @@ class Update(dns.message.Message):
                 args.insert(0, 0)
             self._add(False, self.answer, name, *args)
         else:
-            rdtype = dns.rdatatype.to_enum(args[0])
+            rdtype = dns.rdatatype.RdataType.make(args[0])
             self.find_rrset(self.answer, name,
                             dns.rdataclass.ANY, rdtype,
                             dns.rdatatype.NONE, None,
@@ -242,7 +242,7 @@ class Update(dns.message.Message):
                             dns.rdatatype.NONE, None,
                             True, True)
         else:
-            rdtype = dns.rdatatype.to_enum(rdtype)
+            rdtype = dns.rdatatype.RdataType.make(rdtype)
             self.find_rrset(self.answer, name,
                             dns.rdataclass.NONE, rdtype,
                             dns.rdatatype.NONE, None,

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -270,9 +270,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if covers is not None:
-            covers = dns.rdatatype.to_enum(covers)
+            covers = dns.rdatatype.RdataType.make(covers)
         node = self.find_node(name, create)
         return node.find_rdataset(self.rdclass, rdtype, covers, create)
 
@@ -348,9 +348,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if covers is not None:
-            covers = dns.rdatatype.to_enum(covers)
+            covers = dns.rdatatype.RdataType.make(covers)
         node = self.get_node(name)
         if node is not None:
             node.delete_rdataset(self.rdclass, rdtype, covers)
@@ -421,9 +421,9 @@ class Zone(object):
         """
 
         name = self._validate_name(name)
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if covers is not None:
-            covers = dns.rdatatype.to_enum(covers)
+            covers = dns.rdatatype.RdataType.make(covers)
         rdataset = self.nodes[name].find_rdataset(self.rdclass, rdtype, covers)
         rrset = dns.rrset.RRset(name, self.rdclass, rdtype, covers)
         rrset.update(rdataset)
@@ -493,9 +493,9 @@ class Zone(object):
         RRSIG rdataset.
         """
 
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if covers is not None:
-            covers = dns.rdatatype.to_enum(covers)
+            covers = dns.rdatatype.RdataType.make(covers)
         for (name, node) in self.items():
             for rds in node:
                 if rdtype == dns.rdatatype.ANY or \
@@ -522,9 +522,9 @@ class Zone(object):
         RRSIG rdataset.
         """
 
-        rdtype = dns.rdatatype.to_enum(rdtype)
+        rdtype = dns.rdatatype.RdataType.make(rdtype)
         if covers is not None:
-            covers = dns.rdatatype.to_enum(covers)
+            covers = dns.rdatatype.RdataType.make(covers)
         for (name, node) in self.items():
             for rds in node:
                 if rdtype == dns.rdatatype.ANY or \


### PR DESCRIPTION
These methods (which convert a str/int into an enum/int) shouldn't be
commonly used by external code, so don't need to exist at the module
level.  The make() method on the enum class (renamed from to_enum()) can
still be used, and the internal callers have been updated to use it.