### PR TITLE
Check character-string length for HINFO records

### DIFF
--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -48,8 +48,8 @@ class HINFO(dns.rdata.Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
                   relativize_to=None):
-        cpu = tok.get_string()
-        os = tok.get_string()
+        cpu = tok.get_string(max_length=255)
+        os = tok.get_string(max_length=255)
         tok.get_eol()
         return cls(rdclass, rdtype, cpu, os)
 

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -533,10 +533,12 @@ class Tokenizer(object):
                 '%d is not an unsigned 32-bit integer' % value)
         return value
 
-    def get_string(self, origin=None):
+    def get_string(self, origin=None, max_length=None):
         """Read the next token and interpret it as a string.
 
         Raises dns.exception.SyntaxError if not a string.
+        Raises dns.exception.SyntaxError if token value length
+        exceeds max_length (if specified).
 
         Returns a string.
         """
@@ -544,6 +546,8 @@ class Tokenizer(object):
         token = self.get().unescape()
         if not (token.is_identifier() or token.is_quoted_string()):
             raise dns.exception.SyntaxError('expecting a string')
+        if max_length and len(token.value) > max_length:
+            raise dns.exception.SyntaxError("string too long")
         return token.value
 
     def get_identifier(self, origin=None):


### PR DESCRIPTION
Addressing #493

Technical note: A difference between the processing in `TXTBase.from_text` and `Tokenizer.get_string` is that `TXTBase` uses `token = tok.get().unescape_to_bytes().value`, while `Tokenizer.get_string` uses `token = self.get().unescape().value`. Maybe there is a clever way to reduce code duplication that I did not yet see.