### PR TITLE
Lowercasing in to_digestable() methods for records containing DNS names

### DIFF
--- a/dns/rdtypes/IN/SRV.py
+++ b/dns/rdtypes/IN/SRV.py
@@ -15,6 +15,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import io
 import struct
 
 import dns.exception
@@ -56,6 +57,13 @@ class SRV(dns.rdata.Rdata):
         three_ints = struct.pack("!HHH", self.priority, self.weight, self.port)
         file.write(three_ints)
         self.target.to_wire(file, compress, origin)
+
+    def to_digestable(self, origin=None):
+        # TODO how to avoid code duplication here? This is mostly identical to self.to_wire.
+        f = io.BytesIO()
+        f.write(struct.pack("!HHH", self.priority, self.weight, self.port))
+        f.write(self.target.to_digestable(origin))
+        return f.getvalue()
 
     @classmethod
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -25,6 +25,8 @@ import dns.rdataclass
 import dns.rdatatype
 import dns.rdtypes.ANY.TXT
 import dns.ttl
+from dns import rdata, rdataclass, rdatatype
+
 
 class BugsTestCase(unittest.TestCase):
 
@@ -94,6 +96,27 @@ class BugsTestCase(unittest.TestCase):
         self.assertEqual(t1, t2)
         self.assertEqual(t1, t2)
         self.assertEqual(t1, t4)
+
+    def test_lowercase_canonicals(self):
+        for t, presentation_format in [
+            ('SRV', '100 1 5061 EXAMPLE.com.'),
+            # TODO also check NS, MD, MF, CNAME, SOA, MB, MG, MR, PTR,
+            #  HINFO, MINFO, MX, HINFO, RP, AFSDB, RT, SIG, PX, NXT,
+            #  NAPTR, KX, SRV, DNAME, A6, RRSIG, or NSEC
+        ]:
+            canonical_format = rdata.from_text(
+                    rdclass=rdataclass.IN,
+                    rdtype=rdatatype.from_text(t),
+                    tok=presentation_format,
+                    relativize=False
+                ).to_digestable()
+            self.assertIn(
+                b'example',
+                canonical_format,
+                f'Expected canonical format of {t} record type to have '
+                f'lowercase DNS names, but saw {canonical_format}.'
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #496 

Introduces some code duplication in `SRV.to_digestable`.

Tests for other record types pending.