### PR TITLE
Minor Python 3 cleanups.

### DIFF
--- a/dns/edns.py
+++ b/dns/edns.py
@@ -43,7 +43,7 @@ PADDING = 12
 #: CHAIN
 CHAIN = 13
 
-class Option(object):
+class Option:
 
     """Base class for all EDNS option types."""
 
@@ -132,7 +132,7 @@ class GenericOption(Option):
     """
 
     def __init__(self, otype, data):
-        super(GenericOption, self).__init__(otype)
+        super().__init__(otype)
         self.data = data
 
     def to_wire(self, file):
@@ -169,7 +169,7 @@ class ECSOption(Option):
         must be 0 in queries, and should be set in responses.
         """
 
-        super(ECSOption, self).__init__(ECS)
+        super().__init__(ECS)
         af = dns.inet.af_for_address(address)
 
         if af == dns.inet.AF_INET6:

--- a/dns/entropy.py
+++ b/dns/entropy.py
@@ -25,7 +25,7 @@ except ImportError:
     import dummy_threading as _threading    # type: ignore
 
 
-class EntropyPool(object):
+class EntropyPool:
 
     # This is an entropy pool for Python implementations that do not
     # have a working SystemRandom.  I'm not sure there are any, but

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -59,9 +59,9 @@ class DNSException(Exception):
             # doc string is better implicit message than empty string
             self.msg = self.__doc__
         if args:
-            super(DNSException, self).__init__(*args)
+            super().__init__(*args)
         else:
-            super(DNSException, self).__init__(self.msg)
+            super().__init__(self.msg)
 
     def _check_params(self, *args, **kwargs):
         """Old exceptions supported only args and not kwargs.
@@ -103,7 +103,7 @@ class DNSException(Exception):
             return self.fmt.format(**fmtargs)
         else:
             # print *args directly in the same way as old DNSException
-            return super(DNSException, self).__str__()
+            return super().__str__()
 
 
 class FormError(DNSException):

--- a/dns/message.py
+++ b/dns/message.py
@@ -90,7 +90,7 @@ AUTHORITY = 2
 #: The additional section number
 ADDITIONAL = 3
 
-class Message(object):
+class Message:
     """A DNS message."""
 
     def __init__(self, id=None):
@@ -592,7 +592,7 @@ class Message(object):
         self.flags |= dns.opcode.to_flags(opcode)
 
 
-class _WireReader(object):
+class _WireReader:
 
     """Wire format reader.
 
@@ -852,7 +852,7 @@ def from_wire(wire, keyring=None, request_mac=b'', xfr=False, origin=None,
     return m
 
 
-class _TextReader(object):
+class _TextReader:
 
     """Text format reader.
 

--- a/dns/name.py
+++ b/dns/name.py
@@ -95,7 +95,7 @@ class IDNAException(dns.exception.DNSException):
     fmt = "IDNA processing exception: {idna_exception}"
 
 
-class IDNACodec(object):
+class IDNACodec:
     """Abstract base class for IDNA encoder/decoders."""
 
     def __init__(self):
@@ -128,7 +128,7 @@ class IDNA2003Codec(IDNACodec):
         was encoded with IDNA2008.  The default is `False`.
         """
 
-        super(IDNA2003Codec, self).__init__()
+        super().__init__()
         self.strict_decode = strict_decode
 
     def encode(self, label):
@@ -144,7 +144,7 @@ class IDNA2003Codec(IDNACodec):
     def decode(self, label):
         """Decode *label*."""
         if not self.strict_decode:
-            return super(IDNA2003Codec, self).decode(label)
+            return super().decode(label)
         if label == b'':
             return ''
         try:
@@ -181,7 +181,7 @@ class IDNA2008Codec(IDNACodec):
         is done when decoding.  This can cause failures if the name
         was encoded with IDNA2003.  The default is False.
         """
-        super(IDNA2008Codec, self).__init__()
+        super().__init__()
         self.uts_46 = uts_46
         self.transitional = transitional
         self.allow_pure_ascii = allow_pure_ascii
@@ -203,7 +203,7 @@ class IDNA2008Codec(IDNACodec):
 
     def decode(self, label):
         if not self.strict_decode:
-            return super(IDNA2008Codec, self).decode(label)
+            return super().decode(label)
         if label == b'':
             return ''
         if not have_idna_2008:
@@ -300,7 +300,7 @@ def _maybe_convert_to_binary(label):
     raise ValueError
 
 
-class Name(object):
+class Name:
 
     """A DNS name.
 
@@ -316,7 +316,7 @@ class Name(object):
         """
 
         labels = [_maybe_convert_to_binary(x) for x in labels]
-        super(Name, self).__setattr__('labels', tuple(labels))
+        super().__setattr__('labels', tuple(labels))
         _validate_labels(self.labels)
 
     def __setattr__(self, name, value):
@@ -338,7 +338,7 @@ class Name(object):
         return {'labels': self.labels}
 
     def __setstate__(self, state):
-        super(Name, self).__setattr__('labels', state['labels'])
+        super().__setattr__('labels', state['labels'])
         _validate_labels(self.labels)
 
     def is_absolute(self):

--- a/dns/namedict.py
+++ b/dns/namedict.py
@@ -44,7 +44,7 @@ class NameDict(MutableMapping):
     __slots__ = ["max_depth", "max_depth_items", "__store"]
 
     def __init__(self, *args, **kwargs):
-        super(NameDict, self).__init__()
+        super().__init__()
         self.__store = dict()
         #: the maximum depth of the keys that have ever been added
         self.max_depth = 0

--- a/dns/node.py
+++ b/dns/node.py
@@ -24,7 +24,7 @@ import dns.rdatatype
 import dns.renderer
 
 
-class Node(object):
+class Node:
 
     """A Node is a set of rdatasets."""
 

--- a/dns/query.py
+++ b/dns/query.py
@@ -47,7 +47,7 @@ except ImportError:
 try:
     import ssl
 except ImportError:
-    class ssl(object):    # type: ignore
+    class ssl:    # type: ignore
 
         class WantReadException(Exception):
             pass
@@ -55,7 +55,7 @@ except ImportError:
         class WantWriteException(Exception):
             pass
 
-        class SSLSocket(object):
+        class SSLSocket:
             pass
 
         def create_default_context(self, *args, **kwargs):
@@ -78,7 +78,7 @@ class TransferError(dns.exception.DNSException):
 
     def __init__(self, rcode):
         message = 'Zone transfer error: %s' % dns.rcode.to_text(rcode)
-        super(TransferError, self).__init__(message)
+        super().__init__(message)
         self.rcode = rcode
 
 

--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -10,7 +10,7 @@ from requests.sessions import Session
 try:
     import ssl
 except ImportError:
-    class ssl(object):    # type: ignore
+    class ssl:    # type: ignore
         SSLContext : Dict = {}
 
 have_doh: bool

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -103,7 +103,7 @@ def _constify(o):
         return tuple(_constify(elt) for elt in o)
     return o
 
-class Rdata(object):
+class Rdata:
     """Base class for all DNS rdata types."""
 
     __slots__ = ['rdclass', 'rdtype']
@@ -340,7 +340,7 @@ class GenericRdata(Rdata):
     __slots__ = ['data']
 
     def __init__(self, rdclass, rdtype, data):
-        super(GenericRdata, self).__init__(rdclass, rdtype)
+        super().__init__(rdclass, rdtype)
         object.__setattr__(self, 'data', data)
 
     def to_text(self, origin=None, relativize=True, **kw):

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -58,14 +58,14 @@ class Rdataset(dns.set.Set):
         *ttl*, an ``int``, the TTL.
         """
 
-        super(Rdataset, self).__init__()
+        super().__init__()
         self.rdclass = rdclass
         self.rdtype = rdtype
         self.covers = covers
         self.ttl = ttl
 
     def _clone(self):
-        obj = super(Rdataset, self)._clone()
+        obj = super()._clone()
         obj.rdclass = self.rdclass
         obj.rdtype = self.rdtype
         obj.covers = self.covers
@@ -123,15 +123,15 @@ class Rdataset(dns.set.Set):
                 raise DifferingCovers
         if dns.rdatatype.is_singleton(rd.rdtype) and len(self) > 0:
             self.clear()
-        super(Rdataset, self).add(rd)
+        super().add(rd)
 
     def union_update(self, other):
         self.update_ttl(other.ttl)
-        super(Rdataset, self).union_update(other)
+        super().union_update(other)
 
     def intersection_update(self, other):
         self.update_ttl(other.ttl)
-        super(Rdataset, self).intersection_update(other)
+        super().intersection_update(other)
 
     def update(self, other):
         """Add all rdatas in other to self.
@@ -141,7 +141,7 @@ class Rdataset(dns.set.Set):
         """
 
         self.update_ttl(other.ttl)
-        super(Rdataset, self).update(other)
+        super().update(other)
 
     def _rdata_repr(self):
         def maybe_truncate(s):
@@ -170,7 +170,7 @@ class Rdataset(dns.set.Set):
            self.rdtype != other.rdtype or \
            self.covers != other.covers:
             return False
-        return super(Rdataset, self).__eq__(other)
+        return super().__eq__(other)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/dns/rdtypes/ANY/RP.py
+++ b/dns/rdtypes/ANY/RP.py
@@ -29,7 +29,7 @@ class RP(dns.rdata.Rdata):
     __slots__ = ['mbox', 'txt']
 
     def __init__(self, rdclass, rdtype, mbox, txt):
-        super(RP, self).__init__(rdclass, rdtype)
+        super().__init__(rdclass, rdtype)
         object.__setattr__(self, 'mbox', mbox)
         object.__setattr__(self, 'txt', txt)
 

--- a/dns/rdtypes/CH/A.py
+++ b/dns/rdtypes/CH/A.py
@@ -28,7 +28,7 @@ class A(dns.rdtypes.mxbase.MXBase):
     __slots__ = ['domain', 'address']
 
     def __init__(self, rdclass, rdtype, address, domain):
-        super(A, self).__init__(rdclass, rdtype, address, domain)
+        super().__init__(rdclass, rdtype, address, domain)
         object.__setattr__(self, 'domain', domain)
         object.__setattr__(self, 'address', address)
 

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -25,7 +25,7 @@ import dns.ipv6
 import dns.rdata
 import dns.tokenizer
 
-class APLItem(object):
+class APLItem:
 
     """An APL list item."""
 

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -32,7 +32,7 @@ AUTHORITY = 2
 ADDITIONAL = 3
 
 
-class Renderer(object):
+class Renderer:
     """Helper class for building DNS wire-format messages.
 
     Most applications can use the higher-level L{dns.message.Message}

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -66,7 +66,7 @@ class NXDOMAIN(dns.exception.DNSException):
 
     def __str__(self):
         if 'qnames' not in self.kwargs:
-            return super(NXDOMAIN, self).__str__()
+            return super().__str__()
         qnames = self.kwargs['qnames']
         if len(qnames) > 1:
             msg = 'None of DNS query names exist'
@@ -145,8 +145,7 @@ class NoAnswer(dns.exception.DNSException):
     supp_kwargs = {'response'}
 
     def _fmt_kwargs(self, **kwargs):
-        return super(NoAnswer, self)._fmt_kwargs(
-            query=kwargs['response'].question)
+        return super()._fmt_kwargs(query=kwargs['response'].question)
 
 
 class NoNameservers(dns.exception.DNSException):
@@ -167,8 +166,8 @@ class NoNameservers(dns.exception.DNSException):
         for err in kwargs['errors']:
             srv_msgs.append('Server {} {} port {} answered {}'.format(err[0],
                             'TCP' if err[1] else 'UDP', err[2], err[3]))
-        return super(NoNameservers, self)._fmt_kwargs(
-            query=kwargs['request'].question, errors='; '.join(srv_msgs))
+        return super()._fmt_kwargs(query=kwargs['request'].question,
+                                   errors='; '.join(srv_msgs))
 
 
 class NotAbsolute(dns.exception.DNSException):
@@ -185,7 +184,7 @@ class NoMetaqueries(dns.exception.DNSException):
 class NoResolverConfiguration(dns.exception.DNSException):
     """Resolver configuration could not be read or specified no nameservers."""
 
-class Answer(object):
+class Answer:
     """DNS stub resolver answer.
 
     Instances of this class bundle up the result of a successful DNS
@@ -286,7 +285,7 @@ class Answer(object):
         del self.rrset[i]
 
 
-class Cache(object):
+class Cache:
     """Simple thread-safe DNS answer cache."""
 
     def __init__(self, cleaning_interval=300.0):
@@ -363,7 +362,7 @@ class Cache(object):
                 self.next_cleaning = time.time() + self.cleaning_interval
 
 
-class LRUCacheNode(object):
+class LRUCacheNode:
     """LRUCache node."""
 
     def __init__(self, key, value):
@@ -389,7 +388,7 @@ class LRUCacheNode(object):
         self.prev.next = self.next
 
 
-class LRUCache(object):
+class LRUCache:
     """Thread-safe, bounded, least-recently-used DNS answer cache.
 
     This cache is better than the simple cache (above) if you're
@@ -486,7 +485,7 @@ class LRUCache(object):
                     node = next
                 self.data = {}
 
-class _Resolution(object):
+class _Resolution:
     """Helper class for dns.resolver.Resolver.resolve().
 
     All of the "business logic" of resolution is encapsulated in this
@@ -677,7 +676,7 @@ class _Resolution(object):
                                 dns.rcode.to_text(rcode), response))
             return (None, False)
 
-class Resolver(object):
+class Resolver:
     """DNS stub resolver."""
 
     # We initialize in reset()

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -41,12 +41,12 @@ class RRset(dns.rdataset.Rdataset):
                  deleting=None):
         """Create a new RRset."""
 
-        super(RRset, self).__init__(rdclass, rdtype, covers)
+        super().__init__(rdclass, rdtype, covers)
         self.name = name
         self.deleting = deleting
 
     def _clone(self):
-        obj = super(RRset, self)._clone()
+        obj = super()._clone()
         obj.name = self.name
         obj.deleting = self.deleting
         return obj
@@ -73,14 +73,14 @@ class RRset(dns.rdataset.Rdataset):
             return False
         if self.name != other.name:
             return False
-        return super(RRset, self).__eq__(other)
+        return super().__eq__(other)
 
     def match(self, name, rdclass, rdtype, covers, deleting=None):
         """Returns ``True`` if this rrset matches the specified class, type,
         covers, and deletion state.
         """
 
-        if not super(RRset, self).match(rdclass, rdtype, covers):
+        if not super().match(rdclass, rdtype, covers):
             return False
         if self.name != name or self.deleting != deleting:
             return False
@@ -103,8 +103,8 @@ class RRset(dns.rdataset.Rdataset):
         to *origin*.
         """
 
-        return super(RRset, self).to_text(self.name, origin, relativize,
-                                          self.deleting, **kw)
+        return super().to_text(self.name, origin, relativize,
+                               self.deleting, **kw)
 
     def to_wire(self, file, compress=None, origin=None, **kw):
         """Convert the RRset to wire format.
@@ -115,8 +115,8 @@ class RRset(dns.rdataset.Rdataset):
         Returns an ``int``, the number of records emitted.
         """
 
-        return super(RRset, self).to_wire(self.name, file, compress, origin,
-                                          self.deleting, **kw)
+        return super().to_wire(self.name, file, compress, origin,
+                               self.deleting, **kw)
 
     def to_rdataset(self):
         """Convert an RRset into an Rdataset.

--- a/dns/set.py
+++ b/dns/set.py
@@ -23,7 +23,7 @@ if sys.version_info >= (3, 7):
 else:
     from collections import OrderedDict as odict
 
-class Set(object):
+class Set:
 
     """A simple set class.
 

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -40,7 +40,7 @@ class UngetBufferFull(dns.exception.DNSException):
     """An attempt was made to unget a token when the unget buffer was full."""
 
 
-class Token(object):
+class Token:
     """A DNS master file format token.
 
     ttype: The token type
@@ -183,7 +183,7 @@ class Token(object):
         return Token(self.ttype, bytes(unescaped))
 
 
-class Tokenizer(object):
+class Tokenizer:
     """A DNS master file format tokenizer.
 
     A token object is basically a (type, value) tuple.  The valid

--- a/dns/trio/query.pyi
+++ b/dns/trio/query.pyi
@@ -9,7 +9,7 @@ from . import rdatatype, rdataclass, name, message
 try:
     import ssl
 except ImportError:
-    class ssl(object):    # type: ignore
+    class ssl:    # type: ignore
         SSLContext : Dict = {}
 
 def udp(q : message.Message, where : str, port=53,

--- a/dns/update.py
+++ b/dns/update.py
@@ -53,7 +53,7 @@ class Update(dns.message.Message):
 
         *keyalgorithm*, a ``dns.name.Name``, the TSIG algorithm to use.
         """
-        super(Update, self).__init__()
+        super().__init__()
         self.flags |= dns.opcode.to_flags(dns.opcode.UPDATE)
         if isinstance(zone, str):
             zone = dns.name.from_text(zone)
@@ -267,4 +267,4 @@ class Update(dns.message.Message):
 
         if origin is None:
             origin = self.origin
-        return super(Update, self).to_wire(origin, max_size)
+        return super().to_wire(origin, max_size)

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -56,7 +56,7 @@ class UnknownOrigin(BadZone):
     """The DNS zone's origin is unknown."""
 
 
-class Zone(object):
+class Zone:
 
     """A DNS zone.
 
@@ -636,7 +636,7 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
+class _MasterReader:
 
     """Read a DNS master file
 


### PR DESCRIPTION
Classes inherit from object by default; there's no need to explicitly
include this.

Replace super(Foo, self) with super().