### PR TITLE
Refactor OPT handling code into OPT record class.

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -561,11 +561,17 @@ class Message:
 
     @property
     def edns(self):
-        return ((self.ednsflags & 0xff0000) >> 16) if self.opt else -1
+        if self.opt:
+            return (self.ednsflags & 0xff0000) >> 16
+        else:
+            return -1
 
     @property
     def ednsflags(self):
-        return self.opt.ttl if self.opt else 0
+        if self.opt:
+            return self.opt.ttl
+        else:
+            return 0
 
     @ednsflags.setter
     def ednsflags(self, v):
@@ -576,11 +582,17 @@ class Message:
 
     @property
     def payload(self):
-        return self.opt[0].payload if self.opt else 0
+        if self.opt:
+            return self.opt[0].payload
+        else:
+            return 0
 
     @property
     def options(self):
-        return self.opt[0].options if self.opt else ()
+        if self.opt:
+            return self.opt[0].options
+        else:
+            return ()
 
     def want_dnssec(self, wanted=True):
         """Enable or disable 'DNSSEC desired' flag in requests.

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -229,41 +229,6 @@ class Rdataset(dns.set.Set):
         #
         return s.getvalue()[:-1]
 
-    @staticmethod
-    def rdata_to_wire(name, ttl, rdata, file, compress=None, origin=None,
-                      override_rdclass=None):
-        """Convert a single rdata to wire format, including the header.
-
-        *name*, a ``dns.name.Name`` is the owner name to use.
-
-        *file* is the file where the name is emitted (typically a
-        BytesIO file).
-
-        *compress*, a ``dict``, is the compression table to use.  If
-        ``None`` (the default), names will not be compressed.
-
-        *origin* is a ``dns.name.Name`` or ``None``.  If the name is
-        relative and origin is not ``None``, then *origin* will be appended
-        to it.
-
-        *override_rdclass*, an ``int``, is used as the class instead of the
-        class of the rdataset.  This is useful when rendering rdatasets
-        associated with dynamic updates.
-        """
-        if override_rdclass is not None:
-            rdclass = override_rdclass
-        else:
-            rdclass = rdata.rdclass
-        name.to_wire(file, compress, origin)
-        file.write(struct.pack("!HHIH", rdata.rdtype, rdclass, ttl, 0))
-        start = file.tell()
-        rdata.to_wire(file, compress, origin)
-        end = file.tell()
-        assert end - start < 65536
-        file.seek(start - 2)
-        file.write(struct.pack("!H", end - start))
-        file.seek(0, io.SEEK_END)
-
     def to_wire(self, name, file, compress=None, origin=None,
                 override_rdclass=None, want_shuffle=True):
         """Convert the rdataset to wire format.
@@ -308,8 +273,18 @@ class Rdataset(dns.set.Set):
             else:
                 l = self
             for rd in l:
-                self.rdata_to_wire(name, self.ttl, rd, file, compress, origin,
-                                   override_rdclass)
+                name.to_wire(file, compress, origin)
+                stuff = struct.pack("!HHIH", self.rdtype, rdclass,
+                                    self.ttl, 0)
+                file.write(stuff)
+                start = file.tell()
+                rd.to_wire(file, compress, origin)
+                end = file.tell()
+                assert end - start < 65536
+                file.seek(start - 2)
+                stuff = struct.pack("!H", end - start)
+                file.write(stuff)
+                file.seek(0, 2)
             return len(self)
 
     def match(self, rdclass, rdtype, covers):

--- a/dns/rdtypes/ANY/OPT.py
+++ b/dns/rdtypes/ANY/OPT.py
@@ -1,0 +1,71 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+# Copyright (C) 2001-2017 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import struct
+
+import dns.edns
+import dns.exception
+import dns.rdata
+
+
+class OPT(dns.rdata.Rdata):
+
+    """OPT record"""
+
+    __slots__ = ['options']
+
+    def __init__(self, rdclass, rdtype, options):
+        """Initialize an OPT rdata.
+
+        *rdclass*, an ``int`` is the rdataclass of the Rdata,
+        which is also the payload size.
+
+        *rdtype*, an ``int`` is the rdatatype of the Rdata.
+
+        *options*, a tuple of ``bytes``
+        """
+
+        super().__init__(rdclass, rdtype)
+        object.__setattr__(self, 'options', dns.rdata._constify(options))
+
+    def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
+        for opt in self.options:
+            owire = opt.to_wire()
+            file.write(struct.pack("!HH", opt.otype, len(owire)))
+            file.write(owire)
+
+    @classmethod
+    def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
+        options = []
+        while rdlen > 0:
+            if rdlen < 4:
+                raise dns.exception.FormError
+            (otype, olen) = struct.unpack('!HH', wire[current:current + 4])
+            current += 4
+            rdlen -= 4
+            if olen > rdlen:
+                raise dns.exception.FormError
+            opt = dns.edns.option_from_wire(otype, wire, current, olen)
+            current += olen
+            rdlen -= olen
+            options.append(opt)
+        return cls(rdclass, rdtype, options)
+
+    @property
+    def payload(self):
+        "payload size"
+        return self.rdclass

--- a/dns/rdtypes/ANY/OPT.py
+++ b/dns/rdtypes/ANY/OPT.py
@@ -48,6 +48,9 @@ class OPT(dns.rdata.Rdata):
             file.write(struct.pack("!HH", opt.otype, len(owire)))
             file.write(owire)
 
+    def to_text(self, origin=None, relativize=True, **kw):
+        return ' '.join(opt.to_text() for opt in self.options)
+
     @classmethod
     def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
         options = []

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -164,26 +164,14 @@ class Renderer:
                                  **kw)
         self.counts[section] += n
 
-    def add_rdata(self, section, name, ttl, rdata):
-        """Add the rdata to the specified section, using the specified
-        name as the owner name.
-        """
-
-        self._set_section(section)
-        with self._track_size():
-            dns.rdataset.Rdataset.rdata_to_wire(name, ttl, rdata,
-                                                self.output, self.compress,
-                                                self.origin)
-        self.counts[section] += 1
-
     def add_edns(self, edns, ednsflags, payload, options=None):
         """Add an EDNS OPT record to the message."""
 
         # make sure the EDNS version in ednsflags agrees with edns
         ednsflags &= 0xFF00FFFF
         ednsflags |= (edns << 16)
-        opt = dns.message.Message._make_opt(payload, options)
-        self.add_rdata(ADDITIONAL, dns.name.root, ednsflags, opt)
+        opt = dns.message.Message._make_opt(flags, payload, options)
+        self.add_rdataset(ADDITIONAL, dns.name.root, opt)
 
     def add_tsig(self, keyname, secret, fudge, id, tsig_error, other_data,
                  request_mac, algorithm=dns.tsig.default_algorithm):

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -170,7 +170,7 @@ class Renderer:
         # make sure the EDNS version in ednsflags agrees with edns
         ednsflags &= 0xFF00FFFF
         ednsflags |= (edns << 16)
-        opt = dns.message.Message._make_opt(flags, payload, options)
+        opt = dns.message.Message._make_opt(ednsflags, payload, options)
         self.add_rdataset(ADDITIONAL, dns.name.root, opt)
 
     def add_tsig(self, keyname, secret, fudge, id, tsig_error, other_data,

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -171,16 +171,9 @@ class Renderer:
 
         self._set_section(section)
         with self._track_size():
-            name.to_wire(self.output, self.compress, self.origin)
-            header = struct.pack("!HHIH", rdata.rdtype, rdata.rdclass, ttl, 0)
-            self.output.write(header)
-            start = self.output.tell()
-            rdata.to_wire(self.output, self.compress, self.origin)
-            end = self.output.tell()
-            assert end - start < 65536
-            self.output.seek(start - 2)
-            self.output.write(struct.pack("!H", end - start))
-            self.output.seek(0, io.SEEK_END)
+            dns.rdataset.Rdataset.rdata_to_wire(name, ttl, rdata,
+                                                self.output, self.compress,
+                                                self.origin)
         self.counts[section] += 1
 
     def add_edns(self, edns, ednsflags, payload, options=None):

--- a/dns/update.py
+++ b/dns/update.py
@@ -300,7 +300,7 @@ class UpdateMessage(dns.message.Message):
         # Updates are always one_rr_per_rrset
         return True
 
-    def _parse_rr_header(self, section, rdclass, rdtype):
+    def _parse_rr_header(self, section, name, rdclass, rdtype):
         deleting = None
         empty = False
         if section == UpdateSection.ZONE:


### PR DESCRIPTION
This creates a class corresponding to the OPT record, and moves option parsing/rendering from the message and renderer code into it.

It also fixes some minor bugs related to option parsing, where some length checks were missing.  Theoretically, this could have allowed invalid messages to parse in rare situations.