### PR TITLE
Add first class support for TSIG keys.

### DIFF
--- a/dns/rdtypes/ANY/TSIG.py
+++ b/dns/rdtypes/ANY/TSIG.py
@@ -1,0 +1,269 @@
+# Copyright (C) 2004-2007, 2009-2011 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import struct
+
+import dns.dnssec
+import dns.exception
+import dns.rdata
+
+
+class TSIG(dns.rdata.Rdata):
+    """
+    Implementation of the TSIG DNS message type, defined in RFC2845.
+
+    @ivar algorithm: the algorithm used for the key
+    @type algorithm: dns.name.Name object
+    @ivar time_signed: seconds since 1-Jan-70 UTC (*48bits*)
+    @type time_signed: int
+    @ivar fudge: seconds of error permitted in time signed
+    @type fudge: int
+    @ivar mac_size: number of octets in MAC
+    @type mac_size: int
+    @ivar mac: defined by Algorithm Name
+    @type mac: bytes
+    @ivar original_id: original message ID
+    @type original_id: int
+    @ivar error: expanded RCODE covering TSIG processing
+    @type error: int
+    @ivar other_len: length, in octets, of Other Data
+    @type other_len: int
+    @ivar other_data: empty unless Error == BADTIME
+    @type other_data: bytes"""
+
+    __slots__ = ['algorithm', 'time_signed', 'fudge', 'mac_size', 'mac',
+                 'original_id', 'error', 'other_len', 'other_data']
+
+    def __init__(self, rdclass, rdtype, algorithm, time_signed, fudge,
+                 mac_size, mac, original_id, error, other_len, other_data):
+        super().__init__(rdclass, rdtype)
+        object.__setattr__(self, 'algorithm', algorithm)
+        object.__setattr__(self, 'time_signed', time_signed)
+        object.__setattr__(self, 'fudge', fudge)
+        object.__setattr__(self, 'mac_size', mac_size)
+        object.__setattr__(self, 'mac', mac)
+        object.__setattr__(self, 'original_id', original_id)
+        object.__setattr__(self, 'error', error)
+        object.__setattr__(self, 'other_len', other_len)
+        if self.other_len > 65535:
+            raise ValueError('TSIG Other Data is > 65535 bytes')
+        object.__setattr__(self, 'other_data', other_data)
+
+    def to_text(self, origin=None, relativize=True, **kw):
+        _algorithm = self.algorithm.choose_relativity(origin, relativize)
+        return '%s %d %d %d %s %d %d %d %s' % (
+            str(_algorithm), self.time_signed, self.fudge, self.mac_size,
+            dns.rdata._base64ify(self.mac), self.original_id, self.error,
+            self.other_len, dns.rdata._base64ify(self.other_data))
+
+    @classmethod
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
+        algorithm = tok.get_name()
+        time_signed = tok.get_uint48()
+        fudge = tok.get_uint16()
+        mac_size = tok.get_uint16()
+        mac = bytearray(tok.get_string())
+        original_id = tok.get_uint16()
+        error = tok.get_uint16()
+        other_len = tok.get_uint16()
+        other_data = bytearray(tok.get_string())
+
+        return cls(rdclass, rdtype, algorithm, time_signed, fudge, mac_size,
+                   mac, original_id, error, other_len, other_data)
+
+    def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
+        self.algorithm.to_wire(file, compress, origin)
+        time_signed_long = self.time_signed + int(0)
+        upper_time = (time_signed_long >> 32) & int(0xffff)
+        lower_time = time_signed_long & int(0xffffffff)
+        file.write(struct.pack("!HIHH", upper_time, lower_time, self.fudge,
+                               self.mac_size))
+        file.write(self.mac)
+        file.write(struct.pack("!HHH", self.original_id, self.error,
+                               self.other_len))
+        file.write(self.other_data)
+
+    @classmethod
+    def from_wire(cls, rdclass, rdtype, wire, current, rdlen, origin=None):
+        # Field Name       Data Type      Notes
+        #       --------------------------------------------------------------
+        #       Algorithm Name   domain-name    Name of the algorithm
+        (algorithm, cused) = dns.name.from_wire(wire[: current + rdlen],
+                                                current)
+        if cused >= rdlen:
+            raise dns.exception.FormError
+        if origin is not None:
+            algorithm = algorithm.relativize(origin)
+        #       Time Signed      u_int48_t      seconds since 1-Jan-70 UTC.
+        current += cused
+        rdlen -= cused
+        (upper_time, lower_time) = struct.unpack("!HI",
+                                                 wire[current: current + 6])
+        time_signed = lower_time + (upper_time << 32)
+        current += 6
+        rdlen -= 6
+        #       Fudge            u_int16_t      seconds of error permitted
+        #                                       in Time Signed.
+        #       MAC Size         u_int16_t      number of octets in MAC.
+        (fudge, mac_size) = struct.unpack("!HH", wire[current: current + 4])
+        current += 4
+        rdlen -= 4
+        #       MAC              octet stream   defined by Algorithm Name.
+        mac = wire[current: current + mac_size]
+        current += mac_size
+        rdlen -= mac_size
+        #       Original ID      u_int16_t      original message ID
+        #       Error            u_int16_t      expanded RCODE covering
+        #                                       TSIG processing.
+        #       Other Len        u_int16_t      length, in octets, of
+        #                                       Other Data.
+        (original_id, error, other_len) = \
+            struct.unpack("!HHH", wire[current: current + 6])
+        current += 6
+        rdlen -= 6
+        #       Other Data       octet stream   empty unless Error == BADTIME
+        other_data = wire[current: current + other_len].unwrap()
+        current += other_len
+        rdlen -= other_len
+
+        return cls(rdclass, rdtype, algorithm, time_signed, fudge, mac_size,
+                   mac, original_id, error, other_len, other_data)
+
+    def build_digest_data(self, keyname, wire, request_mac, first):
+        """
+        This method builds the data needed to compute the TSIG; this is a
+        partial selection of the data in the message as defined in the RFC.
+
+        *keyname*, ``string`` name of the TSIG key used
+
+        *wire* ``binary`` wire representation of the message to be signed
+
+        *request_mac*, the ``binary`` representation of the MAC from the
+        original request if present
+
+        *first*, a ``bool`` defining if this message is the first message in a
+        longer sequence of DNS messages (per the RFC, the first/only message is
+        handled differently to the remainder)]
+
+        Returns the ``binary`` data to be digested
+        """
+        # some preliminary calculations
+        long_time = self.time_signed + int(0)
+        upper_time = (long_time >> 32) & int(0xffff)
+        lower_time = long_time & int(0xffffffff)
+        time_signed = struct.pack("!HI", upper_time, lower_time)
+
+        # construct the data required to create the TSIG; from RFC2845:
+        data = b''
+
+        # 4.1. TSIG generation on requests
+        #
+        # Client performs the message digest operation and appends a TSIG
+        # record to the additional data section and transmits the request to
+        # the server.  The client MUST store the message digest from the
+        # request while awaiting an answer.  The digest components for a
+        # request are:
+        #
+        #    DNS Message (request)
+        #    TSIG Variables (request)
+        #
+        # Note that some older name servers will not accept requests with a
+        # nonempty additional data section.  Clients SHOULD only attempt signed
+        # transactions with servers who are known to support TSIG and share
+        # some secret key with the client -- so, this is not a problem in
+        # practice.
+        #
+        # 4.2. TSIG on Answers
+        #
+        # When a server has generated a response to a signed request, it signs
+        # the response using the same algorithm and key.  The server MUST not
+        # generate a signed response to an unsigned request.  The digest
+        # components are:
+        #
+        #    Request MAC
+        #    DNS Message (response)
+        #    TSIG Variables (response)
+        #
+        # 4.3. TSIG on TSIG Error returns
+        #
+        # When a server detects an error relating to the key or MAC, the server
+        # SHOULD send back an unsigned error message (MAC size == 0 and empty
+        # MAC).  If an error is detected relating to the TSIG validity period,
+        # the server SHOULD send back a signed error message.  The digest
+        # components are:
+        #
+        #    Request MAC (if the request MAC validated)
+        #    DNS Message (response)
+        #    TSIG Variables (response)
+
+        if first:
+            # request mac if it exists
+            ml = len(request_mac)
+            if ml > 0:
+                data += struct.pack('!H', ml)
+                data += request_mac
+
+            # DNS message (minus the TSIG additional data section)
+            data += wire
+
+            # 3.4.2. TSIG Variables
+            #
+            # Source       Field Name      Notes
+            # ------------------------------------------------------------------
+            # TSIG RR      NAME            Key name, in canonical wire format
+            data += keyname.to_digestable()
+            # TSIG RR      CLASS           (Always ANY in the current spec)
+            data += struct.pack('!H', dns.rdataclass.ANY)
+            # TSIG RR      TTL             (Always 0 in the current spec)
+            data += struct.pack('!I', 0)
+            # TSIG RDATA   Algorithm Name  in canonical wire format
+            data += self.algorithm.to_digestable()
+            # TSIG RDATA   Time Signed     in network byte order
+            data += time_signed
+            # TSIG RDATA   Fudge           in network byte order
+            data += struct.pack("!H", self.fudge)
+            # TSIG RDATA   Error           in network byte order
+            data += struct.pack("!H", self.error)
+            # TSIG RDATA   Other Len       in network byte order
+            data += struct.pack("!H", self.other_len)
+            # TSIG RDATA   Other Data      exactly as transmitted
+            if self.other_len > 0:
+                data += self.other_data
+        else:
+            # 4.4. TSIG on TCP connection
+            #
+            # A DNS TCP session can include multiple DNS envelopes.  This is,
+            # fot example, commonly used by zone transfer.  Using TSIG on such a
+            # connection can protect the connection from hijacking and provide
+            # data integrity.  The TSIG MUST be included on the first and last
+            # DNS envelopes.  It can be optionally placed on any intermediary
+            # envelopes.  It is expensive to include it on every envelopes, but
+            # it MUST be placed on at least every 100'th envelope.  The first
+            # envelope is processed as a standard answer, and subsequent
+            # messages have the following digest components:
+            #
+            #    Prior Digest (running)
+            #    DNS Messages (any unsigned messages since the last TSIG)
+            #    TSIG Timers (current message)
+
+            # DNS message (minus the TSIG additional data section)
+            data += wire
+            # TSIG RDATA   Time Signed      in network byte order
+            data += time_signed
+            # TSIG RDATA   Fudge            in network byte order
+            data += struct.pack("!H", self.fudge)
+
+        # return the data to be signed
+        return data

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -529,7 +529,27 @@ class Tokenizer:
                 '%d is not an unsigned 32-bit integer' % value)
         return value
 
-    def get_string(self, max_length=None):
+    def get_uint48(self):
+        """Read the next token and interpret it as a 32-bit unsigned
+        integer.
+
+        Raises dns.exception.SyntaxError if not a 32-bit unsigned integer.
+
+        Returns an int.
+        """
+
+        token = self.get().unescape()
+        if not token.is_identifier():
+            raise dns.exception.SyntaxError('expecting an identifier')
+        if not token.value.isdigit():
+            raise dns.exception.SyntaxError('expecting an integer')
+        value = long(token.value)
+        if value < 0 or value > long(2^48 - 1):
+            raise dns.exception.SyntaxError(
+                '%d is not an unsigned 48-bit integer' % value)
+        return value
+
+    def get_string(self, max_length=None, origin=None):
         """Read the next token and interpret it as a string.
 
         Raises dns.exception.SyntaxError if not a string.

--- a/dns/tsig.py
+++ b/dns/tsig.py
@@ -17,13 +17,14 @@
 
 """DNS TSIG support."""
 
-import hashlib
-import hmac
 import struct
 
 import dns.exception
 import dns.rdataclass
 import dns.name
+from dns.rdtypes.ANY.TSIG import TSIG
+from dns.tsigtypes.tsigbase import TSIGBase
+
 
 class BadTime(dns.exception.DNSException):
 
@@ -33,6 +34,10 @@ class BadTime(dns.exception.DNSException):
 class BadSignature(dns.exception.DNSException):
 
     """The TSIG signature fails to verify."""
+
+
+class BadAlgorithm(dns.exception.DNSException):
+    """An unsupported TSIG algorithm was used."""
 
 
 class PeerError(dns.exception.DNSException):
@@ -59,35 +64,111 @@ class PeerBadTruncation(PeerError):
 
     """The peer didn't like amount of truncation in the TSIG we sent"""
 
-# TSIG Algorithms
 
-HMAC_MD5 = dns.name.from_text("HMAC-MD5.SIG-ALG.REG.INT")
-HMAC_SHA1 = dns.name.from_text("hmac-sha1")
-HMAC_SHA224 = dns.name.from_text("hmac-sha224")
-HMAC_SHA256 = dns.name.from_text("hmac-sha256")
-HMAC_SHA384 = dns.name.from_text("hmac-sha384")
-HMAC_SHA512 = dns.name.from_text("hmac-sha512")
-
-_hashes = {
-    HMAC_SHA224: hashlib.sha224,
-    HMAC_SHA256: hashlib.sha256,
-    HMAC_SHA384: hashlib.sha384,
-    HMAC_SHA512: hashlib.sha512,
-    HMAC_SHA1: hashlib.sha1,
-    HMAC_MD5: hashlib.md5,
-}
-
-default_algorithm = HMAC_SHA256
-
+# Error conditions
 BADSIG = 16
 BADKEY = 17
 BADTIME = 18
 BADTRUNC = 22
 
+# TSIG Module repository
+_tsig_modules = {}
+_module_prefix = 'dns.tsigtypes.algorithms'
 
-def sign(wire, keyname, secret, time, fudge, original_id, error,
-         other_data, request_mac, ctx=None, multi=False, first=True,
-         algorithm=default_algorithm):
+
+def get_algorithm(algorithm):
+    """Returns the wire format string and the hash module to use for the
+    specified TSIG algorithm.  Note - this only works for digest-style TSIGs
+    and is retained for backwards compatibility.
+
+    @rtype: (string, hash constructor)
+    @raises NotImplementedError: I{algorithm} is not supported
+    """
+
+    try:
+        tsig_class = get_tsig_class(algorithm)
+        return (
+            tsig_class.algorithm_name().to_digestable(),
+            tsig_class.algorithm_type()
+        )
+    except BadAlgorithm:
+        raise NotImplementedError("TSIG algorithm " + str(algorithm) +
+                                  " is not supported")
+
+
+def get_tsig_class(tsigtype):
+    """
+    Method to get the TSIG class for a particular type (similar approach as
+    for getting the class for a DNS RR type
+
+    *tsigtype*, a ``string`` with the TSIG type to be looked for
+
+    Returns a ``dns.tsigbase`` (derived class) for this TSIG type.
+    """
+    def import_module(name):
+        mod = __import__(name)
+        components = name.split('.')
+        for comp in components[1:]:
+            mod = getattr(mod, comp)
+        return mod
+
+    # get the type as text (minus the trailing dot)
+    if isinstance(tsigtype, str):
+        tsigtype_text = tsigtype
+    else:
+        tsigtype_text = tsigtype.to_text(True)
+
+    # lookup the TSIG type in the existing repository
+    cls = _tsig_modules.get(tsigtype_text)
+    if not cls:
+        # replace - with _ and split on the first dot; per RFC2845:
+        #
+        # 7 - IANA Considerations
+        #
+        #    IANA is expected to create and maintain a registry of algorithm
+        #    names to be used as "Algorithm Names" as defined in Section 2.3.
+        #    The initial value should be "HMAC-MD5.SIG-ALG.REG.INT".  Algorithm
+        #    names are text strings encoded using the syntax of a domain name.
+        #    There is no structure required other than names for different
+        #    algorithms must be unique when compared as DNS names, i.e.,
+        #    comparison is case insensitive.  Note that the initial value
+        #    mentioned above is not a domain name, and therefore need not be a
+        #    registered name within the DNS.  New algorithms are assigned using
+        #    the IETF Consensus policy defined in RFC 2434. The algorithm name
+        #    HMAC-MD5.SIG-ALG.REG.INT looks like a FQDN for historical reasons;
+        #    future algorithm names are expected to be simple (i.e.,
+        #    single-component) names.
+        tsigtype_text = tsigtype_text.replace('-', '_')
+        tsigtype_text = (tsigtype_text.split('.'))[0]
+        tsigtype_text = tsigtype_text.lower()
+
+        try:
+            mod = import_module(_module_prefix)
+            _tsig_modules[tsigtype_text] = getattr(mod, tsigtype_text)
+            cls = _tsig_modules[tsigtype_text]
+        except ImportError:
+            cls = TSIGBase
+        except AttributeError:
+            raise BadAlgorithm
+
+    return cls
+
+
+# TSIG Algorithms
+HMAC_MD5 = get_tsig_class("HMAC-MD5.SIG-ALG.REG.INT").algorithm_name()
+HMAC_SHA1 = get_tsig_class("hmac-sha512").algorithm_name()
+HMAC_SHA224 = get_tsig_class("hmac-sha512").algorithm_name()
+HMAC_SHA256 = get_tsig_class("hmac-sha512").algorithm_name()
+HMAC_SHA384 = get_tsig_class("hmac-sha512").algorithm_name()
+HMAC_SHA512 = get_tsig_class("hmac-sha512").algorithm_name()
+default_algorithm = HMAC_MD5
+
+
+# TSIG signature related methods
+def sign(wire, keyname, secret, time_signed, fudge, original_id, error,
+         other_data, request_mac, algorithm=default_algorithm, ctx=None,
+         multi=False, first=True):
+
     """Return a (tsig_rdata, mac, ctx) tuple containing the HMAC TSIG rdata
     for the input parameters, the HMAC MAC calculated by applying the
     TSIG signature algorithm, and the TSIG digest context.
@@ -95,133 +176,102 @@ def sign(wire, keyname, secret, time, fudge, original_id, error,
     @raises ValueError: I{other_data} is too long
     @raises NotImplementedError: I{algorithm} is not supported
     """
+    # look up the TSIG algorithm required
+    algorithm_class = get_tsig_class(algorithm)
 
-    if isinstance(other_data, str):
-        other_data = other_data.encode()
-    (algorithm_name, digestmod) = get_algorithm(algorithm)
+    # create the TSIG
+    tsig_rdata = TSIG(dns.rdataclass.ANY, dns.rdatatype.TSIG, algorithm,
+                      time_signed, fudge, 0, b'', original_id, error,
+                      len(other_data), other_data)
+
     if first:
-        ctx = hmac.new(secret, digestmod=digestmod)
-        ml = len(request_mac)
-        if ml > 0:
-            ctx.update(struct.pack('!H', ml))
-            ctx.update(request_mac)
-    id = struct.pack('!H', original_id)
-    ctx.update(id)
-    ctx.update(wire[2:])
-    if first:
-        ctx.update(keyname.to_digestable())
-        ctx.update(struct.pack('!H', dns.rdataclass.ANY))
-        ctx.update(struct.pack('!I', 0))
-    upper_time = (time >> 32) & 0xffff
-    lower_time = time & 0xffffffff
-    time_mac = struct.pack('!HIH', upper_time, lower_time, fudge)
-    pre_mac = algorithm_name + time_mac
-    ol = len(other_data)
-    if ol > 65535:
-        raise ValueError('TSIG Other Data is > 65535 bytes')
-    post_mac = struct.pack('!HH', error, ol) + other_data
-    if first:
-        ctx.update(pre_mac)
-        ctx.update(post_mac)
-    else:
-        ctx.update(time_mac)
-    mac = ctx.digest()
-    mpack = struct.pack('!H', len(mac))
-    tsig_rdata = pre_mac + mpack + mac + id + post_mac
+        # first message in a multi-part sequence or single message; construct
+        # the required context and encode the request mac if it exists
+        ctx = algorithm_class(secret)
+
+    # build the digest data
+    data = tsig_rdata.build_digest_data(keyname, wire, request_mac, first)
+
+    # record the data and sign
+    ctx.update(data)
+    object.__setattr__(tsig_rdata, 'mac', ctx.sign())
+    object.__setattr__(tsig_rdata, 'mac_size', len(tsig_rdata.mac))
+
+    # record items for future multi-message processing
+    # TODO - what about the last message in a sequence?  Must it contain
+    #        a full TSIG?
     if multi:
-        ctx = hmac.new(secret, digestmod=digestmod)
-        ml = len(mac)
-        ctx.update(struct.pack('!H', ml))
-        ctx.update(mac)
+        # message in a multi-message sequence
+        ctx = algorithm_class(secret)
+        mac_len = len(tsig_rdata.mac)
+        ctx.update(struct.pack('!H', mac_len))
+        ctx.update(tsig_rdata.mac)
     else:
         ctx = None
-    return (tsig_rdata, mac, ctx)
+
+    return tsig_rdata, ctx
 
 
-def validate(wire, keyname, secret, now, request_mac, tsig_start, tsig_rdata,
-             tsig_rdlen, ctx=None, multi=False, first=True):
-    """Validate the specified TSIG rdata against the other input parameters.
+def validate(wire, tsig_start, tsig_rdlen, message_wire, keyname, secret,
+             request_mac, error, now, ctx=None, first=True, multi=False):
+    # build TSIG
+    tsig_rdata = TSIG.from_wire(dns.rdataclass.ANY, dns.rdatatype.TSIG,
+                                wire, tsig_start, tsig_rdlen)
 
-    @raises FormError: The TSIG is badly formed.
-    @raises BadTime: There is too much time skew between the client and the
-    server.
-    @raises BadSignature: The TSIG signature did not validate
-    @rtype: hmac.HMAC object"""
-
-    (adcount,) = struct.unpack("!H", wire[10:12])
-    if adcount == 0:
-        raise dns.exception.FormError
-    adcount -= 1
-    new_wire = wire[0:10] + struct.pack("!H", adcount) + wire[12:tsig_start]
-    current = tsig_rdata
-    (aname, used) = dns.name.from_wire(wire, current)
-    current = current + used
-    (upper_time, lower_time, fudge, mac_size) = \
-        struct.unpack("!HIHH", wire[current:current + 10])
-    time = (upper_time << 32) + lower_time
-    current += 10
-    mac = wire[current:current + mac_size]
-    current += mac_size
-    (original_id, error, other_size) = \
-        struct.unpack("!HHH", wire[current:current + 6])
-    current += 6
-    other_data = wire[current:current + other_size]
-    current += other_size
-    if current != tsig_rdata + tsig_rdlen:
-        raise dns.exception.FormError
-    if error != 0:
-        if error == BADSIG:
+    # check errors
+    if tsig_rdata.error != 0:
+        if tsig_rdata.error == BADSIG:
             raise PeerBadSignature
-        elif error == BADKEY:
+        elif tsig_rdata.error == BADKEY:
             raise PeerBadKey
-        elif error == BADTIME:
+        elif tsig_rdata.error == BADTIME:
             raise PeerBadTime
-        elif error == BADTRUNC:
+        elif tsig_rdata.error == BADTRUNC:
             raise PeerBadTruncation
         else:
             raise PeerError('unknown TSIG error code %d' % error)
-    time_low = time - fudge
-    time_high = time + fudge
+
+    # adjust time for fudge and error check
+    time_low = tsig_rdata.time_signed - tsig_rdata.fudge
+    time_high = tsig_rdata.time_signed + tsig_rdata.fudge
+
     if now < time_low or now > time_high:
-        raise BadTime
-    (junk, our_mac, ctx) = sign(new_wire, keyname, secret, time, fudge,
-                                original_id, error, other_data,
-                                request_mac, ctx, multi, first, aname)
-    if our_mac != mac:
-        raise BadSignature
-    return ctx
+        raise dns.exception.BadTime
+
+    # look up the TSIG algorithm implementation
+    algorithm_class = get_tsig_class(tsig_rdata.algorithm)
+
+    # verify TSIG, return the context or throw exception
+    if first:
+        # first message in a multi-part sequence or single message; construct
+        # the required context and encode the request mac if it exists
+        ctx = algorithm_class(secret)
+
+    # build the digest data
+    data = tsig_rdata.build_digest_data(keyname, message_wire,
+                                        request_mac, first)
+    # record the data and verify the mac
+    ctx.update(data)
+    ctx.verify(tsig_rdata.mac)
+
+    if multi:
+        # message in a multi-message sequence
+        ctx = algorithm_class(secret)
+        mac_len = len(tsig_rdata.mac)
+        ctx.update(struct.pack('!H', mac_len))
+        ctx.update(tsig_rdata.mac)
+    else:
+        ctx = None
+
+    return tsig_rdata, ctx
 
 
-def get_algorithm(algorithm):
-    """Returns the wire format string and the hash module to use for the
-    specified TSIG algorithm
-
-    @rtype: (string, hash constructor)
-    @raises NotImplementedError: I{algorithm} is not supported
-    """
-
-    if isinstance(algorithm, str):
-        algorithm = dns.name.from_text(algorithm)
-
-    try:
-        return (algorithm.to_digestable(), _hashes[algorithm])
-    except KeyError:
-        raise NotImplementedError("TSIG algorithm " + str(algorithm) +
-                                  " is not supported")
+def build_tsig_message_wire(wire, adcount, tsig_start):
+    return wire[0:10] + struct.pack("!H", adcount) + wire[12:tsig_start]
 
 
-def get_algorithm_and_mac(wire, tsig_rdata, tsig_rdlen):
-    """Return the tsig algorithm for the specified tsig_rdata
-    @raises FormError: The TSIG is badly formed.
-    """
-    current = tsig_rdata
-    (aname, used) = dns.name.from_wire(wire, current)
-    current = current + used
-    (upper_time, lower_time, fudge, mac_size) = \
-        struct.unpack("!HIHH", wire[current:current + 10])
-    current += 10
-    mac = wire[current:current + mac_size]
-    current += mac_size
-    if current > tsig_rdata + tsig_rdlen:
-        raise dns.exception.FormError
-    return (aname, mac)
+def hmac_md5(wire, keyname, secret, time, fudge, original_id, error,
+             other_data, request_mac, ctx=None, multi=False, first=True,
+             algorithm=default_algorithm):
+    return sign(wire, keyname, secret, time, fudge, original_id, error,
+                other_data, request_mac, ctx, multi, first, algorithm)

--- a/dns/tsigtypes/algorithms.py
+++ b/dns/tsigtypes/algorithms.py
@@ -1,0 +1,80 @@
+import hashlib
+
+from dns.tsigtypes.tsigbase import TSIGBase, TSIGContext
+from dns.tsigtypes.hmacbase import HMACBase
+
+
+class hmac_md5(HMACBase):
+    """
+    MD5 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "HMAC-MD5.SIG-ALG.REG.INT"
+    _algorithm_type = hashlib.md5
+
+
+class hmac_sha1(HMACBase):
+    """
+    SHA1 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "hmac-sha1"
+    _algorithm_type = hashlib.sha1
+
+
+class hmac_sha224(HMACBase):
+    """
+    SHA224 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "hmac-sha224"
+    _algorithm_type = hashlib.sha224
+
+
+class hmac_sha256(HMACBase):
+    """
+    SHA256 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "hmac-sha256"
+    _algorithm_type = hashlib.sha256
+
+
+class hmac_sha384(HMACBase):
+    """
+    SHA384 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "hmac-sha384"
+    _algorithm_type = hashlib.sha384
+
+
+class hmac_sha512(HMACBase):
+    """
+    SHA512 HMAC Algorithm.  See :ref:`HMACBase` for the remaining documentation.
+    """
+    _algorithm_name = "hmac-sha512"
+    _algorithm_type = hashlib.sha512
+
+
+class gss_tsig(TSIGBase):
+    """
+    GSS-TSIG TSIG implementation.  Note that as this isn't a digest-based
+    algorithm, this has TSIGBase as the parent.  This uses the GSS-API context
+    established in the TKEY message handshake to sign messages using GSS-API
+    message integrity codes, per the RFC.
+
+    Note there is an implicit dependency here on the Python GSSAPI package,
+    although not specified, to run the get/verify signature methods.
+    """
+    _algorithm_name = "gss-tsig"
+    _algorithm_type = None
+
+    def __init__(self, gssapi):
+        super().__init__(TSIGContext(gssapi, b''))
+
+    def update(self, data):
+        self.ctx.data += data
+
+    def sign(self):
+        # defer to the GSSAPI function to sign
+        return self.ctx.impl.get_signature(self.ctx.data)
+
+    def verify(self, mac):
+        # defer to the GSSAPI function to verify
+        return self.ctx.impl.verify_signature(self.ctx.data, mac)

--- a/dns/tsigtypes/hmacbase.py
+++ b/dns/tsigtypes/hmacbase.py
@@ -1,0 +1,55 @@
+import hmac
+
+import dns.name
+from dns.tsigtypes.tsigbase import TSIGBase, TSIGContext
+from dns.tsig import BadSignature
+
+
+class HMACBase(TSIGBase):
+    """
+    Base class for HMAC style algorithms.  Each child class calls the
+    constructor with the right strings to map the digest module and algorithm.
+    """
+    def __init__(self, secret):
+        _type = type(self).algorithm_type()
+        super().__init__(
+            TSIGContext(_type, hmac.new(secret, digestmod=_type))
+        )
+
+    def update(self, data):
+        """
+        Method to update the data that will be digested - this is effectively
+        an accumulator.
+
+        *data*, a ``binary``, is the data to be added to the accumulator to be
+        digested.
+
+        Returns nothing.
+        """
+        self.ctx.data.update(data)
+
+    def sign(self):
+        """
+        Method to sign a particular set of data that is in the accumulator
+        using the digest algorithm chosen.
+
+        Returns a signature in ``binary``.
+        """
+        return self.ctx.data.digest()
+
+    def verify(self, mac):
+        """
+        Method to verify a previously signed piece of data.  In the case
+        of HMAC style algorithms, this is just a case of signing the same
+        dataset from the DNS message and comparing the signatures.
+
+        *mac, a ``binary`` which is the signature from the message to be
+        verified.
+
+        Returns nothing; throw ``dns.exception.BadSignature`` exception on
+        error.
+        """
+        new_mac = self.ctx.data.digest()
+        if new_mac != mac:
+            raise BadSignature
+        return

--- a/dns/tsigtypes/tsigbase.py
+++ b/dns/tsigtypes/tsigbase.py
@@ -1,0 +1,86 @@
+import dns.name
+
+
+class TSIGContext:
+    """
+    Class containing TSIG context for TSIG algorithm being used
+    """
+    def __init__(self, impl, data):
+        self._impl = impl
+        self._data = data
+
+    @property
+    def impl(self):
+        return self._impl
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, _data):
+        self._data = _data
+
+
+class TSIGBase:
+    """
+    Abstract base class for TSIG algorithms - sub classes are expected to
+    implement the various methods (no actual code here)
+    """
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    @classmethod
+    def algorithm_name(cls):
+        """
+        Get the algorithm name for the TSIG.
+
+        Returns name of algorithm in ``dns.name`` format.
+        """
+        return dns.name.from_text(cls._algorithm_name)
+
+    @classmethod
+    def algorithm_type(cls):
+        """
+        Get the algorithm type for the TSIG - note, only applies to HMAC types.
+
+        Returns type of algorithm.
+        """
+        return cls._algorithm_type
+
+    def update(self, data):
+        """
+        Method to update the data that will be signed - this is effectively
+        an accumulator.
+
+        *data*, a ``binary``, is the data to be added to the accumulator to be
+        signed.
+
+        Returns nothing.
+        """
+        raise NotImplementedError
+
+    def sign(self):
+        """
+        Method to sign a particular set of data that is in the accumulator
+        using the algorithm chosen.
+
+        Returns a signature in ``binary``.
+        """
+        raise NotImplementedError
+
+    def verify(self, mac):
+        """
+        Method to verify a previously signed piece of data.
+
+        *mac, a ``binary`` which is the signature from the message to be
+        verified.
+
+        Returns nothing; throw ``dns.exception.BadSignature`` exception on
+        error.
+        """
+        raise NotImplementedError
+
+    @property
+    def ctx(self):
+        return self._ctx


### PR DESCRIPTION
This PR adds first class support for TSIG keys, including gss-tsig.

The different implementation for gss-tsig this has led to a need to split out the HMAC-style tsig types into a real class hierarchy to allow for a different implementation for gss-tsig.  In particular, note the new 'TSIGContext' object which passes context for the TSIG while it's being calculated - for the HMAC types, this is just the hmac object; for the GSS-tsig type, this is the accumulated data to be signed, and an opaque gssapi implementation object which allows for this to be unit tested without requiring actual Kerberos infrastructure (although we should probably have a real integration test for this case).

- new TSIG RR type
- move existing algorithms over to new structure
- add GSS-TSIG TSIG type
- write/update tests

Based on prior feedback, I've come up with a lighter weight way to represent the various algorithm classes while still getting the advantage of them being full classes.
