### PR TITLE
Add dns.tsig.Key class.

### DIFF
--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -179,10 +179,14 @@ class Renderer:
 
         s = self.output.getvalue()
 
+        if isinstance(secret, dns.tsig.Key):
+            key = secret
+        else:
+            key = dns.tsig.Key(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
-        (tsig, _) = dns.tsig.sign(s, keyname, tsig[0], secret,
-                                  int(time.time()), request_mac)
+        (tsig, _) = dns.tsig.sign(s, key, tsig[0], int(time.time()),
+                                  request_mac)
         self._write_tsig(tsig, keyname)
 
     def add_multi_tsig(self, ctx, keyname, secret, fudge, id, tsig_error,
@@ -198,11 +202,14 @@ class Renderer:
 
         s = self.output.getvalue()
 
+        if isinstance(secret, dns.tsig.Key):
+            key = secret
+        else:
+            key = dns.tsig.Key(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
-        (tsig, ctx) = dns.tsig.sign(s, keyname, tsig[0], secret,
-                                    int(time.time()), request_mac,
-                                    ctx, True)
+        (tsig, ctx) = dns.tsig.sign(s, key, tsig[0], int(time.time()),
+                                    request_mac, ctx, True)
         self._write_tsig(tsig, keyname)
         return ctx
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1111,29 +1111,14 @@ class Resolver:
 
     def use_tsig(self, keyring, keyname=None,
                  algorithm=dns.tsig.default_algorithm):
-        """Add a TSIG signature to the query.
+        """Add a TSIG signature to each query.
 
-        See the documentation of the Message class for a complete
-        description of the keyring dictionary.
-
-        *keyring*, a ``dict``, the TSIG keyring to use.  If a
-        *keyring* is specified but a *keyname* is not, then the key
-        used will be the first key in the *keyring*.  Note that the
-        order of keys in a dictionary is not defined, so applications
-        should supply a keyname when a keyring is used, unless they
-        know the keyring contains only one key.
-
-        *keyname*, a ``dns.name.Name`` or ``None``, the name of the TSIG key
-        to use; defaults to ``None``. The key must be defined in the keyring.
-
-        *algorithm*, a ``dns.name.Name``, the TSIG algorithm to use.
+        The parameters are passed to ``dns.message.Message.use_tsig()``;
+        see its documentation for details.
         """
 
         self.keyring = keyring
-        if keyname is None:
-            self.keyname = list(self.keyring.keys())[0]
-        else:
-            self.keyname = keyname
+        self.keyname = keyname
         self.keyalgorithm = algorithm
 
     def use_edns(self, edns, ednsflags, payload):

--- a/dns/tsig.py
+++ b/dns/tsig.py
@@ -209,6 +209,8 @@ class Key:
         if isinstance(secret, str):
             secret = base64.decodebytes(secret.encode())
         self.secret = secret
+        if isinstance(algorithm, str):
+            algorithm = dns.name.from_text(algorithm)
         self.algorithm = algorithm
 
     def __eq__(self, other):

--- a/dns/tsig.py
+++ b/dns/tsig.py
@@ -106,7 +106,7 @@ def sign(wire, key, rdata, time=None, request_mac=None, ctx=None, multi=False):
     """
 
     first = not (ctx and multi)
-    (algorithm_name, digestmod) = get_algorithm(rdata.algorithm)
+    (algorithm_name, digestmod) = get_algorithm(key.algorithm)
     if first:
         ctx = hmac.new(key.secret, digestmod=digestmod)
         if request_mac:
@@ -139,7 +139,7 @@ def sign(wire, key, rdata, time=None, request_mac=None, ctx=None, multi=False):
     else:
         ctx = None
     tsig = dns.rdtypes.ANY.TSIG.TSIG(dns.rdataclass.ANY, dns.rdatatype.TSIG,
-                                     rdata.algorithm, time, rdata.fudge, mac,
+                                     key.algorithm, time, rdata.fudge, mac,
                                      rdata.original_id, rdata.error,
                                      rdata.other)
 

--- a/dns/update.py
+++ b/dns/update.py
@@ -60,18 +60,8 @@ class UpdateMessage(dns.message.Message):
 
         *rdclass*, an ``int`` or ``str``, the class of the zone.
 
-        *keyring*, a ``dict``, the TSIG keyring to use.  If a
-        *keyring* is specified but a *keyname* is not, then the key
-        used will be the first key in the *keyring*.  Note that the
-        order of keys in a dictionary is not defined, so applications
-        should supply a keyname when a keyring is used, unless they
-        know the keyring contains only one key.
-
-        *keyname*, a ``dns.name.Name`` or ``None``, the name of the TSIG key
-        to use; defaults to ``None``. The key must be defined in the keyring.
-
-        *keyalgorithm*, a ``dns.name.Name``, the TSIG algorithm to use.
-
+        The *keyring*, *keyname*, and *keyalgorithm* parameters are passed to
+        ``use_tsig()``; see its documentation for details.
         """
         super().__init__(id=id)
         self.flags |= dns.opcode.to_flags(dns.opcode.UPDATE)

--- a/doc/message-class.rst
+++ b/doc/message-class.rst
@@ -47,9 +47,7 @@ DNS opcodes that do not have a more specific class.
 
    .. attribute:: keyring
 
-      The TSIG keyring to use.  The default is `None`.  A TSIG keyring
-      is a dictionary mapping from TSIG key name, a ``dns.name.Name``, to
-      a TSIG secret, a ``bytes``.
+      A ``dns.tsig.Key``, the TSIG key.  The default is None.
 
    .. attribute:: keyname
 

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -197,11 +197,11 @@ class ResolutionTestCase(unittest.TestCase):
         self.resolver.keyring = dns.tsigkeyring.from_text({
             'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
         })
+        key = next(iter(self.resolver.keyring.values()))
         self.resolver.keyname = dns.name.from_text('keyname.')
         (request, answer) = self.resn.next_request()
         self.assertFalse(request is None)
-        self.assertEqual(request.keyring, self.resolver.keyring)
-        self.assertEqual(request.keyname, self.resolver.keyname)
+        self.assertEqual(request.keyring, key)
 
     def test_next_request_flags(self):
         self.resolver.flags = dns.flags.RD | dns.flags.CD

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -197,11 +197,12 @@ class ResolutionTestCase(unittest.TestCase):
         self.resolver.keyring = dns.tsigkeyring.from_text({
             'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
         })
-        key = next(iter(self.resolver.keyring.values()))
+        (keyname, secret) = next(iter(self.resolver.keyring.items()))
         self.resolver.keyname = dns.name.from_text('keyname.')
         (request, answer) = self.resn.next_request()
         self.assertFalse(request is None)
-        self.assertEqual(request.keyring, key)
+        self.assertEqual(request.keyring.name, keyname)
+        self.assertEqual(request.keyring.secret, secret)
 
     def test_next_request_flags(self):
         self.resolver.flags = dns.flags.RD | dns.flags.CD

--- a/tests/test_tsigkeyring.py
+++ b/tests/test_tsigkeyring.py
@@ -10,12 +10,12 @@ text_keyring = {
     'keyname.' : ('hmac-sha256.', 'NjHwPsMKjdN++dOfE5iAiQ==')
 }
 
-old_text_keyring = {
-    'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
-}
-
 alt_text_keyring = {
     'keyname.' : (dns.tsig.HMAC_SHA256, 'NjHwPsMKjdN++dOfE5iAiQ==')
+}
+
+old_text_keyring = {
+    'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
 }
 
 key = dns.tsig.Key('keyname.', 'NjHwPsMKjdN++dOfE5iAiQ==')
@@ -31,15 +31,15 @@ class TSIGKeyRingTestCase(unittest.TestCase):
         rkeyring = dns.tsigkeyring.from_text(text_keyring)
         self.assertEqual(rkeyring, rich_keyring)
 
-    def test_from_old_text(self):
-        """old format text keyring -> rich keyring"""
-        rkeyring = dns.tsigkeyring.from_text(old_text_keyring)
-        self.assertEqual(rkeyring, rich_keyring)
-
     def test_from_alt_text(self):
         """alternate format text keyring -> rich keyring"""
         rkeyring = dns.tsigkeyring.from_text(alt_text_keyring)
         self.assertEqual(rkeyring, rich_keyring)
+
+    def test_from_old_text(self):
+        """old format text keyring -> rich keyring"""
+        rkeyring = dns.tsigkeyring.from_text(old_text_keyring)
+        self.assertEqual(rkeyring, old_rich_keyring)
 
     def test_to_text(self):
         """text keyring -> rich keyring -> text keyring"""
@@ -49,10 +49,16 @@ class TSIGKeyRingTestCase(unittest.TestCase):
     def test_old_to_text(self):
         """text keyring -> rich keyring -> text keyring"""
         tkeyring = dns.tsigkeyring.to_text(old_rich_keyring)
-        self.assertEqual(tkeyring, text_keyring)
+        self.assertEqual(tkeyring, old_text_keyring)
 
     def test_from_and_to_text(self):
         """text keyring -> rich keyring -> text keyring"""
         rkeyring = dns.tsigkeyring.from_text(text_keyring)
         tkeyring = dns.tsigkeyring.to_text(rkeyring)
         self.assertEqual(tkeyring, text_keyring)
+
+    def test_old_from_and_to_text(self):
+        """text keyring -> rich keyring -> text keyring"""
+        rkeyring = dns.tsigkeyring.from_text(old_text_keyring)
+        tkeyring = dns.tsigkeyring.to_text(rkeyring)
+        self.assertEqual(tkeyring, old_text_keyring)

--- a/tests/test_tsigkeyring.py
+++ b/tests/test_tsigkeyring.py
@@ -3,16 +3,26 @@
 import base64
 import unittest
 
+import dns.tsig
 import dns.tsigkeyring
 
 text_keyring = {
+    'keyname.' : ('hmac-sha256.', 'NjHwPsMKjdN++dOfE5iAiQ==')
+}
+
+old_text_keyring = {
     'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
 }
 
-rich_keyring = {
-    dns.name.from_text('keyname.') : \
-    base64.decodebytes('NjHwPsMKjdN++dOfE5iAiQ=='.encode())
+alt_text_keyring = {
+    'keyname.' : (dns.tsig.HMAC_SHA256, 'NjHwPsMKjdN++dOfE5iAiQ==')
 }
+
+key = dns.tsig.Key('keyname.', 'NjHwPsMKjdN++dOfE5iAiQ==')
+
+rich_keyring = { key.name : key }
+
+old_rich_keyring = { key.name : key.secret }
 
 class TSIGKeyRingTestCase(unittest.TestCase):
 
@@ -21,9 +31,24 @@ class TSIGKeyRingTestCase(unittest.TestCase):
         rkeyring = dns.tsigkeyring.from_text(text_keyring)
         self.assertEqual(rkeyring, rich_keyring)
 
+    def test_from_old_text(self):
+        """old format text keyring -> rich keyring"""
+        rkeyring = dns.tsigkeyring.from_text(old_text_keyring)
+        self.assertEqual(rkeyring, rich_keyring)
+
+    def test_from_alt_text(self):
+        """alternate format text keyring -> rich keyring"""
+        rkeyring = dns.tsigkeyring.from_text(alt_text_keyring)
+        self.assertEqual(rkeyring, rich_keyring)
+
     def test_to_text(self):
         """text keyring -> rich keyring -> text keyring"""
         tkeyring = dns.tsigkeyring.to_text(rich_keyring)
+        self.assertEqual(tkeyring, text_keyring)
+
+    def test_old_to_text(self):
+        """text keyring -> rich keyring -> text keyring"""
+        tkeyring = dns.tsigkeyring.to_text(old_rich_keyring)
         self.assertEqual(tkeyring, text_keyring)
 
     def test_from_and_to_text(self):


### PR DESCRIPTION
This creates a new class to represent a TSIG key, containing name,
secret, and algorithm.

The keyring format is changed to be {name : key}, and the methods in
dns.tsigkeyring are updated to deal with old and new formats.

The Message class is updated to use dns.tsig.Key, although (to avoid
breaking existing code), it stores them in the keyring field.

Message.use_tsig() can accept either explicit keys, or keyrings; it will
extract and/or create a key.

dns.message.from_wire() can accept either a key or a keyring in the
keyring parameter.  If passed a key, it will now raise if the TSIG
record in the message was signed with a different key.  If passed a
keyring containing keys (as opposed to bare secrets), it will check that
the TSIG record's algorithm matches that of the key.