### PR TITLE
Add support for gss-tsig and TKEY records to support GSSAPI authentication

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -488,8 +488,8 @@ class Message:
         *key*, a ``dns.tsig.Key`` is the key to use.  If a key is specified,
         the *keyring* and *algorithm* fields are not used.
 
-        *keyring*, a ``dict`` or ``dns.tsig.Key``, is either the TSIG
-        keyring or key to use.
+        *keyring*, a ``dict``, ``callable`` or ``dns.tsig.Key``, is either
+        the TSIG keyring or key to use.
 
         The format of a keyring dict is a mapping from TSIG key name, as
         ``dns.name.Name`` to ``dns.tsig.Key`` or a TSIG secret, a ``bytes``.
@@ -497,7 +497,9 @@ class Message:
         used will be the first key in the *keyring*.  Note that the order of
         keys in a dictionary is not defined, so applications should supply a
         keyname when a ``dict`` keyring is used, unless they know the keyring
-        contains only one key.
+        contains only one key.  If a ``callable`` keyring is specified, the
+        callable will be called with the message and the keyname, and is
+        expected to return a key.
 
         *keyname*, a ``dns.name.Name``, ``str`` or ``None``, the name of
         thes TSIG key to use; defaults to ``None``.  If *keyring* is a
@@ -519,6 +521,8 @@ class Message:
 
         if isinstance(keyring, dns.tsig.Key):
             self.keyring = keyring
+        elif callable(keyring):
+            self.keyring = keyring(self, keyname)
         else:
             if isinstance(keyname, str):
                 keyname = dns.name.from_text(keyname)
@@ -920,6 +924,8 @@ class _WireReader:
                     key = self.keyring.get(absolute_name)
                     if isinstance(key, bytes):
                         key = dns.tsig.Key(absolute_name, key, rd.algorithm)
+                elif callable(self.keyring):
+                    key = self.keyring(self.message, absolute_name)
                 else:
                     key = self.keyring
                 if key is None:

--- a/dns/message.py
+++ b/dns/message.py
@@ -424,8 +424,8 @@ class Message:
         *multi*, a ``bool``, should be set to ``True`` if this message is
         part of a multiple message sequence.
 
-        *tsig_ctx*, a ``hmac.HMAC`` object, the ongoing TSIG context, used
-        when signing zone transfers.
+        *tsig_ctx*, a ``dns.tsig.HMACTSig`` or ``dns.tsig.GSSTSig`` object, the
+        ongoing TSIG context, used when signing zone transfers.
 
         Raises ``dns.exception.TooBig`` if *max_size* was exceeded.
 
@@ -994,8 +994,8 @@ def from_wire(wire, keyring=None, request_mac=b'', xfr=False, origin=None,
     of a zone transfer, *origin* should be the origin name of the
     zone.  If not ``None``, names will be relativized to the origin.
 
-    *tsig_ctx*, a ``hmac.HMAC`` object, the ongoing TSIG context, used
-    when validating zone transfers.
+    *tsig_ctx*, a ``dns.tsig.HMACTSig`` or ``dns.tsig.GSSTSig`` object, the
+    ongoing TSIG context, used when validating zone transfers.
 
     *multi*, a ``bool``, should be set to ``True`` if this message is
     part of a multiple message sequence.

--- a/dns/message.pyi
+++ b/dns/message.pyi
@@ -33,7 +33,7 @@ def from_text(a : str, idna_codec : Optional[name.IDNACodec] = None) -> Message:
     ...
 
 def from_wire(wire, keyring : Optional[Dict[name.Name,bytes]] = None, request_mac = b'', xfr=False, origin=None,
-              tsig_ctx : Optional[hmac.HMAC] = None, multi=False,
+              tsig_ctx : Optional[Union[dns.tsig.HMACTSig, dns.tsig.GSSTSig]] = None, multi=False,
               question_only=False, one_rr_per_rrset=False,
               ignore_trailing=False) -> Message:
     ...

--- a/dns/rdtypes/ANY/TKEY.py
+++ b/dns/rdtypes/ANY/TKEY.py
@@ -1,0 +1,117 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+# Copyright (C) 2004-2007, 2009-2011 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import base64
+import struct
+
+import dns.dnssec
+import dns.exception
+import dns.rdata
+
+
+class TKEY(dns.rdata.Rdata):
+
+    """TKEY Record"""
+
+    __slots__ = ['algorithm', 'inception', 'expiration', 'mode', 'error',
+                 'key', 'other']
+
+    def __init__(self, rdclass, rdtype, algorithm, inception, expiration,
+                 mode, error, key, other=b''):
+        super().__init__(rdclass, rdtype)
+        object.__setattr__(self, 'algorithm', algorithm)
+        object.__setattr__(self, 'inception', inception)
+        object.__setattr__(self, 'expiration', expiration)
+        object.__setattr__(self, 'mode', mode)
+        object.__setattr__(self, 'error', error)
+        object.__setattr__(self, 'key', dns.rdata._constify(key))
+        object.__setattr__(self, 'other', dns.rdata._constify(other))
+
+    def to_text(self, origin=None, relativize=True, **kw):
+        _algorithm = self.algorithm.choose_relativity(origin, relativize)
+        text = '%s %u %u %u %u %s' % (str(_algorithm), self.inception,
+                                      self.expiration, self.mode, self.error,
+                                      dns.rdata._base64ify(self.key, 0))
+        if len(self.other):
+            text += ' %s' % (dns.rdata._base64ify(self.other, 0))
+
+        return text
+
+    @classmethod
+    def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True,
+                  relativize_to=None):
+        algorithm = tok.get_name(relativize=False)
+        inception = tok.get_uint32()
+        expiration = tok.get_uint32()
+        mode = tok.get_uint16()
+        error = tok.get_uint16()
+        key_b64 = tok.get_string().encode()
+        key = base64.b64decode(key_b64)
+        other_b64 = tok.concatenate_remaining_identifiers().encode()
+        other = base64.b64decode(other_b64)
+
+        return cls(rdclass, rdtype, algorithm, inception, expiration, mode,
+                   error, key, other)
+
+    def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
+        self.algorithm.to_wire(file, compress, origin)
+        file.write(struct.pack("!IIHH", self.inception, self.expiration,
+                               self.mode, self.error))
+        file.write(struct.pack("!H", len(self.key)))
+        file.write(self.key)
+        file.write(struct.pack("!H", len(self.other)))
+        if len(self.other):
+            file.write(self.other)
+
+    @classmethod
+    def from_wire_parser(cls, rdclass, rdtype, parser, origin=None):
+        algorithm = parser.get_name(origin)
+        inception, expiration, mode, error = parser.get_struct("!IIHH")
+        key = parser.get_counted_bytes(2)
+        other = parser.get_counted_bytes(2)
+
+        return cls(rdclass, rdtype, algorithm, inception, expiration, mode,
+                   error, key, other)
+
+    # Constants for the mode field - from RFC 2930:
+    # 2.5 The Mode Field
+    #
+    #    The mode field specifies the general scheme for key agreement or
+    #    the purpose of the TKEY DNS message.  Servers and resolvers
+    #    supporting this specification MUST implement the Diffie-Hellman key
+    #    agreement mode and the key deletion mode for queries.  All other
+    #    modes are OPTIONAL.  A server supporting TKEY that receives a TKEY
+    #    request with a mode it does not support returns the BADMODE error.
+    #    The following values of the Mode octet are defined, available, or
+    #    reserved:
+    #
+    #          Value    Description
+    #          -----    -----------
+    #           0        - reserved, see section 7
+    #           1       server assignment
+    #           2       Diffie-Hellman exchange
+    #           3       GSS-API negotiation
+    #           4       resolver assignment
+    #           5       key deletion
+    #          6-65534   - available, see section 7
+    #          65535     - reserved, see section 7
+    SERVER_ASSIGNMENT = 1
+    DIFFIE_HELLMAN_EXCHANGE = 2
+    GSSAPI_NEGOTIATION = 3
+    RESOLVER_ASSIGNMENT = 4
+    KEY_DELETION = 5
+

--- a/dns/rdtypes/ANY/__init__.py
+++ b/dns/rdtypes/ANY/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     'SOA',
     'SPF',
     'SSHFP',
+    'TKEY',
     'TLSA',
     'TSIG',
     'TXT',

--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -55,5 +55,10 @@ def to_text(keyring):
         if isinstance(key, bytes):
             textring[name] = b64encode(key)
         else:
-            textring[name] = (key.algorithm.to_text(), b64encode(key.secret))
+            if isinstance(key.secret, bytes):
+                text_secret = b64encode(key.secret)
+            else:
+                text_secret = str(key.secret)
+
+            textring[name] = (key.algorithm.to_text(), text_secret)
     return textring

--- a/tests/test_rdtypeanytkey.py
+++ b/tests/test_rdtypeanytkey.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+# Copyright (C) 2003-2007, 2009-2011 Nominum, Inc.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice and this permission notice
+# appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NOMINUM DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NOMINUM BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import unittest
+import base64
+
+import dns.name
+import dns.zone
+import dns.rdtypes.ANY.TKEY
+from dns.rdataclass import RdataClass
+from dns.rdatatype import RdataType
+
+
+class RdtypeAnyTKeyTestCase(unittest.TestCase):
+    tkey_rdata_text = 'gss-tsig. 1594203795 1594206664 3 0 KEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEY OTHEROTHEROTHEROTHEROTHEROTHEROT'
+    tkey_rdata_text_no_other = 'gss-tsig. 1594203795 1594206664 3 0 KEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEY'
+
+    def testTextOptionalData(self):
+        # construct the rdata from text and extract the TKEY
+        tkey = dns.rdata.from_text(
+            RdataClass.ANY, RdataType.TKEY,
+            RdtypeAnyTKeyTestCase.tkey_rdata_text, origin='.')
+        self.assertEqual(type(tkey), dns.rdtypes.ANY.TKEY.TKEY)
+
+        # go to text and compare
+        tkey_out_text = tkey.to_text(relativize=False)
+        self.assertEqual(tkey_out_text,
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text)
+
+    def testTextNoOptionalData(self):
+        # construct the rdata from text and extract the TKEY
+        tkey = dns.rdata.from_text(
+            RdataClass.ANY, RdataType.TKEY,
+            RdtypeAnyTKeyTestCase.tkey_rdata_text_no_other, origin='.')
+        self.assertEqual(type(tkey), dns.rdtypes.ANY.TKEY.TKEY)
+
+        # go to text and compare
+        tkey_out_text = tkey.to_text(relativize=False)
+        self.assertEqual(tkey_out_text,
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text_no_other)
+
+    def testWireOptionalData(self):
+        key = base64.b64decode('KEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEY')
+        other = base64.b64decode('OTHEROTHEROTHEROTHEROTHEROTHEROT')
+
+        # construct the TKEY and compare the text output
+        tkey = dns.rdtypes.ANY.TKEY.TKEY(dns.rdataclass.ANY,
+                                         dns.rdatatype.TKEY,
+                                         dns.name.from_text('gss-tsig.'),
+                                         1594203795, 1594206664,
+                                         3, 0, key, other)
+        self.assertEqual(tkey.to_text(relativize=False),
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text)
+
+        # go to/from wire and compare the text output
+        wire = tkey.to_wire()
+        tkey_out_wire = dns.rdata.from_wire(dns.rdataclass.ANY,
+                                            dns.rdatatype.TKEY,
+                                            wire, 0, len(wire))
+        self.assertEqual(tkey_out_wire.to_text(relativize=False),
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text)
+
+    def testWireNoOptionalData(self):
+        key = base64.b64decode('KEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEY')
+
+        # construct the TKEY with no 'other' data and compare the text output
+        tkey = dns.rdtypes.ANY.TKEY.TKEY(dns.rdataclass.ANY,
+                                         dns.rdatatype.TKEY,
+                                         dns.name.from_text('gss-tsig.'),
+                                         1594203795, 1594206664,
+                                         3, 0, key)
+        self.assertEqual(tkey.to_text(relativize=False),
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text_no_other)
+
+        # go to/from wire and compare the text output
+        wire = tkey.to_wire()
+        tkey_out_wire = dns.rdata.from_wire(dns.rdataclass.ANY,
+                                            dns.rdatatype.TKEY,
+                                            wire, 0, len(wire))
+        self.assertEqual(tkey_out_wire.to_text(relativize=False),
+                         RdtypeAnyTKeyTestCase.tkey_rdata_text_no_other)

--- a/tests/test_tsig.py
+++ b/tests/test_tsig.py
@@ -142,6 +142,16 @@ class TSIGTestCase(unittest.TestCase):
         # not raising is passing
         dns.message.from_wire(w, keyring)
 
+    def test_sign_respond_and_validate(self):
+        mq = dns.message.make_query('example', 'a')
+        mq.use_tsig(keyring, keyname)
+        wq = mq.to_wire()
+        mq_with_tsig = dns.message.from_wire(wq, keyring)
+        mr = dns.message.make_response(mq)
+        mr.use_tsig(keyring, keyname)
+        wr = mr.to_wire()
+        dns.message.from_wire(wr, keyring, request_mac=mq_with_tsig.mac)
+
     def make_message_pair(self, qname='example', rdtype='A', tsig_error=0):
         q = dns.message.make_query(qname, rdtype)
         q.use_tsig(keyring=keyring, keyname=keyname)

--- a/tests/test_tsig.py
+++ b/tests/test_tsig.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import Mock
 import time
+import base64
 
 import dns.rcode
 import dns.tsig
@@ -46,12 +47,6 @@ class TSIGTestCase(unittest.TestCase):
         self.assertEqual(m.tsig_error, dns.rcode.BADKEY)
 
     def test_verify_mac_for_context(self):
-        dummy_ctx = None
-        dummy_expected = None
-        key = dns.tsig.Key('foo.com', 'abcd', 'bogus')
-        with self.assertRaises(NotImplementedError):
-            dummy_ctx = dns.tsig.get_context(key)
-
         key = dns.tsig.Key('foo.com', 'abcd', 'hmac-sha512')
         ctx = dns.tsig.get_context(key)
         bad_expected = b'xxxxxxxxxx'
@@ -97,10 +92,11 @@ class TSIGTestCase(unittest.TestCase):
         gssapi_context_mock.verify_signature.side_effect = verify_signature
 
         # create the key and add it to the keyring
-        key = dns.tsig.Key('gsstsigtest', gssapi_context_mock, 'gss-tsig')
+        keyname = 'gsstsigtest'
+        key = dns.tsig.Key(keyname, gssapi_context_mock, 'gss-tsig')
         ctx = dns.tsig.get_context(key)
         self.assertEqual(ctx.name, 'gss-tsig')
-        gsskeyname = dns.name.from_text('gsstsigtest')
+        gsskeyname = dns.name.from_text(keyname)
         keyring[gsskeyname] = key
 
         # make sure we can get the keyring (no exception == success)
@@ -114,18 +110,65 @@ class TSIGTestCase(unittest.TestCase):
         gssapi_context_mock.verify_signature.assert_called()
         self.assertEqual(gssapi_context_mock.verify_signature.call_count, 1)
 
-        # create example message and go to/from wire to simulate sign/verify
-        m = dns.message.make_query('example', 'a')
-        m.use_tsig(keyring, gsskeyname)
-        w = m.to_wire()
-        # not raising is passing
-        dns.message.from_wire(w, keyring)
+        # simulate case where TKEY message is used to establish the context;
+        # first, the query from the client
+        tkey_message = dns.message.make_query(keyname, 'tkey', 'any')
+
+        # test existent/non-existent keys in the keyring
+        adapted_keyring = dns.tsig.GSSTSigAdapter(keyring)
+
+        fetched_key = adapted_keyring(tkey_message, gsskeyname)
+        self.assertEqual(fetched_key, key)
+        key = adapted_keyring(None, gsskeyname)
+        self.assertEqual(fetched_key, key)
+        key = adapted_keyring(tkey_message, "dummy")
+        self.assertEqual(key, None)
+
+        # create a response, TKEY and turn it into bytes, simulating the server
+        # sending the response to the query
+        tkey_response = dns.message.make_response(tkey_message)
+        key = base64.b64decode('KEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEYKEY')
+        tkey = dns.rdtypes.ANY.TKEY.TKEY(dns.rdataclass.ANY,
+                                         dns.rdatatype.TKEY,
+                                         dns.name.from_text('gss-tsig.'),
+                                         1594203795, 1594206664,
+                                         3, 0, key)
+
+        # add the TKEY answer and sign it
+        tkey_response.set_rcode(dns.rcode.NOERROR)
+        tkey_response.answer = [
+            dns.rrset.from_rdata(dns.name.from_text(keyname), 0, tkey)]
+        tkey_response.use_tsig(keyring=dns.tsig.GSSTSigAdapter(keyring),
+                               keyname=gsskeyname,
+                               algorithm=dns.tsig.GSS_TSIG)
+
+        # "send" it to the client
+        tkey_wire = tkey_response.to_wire()
+
+        # grab the response from the "server" and simulate the client side
+        dns.message.from_wire(tkey_wire, dns.tsig.GSSTSigAdapter(keyring))
 
         # assertions to make sure the "gssapi" functions were called
         gssapi_context_mock.get_signature.assert_called()
         self.assertEqual(gssapi_context_mock.get_signature.call_count, 1)
         gssapi_context_mock.verify_signature.assert_called()
         self.assertEqual(gssapi_context_mock.verify_signature.call_count, 2)
+        gssapi_context_mock.step.assert_called()
+        self.assertEqual(gssapi_context_mock.step.call_count, 1)
+
+        # create example message and go to/from wire to simulate sign/verify
+        # of regular messages
+        a_message = dns.message.make_query('example', 'a')
+        a_message.use_tsig(dns.tsig.GSSTSigAdapter(keyring), gsskeyname)
+        a_wire = a_message.to_wire()
+        # not raising is passing
+        dns.message.from_wire(a_wire, dns.tsig.GSSTSigAdapter(keyring))
+
+        # assertions to make sure the "gssapi" functions were called again
+        gssapi_context_mock.get_signature.assert_called()
+        self.assertEqual(gssapi_context_mock.get_signature.call_count, 2)
+        gssapi_context_mock.verify_signature.assert_called()
+        self.assertEqual(gssapi_context_mock.verify_signature.call_count, 3)
 
     def test_sign_and_validate(self):
         m = dns.message.make_query('example', 'a')
@@ -133,6 +176,18 @@ class TSIGTestCase(unittest.TestCase):
         w = m.to_wire()
         # not raising is passing
         dns.message.from_wire(w, keyring)
+
+    def test_validate_with_bad_keyring(self):
+        m = dns.message.make_query('example', 'a')
+        m.use_tsig(keyring, keyname)
+        w = m.to_wire()
+
+        # keyring == None is an error
+        with self.assertRaises(dns.message.UnknownTSIGKey):
+            dns.message.from_wire(w, None)
+        # callable keyring that returns None is an error
+        with self.assertRaises(dns.message.UnknownTSIGKey):
+            dns.message.from_wire(w, lambda m, n: None)
 
     def test_sign_and_validate_with_other_data(self):
         m = dns.message.make_query('example', 'a')


### PR DESCRIPTION
Following earlier feedback on https://github.com/rthalley/dnspython/pull/524, I've tried an alternative option for adding support for gss-tsig.

Although it's a smaller and less structural change, I can't help but think it's making the code slightly less clear/tidy, and that at least a small class representing the HMAC style TSIGs would avoid a few of the 'if digestmod == gss_tsig' stanzas.

I'll note that @bwelling's earlier comment about making gss-tsig look like a digest isn't quite possible as verifying a gss-tsig isn't the same as an hmac style TSIG - you can't just re-do the signature operation and compare the result - you have to call a verification method on the GSSAPI context, and pass in the expected value and the data that produced it.  There are other (cryptographic) aspects to the signature that can't be reproduced in this way.  This has led to a small chance in the way verification works (by passing an expected value into the signature operation).  I'd previously proposed an alternative option which might be cleaner, by factoring out the bits of code that collect up the TSIG values required for the signature into a method on a TSIG (which could then be reused in the sign/verify operations separately).

I'll also draw your attention to the minor metaclass related change for TKEY records; these can have a class of ANY, so the metaclass check on queries needs to be slightly relaxed.