### PR TITLE
Receive queries

### DIFF
--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -75,6 +75,9 @@ class DatagramSocket(dns._asyncbackend.DatagramSocket):
     async def getpeername(self):
         return self.transport.get_extra_info('peername')
 
+    async def getsockname(self):
+        return self.transport.get_extra_info('sockname')
+
 
 class StreamSocket(dns._asyncbackend.DatagramSocket):
     def __init__(self, af, reader, writer):
@@ -101,6 +104,9 @@ class StreamSocket(dns._asyncbackend.DatagramSocket):
 
     async def getpeername(self):
         return self.writer.get_extra_info('peername')
+
+    async def getsockname(self):
+        return self.writer.get_extra_info('sockname')
 
 
 class Backend(dns._asyncbackend.Backend):

--- a/dns/_curio_backend.py
+++ b/dns/_curio_backend.py
@@ -43,6 +43,9 @@ class DatagramSocket(dns._asyncbackend.DatagramSocket):
     async def getpeername(self):
         return self.socket.getpeername()
 
+    async def getsockname(self):
+        return self.socket.getsockname()
+
 
 class StreamSocket(dns._asyncbackend.DatagramSocket):
     def __init__(self, socket):
@@ -64,6 +67,9 @@ class StreamSocket(dns._asyncbackend.DatagramSocket):
 
     async def getpeername(self):
         return self.socket.getpeername()
+
+    async def getsockname(self):
+        return self.socket.getsockname()
 
 
 class Backend(dns._asyncbackend.Backend):

--- a/dns/_trio_backend.py
+++ b/dns/_trio_backend.py
@@ -43,6 +43,9 @@ class DatagramSocket(dns._asyncbackend.DatagramSocket):
     async def getpeername(self):
         return self.socket.getpeername()
 
+    async def getsockname(self):
+        return self.socket.getsockname()
+
 
 class StreamSocket(dns._asyncbackend.DatagramSocket):
     def __init__(self, family, stream, tls=False):
@@ -68,6 +71,12 @@ class StreamSocket(dns._asyncbackend.DatagramSocket):
             return self.stream.transport_stream.socket.getpeername()
         else:
             return self.stream.socket.getpeername()
+
+    async def getsockname(self):
+        if self.tls:
+            return self.stream.transport_stream.socket.getsockname()
+        else:
+            return self.stream.socket.getsockname()
 
 
 class Backend(dns._asyncbackend.Backend):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -277,6 +277,8 @@ class AsyncTests(unittest.TestCase):
                         socket.SOCK_STREAM, 0,
                         None,
                         (address, 53)) as s:
+                    # for basic coverage
+                    await s.getsockname()
                     q = dns.message.make_query(qname, dns.rdatatype.A)
                     return await dns.asyncquery.tcp(q, address, sock=s)
             response = self.async_run(run)
@@ -315,6 +317,8 @@ class AsyncTests(unittest.TestCase):
                         None,
                         (address, 853), None,
                         ssl_context, None) as s:
+                    # for basic coverage
+                    await s.getsockname()
                     q = dns.message.make_query(qname, dns.rdatatype.A)
                     return await dns.asyncquery.tls(q, '8.8.8.8', sock=s)
             response = self.async_run(run)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -191,6 +191,18 @@ class QueryTests(unittest.TestCase):
             (_, tcp) = dns.query.udp_with_fallback(q, address)
             self.assertFalse(tcp)
 
+    def testUDPReceiveQuery(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as listener:
+            listener.bind(('127.0.0.1', 0))
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sender:
+                sender.bind(('127.0.0.1', 0))
+                q = dns.message.make_query('dns.google', dns.rdatatype.A)
+                dns.query.send_udp(sender, q, listener.getsockname())
+                expiration = time.time() + 2
+                (q, _, addr) = dns.query.receive_udp(listener,
+                                                     expiration=expiration)
+                self.assertEqual(addr, sender.getsockname())
+
 
 # for brevity
 _d_and_s = dns.query._destination_and_source


### PR DESCRIPTION
Add support for receiving UDP queries.
    
The existing receive_udp() methods are only usable for receiving
responses, as they require an expected destination and check that the
message is from that destination.
    
This change makes the expected destination (and hence the check)
optional, and returns the address that the message was received from (in
the sync case, this is only done if no destination is provided, for
backwards compatibility).
    
New tests are added, which required adding generic getsockname() support
to the async backends.