### PR TITLE
WIP: dns json encode/decode

### DIFF
--- a/dns/json.py
+++ b/dns/json.py
@@ -1,0 +1,195 @@
+import json
+from json.decoder import WHITESPACE
+
+import dns.message
+import dns.rdataset
+import dns.rrset
+import dns.zone
+import dns.rdata
+import dns.rdtypes.IN
+import dns.node
+import dns.flags
+import dns.rdataclass
+
+class DNSJSONEncoder(json.JSONEncoder):
+    def default(self, o): # pylint: disable=E0202
+        if isinstance(o, dns.zone.Zone):
+            return encode_zone(o)
+        if isinstance(o, dns.message.Message):
+            return encode_message(o)
+        if isinstance(o, dns.rrset.RRset):
+            return encode_rrset(o)
+        if isinstance(o, dns.rdataset.Rdataset):
+            return encode_rdataset(o)
+        if isinstance(o, dns.name.Name):
+            return encode_name(o)
+        if isinstance(o, dns.rdata.Rdata):
+            return encode_rdata(o)
+        return super().default(o)
+
+class DNSJSONDecoder(json.JSONDecoder):
+    def decode(self, s, _w=WHITESPACE.match):
+        d = json.loads(s)
+        if 'Origin' in d:
+            return decode_zone(d)
+        if 'Status' in d:
+            return decode_message(d)
+        return d
+
+def dump(o, fp, cls=DNSJSONEncoder, **kwargs):
+    return json.dump(o, fp, cls=cls, **kwargs)
+
+def dumps(o, cls=DNSJSONEncoder, **kwargs):
+    return json.dumps(o, cls=cls, **kwargs)
+
+def loads(s, cls=DNSJSONDecoder, **kwargs):
+    return json.loads(s, cls=cls, **kwargs)
+
+def load(fp, cls=DNSJSONDecoder, **kwargs):
+    return json.load(fp, cls=cls, **kwargs)
+
+# Optionally could use these to match dns.message.from_text(), etc
+# def to_json(*args, **kwargs):
+#     return dumps(*args, **kwargs)
+#
+# def from_json(*args, **kwargs):
+#     return loads(*args, **kwargs)
+
+def decode_message(d):
+    msg = dns.message.Message()
+    msg.set_rcode(d['Status'])
+    if 'ID' in d:
+        msg.id = d['ID']
+    if 'QR' in d:
+        msg.set_opcode(d['QR'])
+    if 'TC' in d and d['TC']:
+        msg.flags |= dns.flags.TC
+    if 'RD' in d and d['RD']:
+        msg.flags |= dns.flags.RD
+    if 'RA' in d and d['RA']:
+        msg.flags |= dns.flags.RA
+    if 'AD' in d and d['AD']:
+        msg.flags |= dns.flags.AD
+    if 'CD' in d and d['CD']:
+        msg.flags |= dns.flags.CD
+    if 'Question' in d and len(d['Question']) > 0:
+        decode_rrsets(msg, msg.question, d['Question'])
+    if 'Answer' in d and len(d['Answer']) > 0:
+        decode_rrsets(msg, msg.answer, d['Answer'])
+    if 'Authority' in d and len(d['Authority']) > 0:
+        decode_rrsets(msg, msg.authority, d['Authority'])
+    if 'Additional' in d and len(d['Additional']) > 0:
+        decode_rrsets(msg, msg.additional, d['Additional'])
+    return msg
+
+def decode_rrsets(msg, section, rrsets):
+    for i in rrsets:
+        rrset = msg.find_rrset(section, dns.name.from_text(i['name']),
+                               dns.rdataclass.IN, rdtype=i['type'], create=True)
+        if 'data' in i:
+            rdata = dns.rdata.from_text(dns.rdataclass.IN, i['type'], i['data'])
+            if 'TTL' in i:
+                rrset.add(rdata, i['TTL'])
+            else:
+                rrset.add(rdata)
+
+def decode_zone(d: dict):
+    # todo
+    return d
+
+def encode_message(message):
+    result = {
+        'ID': message.id,
+        'Status': message.rcode(),
+        'QR': message.opcode(),
+        'TC': bool(message.flags & dns.flags.TC),
+        'RD': bool(message.flags & dns.flags.RD),
+        'RA': bool(message.flags & dns.flags.RA),
+        'AD': bool(message.flags & dns.flags.AD),
+        'CD': bool(message.flags & dns.flags.CD),
+        'Question': [],
+        'Answer': encode_section(message.answer),
+        'Authority': encode_section(message.authority),
+        'Additional': encode_section(message.additional),
+    }
+    if len(message.question) > 0:
+        for q in message.question:
+            result['Question'].append({
+                'name': q.name,
+                'type': q.rdtype
+            })
+    return result
+
+def encode_rrset(rrset, origin=None, relativize=False):
+    result = []
+    name = rrset.name
+    if origin is not None:
+        if relativize:
+            name = rrset.name.relativize(origin)
+        else:
+            name = rrset.name.derelativize(origin)
+    if len(rrset) == 0:
+        result.append({
+            'name': name,
+            'TTL': rrset.ttl,
+            'type': rrset.rdtype,
+        })
+    for rdata in rrset:
+        result.append({
+            'name': name,
+            'TTL': rrset.ttl,
+            'type': rrset.rdtype,
+            'data': rdata
+        })
+    return result
+
+def encode_section(section, origin=None):
+    result = []
+    for rrset in section:
+        result.extend(encode_rrset(rrset, origin=origin))
+    return result
+
+def encode_name(name):
+    return name.to_text()
+
+def encode_rdata(rdata):
+    return rdata.to_text()
+
+def encode_zone(zone, relativize=False):
+    result = {
+        'Origin': zone.origin,
+        'RRSets': []
+    }
+    for name, rdatasets in zone.nodes.items():
+        for rdataset in rdatasets:
+            if not relativize:
+                name = name.derelativize(zone.origin)
+            else:
+                name = name.relativize(zone.origin)
+            rrset = dns.rrset.from_rdata_list(name=name, ttl=rdataset.ttl, rdatas=rdataset)
+            result['rrsets'].extend(encode_rrset(rrset))
+    return result
+
+def encode_nodes(nodes, origin=None, relativize=False):
+    result = []
+    for name, rdatasets in nodes.items():
+        for rdataset in rdatasets:
+            if origin is not None and not relativize:
+                name = name.derelativize(origin)
+            if origin is not None and relativize:
+                name = name.relativize(origin)
+            rrset = dns.rrset.from_rdata_list(name=name, ttl=rdataset.ttl, rdatas=rdataset)
+            result.extend(encode_rrset(rrset))
+    return result
+
+def encode_rdataset(rdataset, name=None):
+    result = {
+        'class': rdataset.rdclass,
+        'type': rdataset.rdtype,
+        'rdatas': []
+    }
+    if name:
+        result['name'] = name
+    for rdata in rdataset:
+        result['rdatas'].append(rdata)
+    return result

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,119 @@
+import unittest
+
+import dns.rdtypes.IN.A
+import dns.message
+import dns.rdatatype
+import dns.json
+import dns.rdataclass
+import dns.name
+
+from tests.test_zone import here
+
+class JsonEncodeTestCase(unittest.TestCase):
+
+    def test_zone_encode(self):
+        z = dns.zone.from_file(here('example'), 'example')
+        s = dns.json.dumps(z, indent=4)
+        print(s)
+
+    def test_message_encode(self):
+        msg = dns.message.make_query('example.com.', rdtype=dns.rdatatype.A)
+        msg.find_rrset(msg.question, dns.name.from_text('example.com.'),
+                                create=True, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN)
+        rrset = msg.find_rrset(msg.answer, dns.name.from_text('example.com.'),
+                                create=True, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN)
+        rrset.add(dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '1.2.3.4'), ttl=1234)
+        rrset.add(dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '1.2.3.5'))
+        s = dns.json.dumps(msg, indent=4)
+        print(s)
+
+    def test_rrset_encode(self):
+        a_rrset = dns.rrset.from_text('foo', 300, 'in', 'a', '10.0.0.1', '10.0.0.2')
+        s = dns.json.dumps(a_rrset, indent=4)
+        print(s)
+
+        aaaa_rrset = dns.rrset.from_text('foo', 300, 'in', 'aaaa', '::', '1::')
+        s = dns.json.dumps(aaaa_rrset, indent=4)
+        print(s)
+
+        txt_rrset = dns.rrset.from_text('foo', 300, 'any', 'txt', '"v=spf1 -all"', '1::')
+        s = dns.json.dumps(txt_rrset, indent=4)
+        print(s)
+
+        dnskey_rrset = dns.rrset.from_text('foo', 300, 'any', 'dnskey',
+                                           '257 3 5 AwEAAenVTr9L1OMlL1/N2ta0Qj9LLLnnmFWIr1dJoAsWM9BQfsbV7kFZ '
+                                           'XbAkER/FY9Ji2o7cELxBwAsVBuWn6IUUAJXLH74YbC1anY0lifjgt29z '
+                                           'SwDzuB7zmC7yVYZzUunBulVW4zT0tg1aePbpVL2EtTL8VzREqbJbE25R '
+                                           'KuQYHZtFwG8S4iBxJUmT2Bbd0921LLxSQgVoFXlQx/gFV2+UERXcJ5ce '
+                                           'iX6A6wc02M/pdg/YbJd2rBa0MYL3/Fz/Xltre0tqsImZGxzi6YtYDs45 '
+                                           'NC8gH+44egz82e2DATCVM1ICPmRDjXYTLldQiWA2ZXIWnK0iitl5ue24 7EsWJefrIhE=')
+        s = dns.json.dumps(dnskey_rrset, indent=4)
+        print(s)
+
+    def test_rdataset_encode(self):
+        r1 = dns.rrset.from_text('foo', 300, 'in', 'a', '10.0.0.1', '10.0.0.2')
+        rdataset = r1.to_rdataset()
+        s = dns.json.dumps(rdataset, indent=4)
+        print(s)
+
+    def test_rdata_encode(self):
+        rdata = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
+        s = dns.json.dumps(rdata, indent=4)
+        print(s)
+
+    def test_name_encode(self):
+        name = dns.name.from_text('example.com')
+        s = dns.json.dumps(name, indent=4)
+        print(s)
+
+class JsonDecodeTestCase(unittest.TestCase):
+
+    def test_dns_message_decode(self):
+        text = """\
+{
+  "Status": 0,
+  "ID": 12345,
+  "TC": false,
+  "RD": true,
+  "RA": true,
+  "AD": true,
+  "CD": false,
+  "Question": [
+    {
+      "name": "example.com",
+      "type": 48
+    }
+  ],
+  "Answer": [
+    {
+      "name": "example.com",
+      "type": 48,
+      "TTL": 1446,
+      "data": "256 3 RSASHA256 AwEAAdTxhSwz3/lGdlPuQdw+WzsBPmt99VBxvkpfbST65UlCgWOW+5fnGbxfFSrscnQixl6ApgVBYE1Z9KuBRf5y9OD69arf3EYLoE3tYvFreCbcl7sFfWhhZUkBLE028i4pzFhdStQO+yY8xzE3zg1NE86wQUT0LChhMudSpXAmf6DJ"
+    },
+    {
+      "name": "example.com",
+      "type": 48,
+      "TTL": 1446,
+      "data": "257 3 RSASHA256 AwEAAZ0aqu1rJ6orJynrRfNpPmayJZoAx9Ic2/Rl9VQWLMHyjxxem3VUSoNUIFXERQbj0A9Ogp0zDM9YIccKLRd6LmWiDCt7UJQxVdD+heb5Ec4qlqGmyX9MDabkvX2NvMwsUecbYBq8oXeTT9LRmCUt9KUt/WOi6DKECxoG/bWTykrXyBR8elD+SQY43OAVjlWrVltHxgp4/rhBCvRbmdflunaPIgu27eE2U4myDSLT8a4A0rB5uHG4PkOa9dIRs9y00M2mWf4lyPee7vi5few2dbayHXmieGcaAHrx76NGAABeY393xjlmDNcUkF1gpNWUla4fWZbbaYQzA93mLdrng+M="
+    },
+    {
+      "name": "example.com",
+      "type": 48,
+      "TTL": 1446,
+      "data": "257 3 RSASHA256 AwEAAbOFAxl+Lkt0UMglZizKEC1AxUu8zlj65KYatR5wBWMrh18TYzK/ig6Y1t5YTWCO68bynorpNu9fqNFALX7bVl9/gybA0v0EhF+dgXmoUfRX7ksMGgBvtfa2/Y9a3klXNLqkTszIQ4PEMVCjtryl19Be9/PkFeC9ITjgMRQsQhmB39eyMYnal+f3bUxKk4fq7cuEU0dbRpue4H/N6jPucXWOwiMAkTJhghqgy+o9FfIp+tR/emKao94/wpVXDcPf5B18j7xz2SvTTxiuqCzCMtsxnikZHcoh1j4g+Y1B8zIMIvrEM+pZGhh/Yuf4RwCBgaYCi9hpiMWVvS4WBzx0/lU="
+    }
+  ]
+}"""
+        msg = dns.json.loads(text)
+        print(msg)
+        text2 = dns.json.dumps(msg, indent=4)
+        print(text2)
+        msg2 = dns.json.loads(text2)
+        print(msg2)
+        text3 = dns.json.dumps(msg2, indent=4)
+        print(text3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I worked on this several months ago for https://github.com/rthalley/dnspython/issues/64, so I figured I'd put up here what I have for some feedback, let people try it out if they want. Fire away! (It's nowhere near close to anything that resembles a merge-able PR)

I opted for trying out a Google/Cloudflare-type DNS JSON implementation.
The JSON encoding process didn't turn out how I expected, mostly because of the way dnspython stores the rrsets, so I had to do some extra processing for zones and messages within `encode_message()` and `encode_zone()`, rather than letting the encoder recursively decode the rrsets.

Something else to think about - we may want to use something like a [`CaseInsensitiveDict`](https://github.com/psf/requests/blob/v1.2.3/requests/structures.py#L37) for keys to allow for things like `ttl` and `TTL` when we're decoding DNS objects.