### PR TITLE
Use the selectors module.

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -540,17 +540,3 @@ class LowLevelWaitTests(unittest.TestCase):
         finally:
             l.close()
             r.close()
-
-    def test_select_for(self):
-        # we test this explicitly in case _wait_for didn't test it (i.e.
-        # if the default polling backing is _poll_for)
-        try:
-            (l, r) = socket.socketpair()
-            # simple timeout
-            self.assertFalse(dns.query._select_for(l, False, False, False,
-                                                   0.05))
-            # writable no timeout
-            self.assertTrue(dns.query._select_for(l, False, True, False, None))
-        finally:
-            l.close()
-            r.close()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -16,7 +16,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from io import StringIO
-import select
+import selectors
 import sys
 import socket
 import time
@@ -477,26 +477,26 @@ class LiveResolverTests(unittest.TestCase):
 
 class PollingMonkeyPatchMixin(object):
     def setUp(self):
-        self.__native_polling_backend = dns.query._polling_backend
-        dns.query._set_polling_backend(self.polling_backend())
+        self.__native_selector_class = dns.query._selector_class
+        dns.query._set_selector_class(self.selector_class())
 
         unittest.TestCase.setUp(self)
 
     def tearDown(self):
-        dns.query._set_polling_backend(self.__native_polling_backend)
+        dns.query._set_selector_class(self.__native_selector_class)
 
         unittest.TestCase.tearDown(self)
 
 
 class SelectResolverTestCase(PollingMonkeyPatchMixin, LiveResolverTests, unittest.TestCase):
-    def polling_backend(self):
-        return dns.query._select_for
+    def selector_class(self):
+        return selectors.SelectSelector
 
 
-if hasattr(select, 'poll'):
+if hasattr(selectors, 'PollSelector'):
     class PollResolverTestCase(PollingMonkeyPatchMixin, LiveResolverTests, unittest.TestCase):
-        def polling_backend(self):
-            return dns.query._poll_for
+        def selector_class(self):
+            return selectors.PollSelector
 
 
 class NXDOMAINExceptionTestCase(unittest.TestCase):


### PR DESCRIPTION
Previously, there was code to either use select.select or select.poll,
depending on OS.  This changes it to use the selectors module, using
either SelectSelector or PollSelector, but sharing code otherwise.