### PR TITLE
Add dns.edns.register_type().

### DIFF
--- a/dns/edns.py
+++ b/dns/edns.py
@@ -342,3 +342,13 @@ def option_from_wire(otype, wire, current, olen):
     parser = dns.wire.Parser(wire, current)
     with parser.restrict_to(olen):
         return option_from_wire_parser(otype, parser)
+
+def register_type(implementation, otype):
+    """Register the implementation of an option type.
+
+    *implementation*, a ``class``, is a subclass of ``dns.edns.Option``.
+
+    *otype*, an ``int``, is the option type.
+    """
+
+    _type_to_class[otype] = implementation

--- a/doc/message-edns.rst
+++ b/doc/message-edns.rst
@@ -32,3 +32,4 @@ will create a ``dns.edns.ECSOption`` object to represent it.
 .. autofunction:: dns.edns.get_option_class
 .. autofunction:: dns.edns.option_from_wire_parser
 .. autofunction:: dns.edns.option_from_wire
+.. autofunction:: dns.edns.register_type


### PR DESCRIPTION
This allows an application to register a custom EDNS option type.