### PR TITLE
Canonical name

### DIFF
--- a/dns/asyncresolver.py
+++ b/dns/asyncresolver.py
@@ -165,6 +165,28 @@ class Resolver(dns.resolver.Resolver):
                                   rdclass=dns.rdataclass.IN,
                                   *args, **kwargs)
 
+    async def canonical_name(self, name):
+        """Determine the canonical name of *name*.
+
+        The canonical name is the name the resolver uses for queries
+        after all CNAME and DNAME renamings have been applied.
+
+        *name*, a ``dns.name.Name`` or ``str``, the query name.
+
+        This method can raise any exception that ``resolve()`` can
+        raise, other than ``dns.resolver.NoAnswer`` and
+        ``dns.resolver.NXDOMAIN``.
+
+        Returns a ``dns.name.Name``.
+        """
+        try:
+            answer = await self.resolve(name, raise_on_no_answer=False)
+            canonical_name = answer.canonical_name
+        except dns.resolver.NXDOMAIN as e:
+            canonical_name = e.canonical_name
+        return canonical_name
+
+
 default_resolver = None
 
 
@@ -212,6 +234,14 @@ async def resolve_address(ipaddr, *args, **kwargs):
 
     return await get_default_resolver().resolve_address(ipaddr, *args, **kwargs)
 
+async def canonical_name(name):
+    """Determine the canonical name of *name*.
+
+    See ``dns.resolver.Resolver.canonical_name`` for more information on the
+    parameters and possible exceptions.
+    """
+
+    return await get_default_resolver().canonical_name(name)
 
 async def zone_for_name(name, rdclass=dns.rdataclass.IN, tcp=False,
                         resolver=None, backend=None):

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -81,6 +81,9 @@ class NXDOMAIN(dns.exception.DNSException):
         IN = dns.rdataclass.IN
         CNAME = dns.rdatatype.CNAME
         cname = None
+        # This code assumes the CNAME chain is in proper order, though
+        # the Answer code does not make a similar assumption when
+        # chaining.
         for qname in self.kwargs['qnames']:
             response = self.kwargs['responses'][qname]
             for answer in response.answer:
@@ -1181,13 +1184,11 @@ class Resolver:
         *name*, a ``dns.name.Name`` or ``str``, the query name.
 
         This method can raise any exception that ``resolve()`` can
-        raise, other than `dns.resolver.NoAnswer`` and
+        raise, other than ``dns.resolver.NoAnswer`` and
         ``dns.resolver.NXDOMAIN``.
 
         Returns a ``dns.name.Name``.
         """
-        if isinstance(name, str):
-            name = dns.name.from_text(name)
         try:
             answer = self.resolve(name, raise_on_no_answer=False)
             canonical_name = answer.canonical_name

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1172,6 +1172,29 @@ class Resolver:
                             rdclass=dns.rdataclass.IN,
                             *args, **kwargs)
 
+    def canonical_name(self, name):
+        """Determine the canonical name of *name*.
+
+        The canonical name is the name the resolver uses for queries
+        after all CNAME and DNAME renamings have been applied.
+
+        *name*, a ``dns.name.Name`` or ``str``, the query name.
+
+        This method can raise any exception that ``resolve()`` can
+        raise, other than `dns.resolver.NoAnswer`` and
+        ``dns.resolver.NXDOMAIN``.
+
+        Returns a ``dns.name.Name``.
+        """
+        if isinstance(name, str):
+            name = dns.name.from_text(name)
+        try:
+            answer = self.resolve(name, raise_on_no_answer=False)
+            canonical_name = answer.canonical_name
+        except dns.resolver.NXDOMAIN as e:
+            canonical_name = e.canonical_name
+        return canonical_name
+
     def use_tsig(self, keyring, keyname=None,
                  algorithm=dns.tsig.default_algorithm):
         """Add a TSIG signature to each query.
@@ -1294,6 +1317,16 @@ def resolve_address(ipaddr, *args, **kwargs):
     """
 
     return get_default_resolver().resolve_address(ipaddr, *args, **kwargs)
+
+
+def canonical_name(name):
+    """Determine the canonical name of *name*.
+
+    See ``dns.resolver.Resolver.canonical_name`` for more information on the
+    parameters and possible exceptions.
+    """
+
+    return get_default_resolver().canonical_name(name)
 
 
 def zone_for_name(name, rdclass=dns.rdataclass.IN, tcp=False, resolver=None):

--- a/doc/async-resolver-functions.rst
+++ b/doc/async-resolver-functions.rst
@@ -5,4 +5,5 @@ Asynchronous Resolver Functions
 
 .. autofunction:: dns.asyncresolver.resolve
 .. autofunction:: dns.asyncresolver.resolve_address
+.. autofunction:: dns.asyncresolver.canonical_name
 .. autofunction:: dns.asyncresolver.zone_for_name

--- a/doc/resolver-functions.rst
+++ b/doc/resolver-functions.rst
@@ -5,6 +5,7 @@ Resolver Functions and The Default Resolver
 
 .. autofunction:: dns.resolver.resolve
 .. autofunction:: dns.resolver.resolve_address
+.. autofunction:: dns.resolver.canonical_name
 .. autofunction:: dns.resolver.zone_for_name
 .. autofunction:: dns.resolver.query
 .. autodata:: dns.resolver.default_resolver

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -182,6 +182,26 @@ class AsyncTests(unittest.TestCase):
         dnsgoogle = dns.name.from_text('dns.google.')
         self.assertEqual(answer[0].target, dnsgoogle)
 
+    def testCanonicalNameNoCNAME(self):
+        cname = dns.name.from_text('www.google.com')
+        async def run():
+            return await dns.asyncresolver.canonical_name('www.google.com')
+        self.assertEqual(self.async_run(run), cname)
+
+    def testCanonicalNameCNAME(self):
+        name = dns.name.from_text('www.dnspython.org')
+        cname = dns.name.from_text('dmfrjf4ips8xa.cloudfront.net')
+        async def run():
+            return await dns.asyncresolver.canonical_name(name)
+        self.assertEqual(self.async_run(run), cname)
+
+    def testCanonicalNameDangling(self):
+        name = dns.name.from_text('dangling-cname.dnspython.org')
+        cname = dns.name.from_text('dangling-target.dnspython.org')
+        async def run():
+            return await dns.asyncresolver.canonical_name(name)
+        self.assertEqual(self.async_run(run), cname)
+
     def testResolverBadScheme(self):
         res = dns.asyncresolver.Resolver(configure=False)
         res.nameservers = ['bogus://dns.google/dns-query']

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -512,17 +512,17 @@ class LiveResolverTests(unittest.TestCase):
 
     def testCanonicalNameNoCNAME(self):
         cname = dns.name.from_text('www.google.com')
-        self.assertTrue(dns.resolver.canonical_name('www.google.com') == cname)
+        self.assertEqual(dns.resolver.canonical_name('www.google.com'), cname)
 
     def testCanonicalNameCNAME(self):
         name = dns.name.from_text('www.dnspython.org')
         cname = dns.name.from_text('dmfrjf4ips8xa.cloudfront.net')
-        self.assertTrue(dns.resolver.canonical_name(name) == cname)
+        self.assertEqual(dns.resolver.canonical_name(name), cname)
 
     def testCanonicalNameDangling(self):
         name = dns.name.from_text('dangling-cname.dnspython.org')
         cname = dns.name.from_text('dangling-target.dnspython.org')
-        self.assertTrue(dns.resolver.canonical_name(name) == cname)
+        self.assertEqual(dns.resolver.canonical_name(name), cname)
 
 class PollingMonkeyPatchMixin(object):
     def setUp(self):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -510,6 +510,20 @@ class LiveResolverTests(unittest.TestCase):
         answer2 = res.resolve('dns.google.', 'A')
         self.assertIs(answer2, answer1)
 
+    def testCanonicalNameNoCNAME(self):
+        cname = dns.name.from_text('www.google.com')
+        self.assertTrue(dns.resolver.canonical_name('www.google.com') == cname)
+
+    def testCanonicalNameCNAME(self):
+        name = dns.name.from_text('www.dnspython.org')
+        cname = dns.name.from_text('dmfrjf4ips8xa.cloudfront.net')
+        self.assertTrue(dns.resolver.canonical_name(name) == cname)
+
+    def testCanonicalNameDangling(self):
+        name = dns.name.from_text('dangling-cname.dnspython.org')
+        cname = dns.name.from_text('dangling-target.dnspython.org')
+        self.assertTrue(dns.resolver.canonical_name(name) == cname)
+
 class PollingMonkeyPatchMixin(object):
     def setUp(self):
         self.__native_selector_class = dns.query._selector_class


### PR DESCRIPTION
This adds a canonical_name() method to the resolver, which returns the name after all CNAME and DNAME chaining has applied.  Note that it works even in the "dangling" case where the final target name is NXDOMAIN.

I treated this like resolve_address(), i.e. "another method on the resolver" as opposed to zone_for_name() which is "a function which uses the resolver".  I sort of which zone_for_name() had been a method at this point, but too late now :)

Having this method seems generally useful, but I was motivated to write it after realizing that the best way to address problem 2) in #349 is to call zone_for_name(canonical_name(name)).