### PR TITLE
Cache statistics

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -283,7 +283,7 @@ class Answer:
         del self.rrset[i]
 
 
-class CacheStats:
+class CacheStatistics:
     """Cache Statistics
     """
 
@@ -296,13 +296,13 @@ class CacheStats:
         self.misses = 0
 
     def clone(self):
-        return CacheStats(self.hits, self.misses)
+        return CacheStatistics(self.hits, self.misses)
 
 
 class CacheBase:
     def __init__(self):
         self.lock = _threading.Lock()
-        self.statistics = CacheStats()
+        self.statistics = CacheStatistics()
 
     def reset_statistics(self):
         """Reset all statistics to zero."""

--- a/doc/resolver-caching.rst
+++ b/doc/resolver-caching.rst
@@ -11,7 +11,12 @@ the data, and will not return expired entries.
 
 Two thread-safe cache implementations are provided, a simple
 dictionary-based Cache, and an LRUCache which provides cache size
-control suitable for use in web crawlers.
+control suitable for use in web crawlers.  Both are subclasses of
+a common base class which provides basic statistics.  The LRUCache can
+also provide a hits count per cache entry.
+
+.. autoclass:: dns.resolver.CacheBase
+   :members:
 
 .. autoclass:: dns.resolver.Cache
    :members:
@@ -19,3 +24,5 @@ control suitable for use in web crawlers.
 .. autoclass:: dns.resolver.LRUCache
    :members:
 
+.. autoclass:: dns.resolver.CacheStatistics
+   :members:


### PR DESCRIPTION
This provides basic hit and misses counts for caches.  Also, the LRUCache object can provide a hits count for any given key.  (The basic Cache can't do that as it doesn't have a separate cache node object, and thus cannot provide proper locking.)  I think this is probably ok as there's not really any reason to use the Cache as the LRUCache is always better.  Probably we should have made Cache an alias for LRUCache in 2.0.0.  I suppose we could still do that :)
