### PR TITLE
Unify Chaining Code

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -745,8 +745,7 @@ class QueryMessage(Message):
             try:
                 rrset = self.find_rrset(self.answer, qname, question.rdclass,
                                         question.rdtype)
-                if rrset.ttl < min_ttl:
-                    min_ttl = rrset.ttl
+                min_ttl = min(min_ttl, rrset.ttl)
                 break
             except KeyError:
                 if question.rdtype != dns.rdatatype.CNAME:
@@ -754,8 +753,7 @@ class QueryMessage(Message):
                         crrset = self.find_rrset(self.answer, qname,
                                                  question.rdclass,
                                                  dns.rdatatype.CNAME)
-                        if crrset.ttl < min_ttl:
-                            min_ttl = crrset.ttl
+                        min_ttl = min(min_ttl, crrset.ttl)
                         for rd in crrset:
                             qname = rd.target
                             break
@@ -778,10 +776,7 @@ class QueryMessage(Message):
                     srrset = self.find_rrset(self.authority, auname,
                                              question.rdclass,
                                              dns.rdatatype.SOA)
-                    if srrset.ttl < min_ttl:
-                        min_ttl = srrset.ttl
-                    if srrset[0].minimum < min_ttl:
-                        min_ttl = srrset[0].minimum
+                    min_ttl = min(min_ttl, srrset.ttl, srrset[0].minimum)
                     break
                 except KeyError:
                     try:

--- a/dns/message.py
+++ b/dns/message.py
@@ -35,6 +35,7 @@ import dns.rdataclass
 import dns.rdatatype
 import dns.rrset
 import dns.renderer
+import dns.ttl
 import dns.tsig
 import dns.rdtypes.ANY.OPT
 import dns.rdtypes.ANY.TSIG
@@ -735,14 +736,14 @@ class QueryMessage(Message):
             raise dns.exception.FormError
         question = self.question[0]
         qname = question.name
-        min_ttl = -1
+        min_ttl = dns.ttl.MAX_TTL
         rrset = None
         count = 0
         while count < MAX_CHAIN:
             try:
                 rrset = self.find_rrset(self.answer, qname, question.rdclass,
                                         question.rdtype)
-                if min_ttl == -1 or rrset.ttl < min_ttl:
+                if rrset.ttl < min_ttl:
                     min_ttl = rrset.ttl
                 break
             except KeyError:
@@ -751,7 +752,7 @@ class QueryMessage(Message):
                         crrset = self.find_rrset(self.answer, qname,
                                                  question.rdclass,
                                                  dns.rdatatype.CNAME)
-                        if min_ttl == -1 or crrset.ttl < min_ttl:
+                        if crrset.ttl < min_ttl:
                             min_ttl = crrset.ttl
                         for rd in crrset:
                             qname = rd.target
@@ -775,7 +776,7 @@ class QueryMessage(Message):
                     srrset = self.find_rrset(self.authority, auname,
                                              question.rdclass,
                                              dns.rdatatype.SOA)
-                    if min_ttl == -1 or srrset.ttl < min_ttl:
+                    if srrset.ttl < min_ttl:
                         min_ttl = srrset.ttl
                     if srrset[0].minimum < min_ttl:
                         min_ttl = srrset[0].minimum

--- a/dns/message.py
+++ b/dns/message.py
@@ -716,19 +716,21 @@ class QueryMessage(Message):
         """Follow the CNAME chain in the response to determine the answer
         RRset.
 
-        Raises NotQueryResponse if the message is not a response.
+        Raises ``dns.message.NotQueryResponse`` if the message is not
+        a response.
 
-        Raises dns.message.ChainTooLong if the CNAME chain is too long.
+        Raises ``dns.message.ChainTooLong`` if the CNAME chain is too long.
 
-        Raises AnswerForNXDOMAIN if the rcode is NXDOMAIN but an answer was
-        found.
+        Raises ``dns.message.AnswerForNXDOMAIN`` if the rcode is NXDOMAIN
+        but an answer was found.
 
-        Raises dns.exception.FormError if the question count is not 1.
+        Raises ``dns.exception.FormError`` if the question count is not 1.
 
         Returns a tuple (dns.name.Name, int, rrset) where the name is the
         canonical name, the int is the minimized TTL, and rrset is their
         answer RRset, which may be ``None`` if the chain was dangling or
         the response is an NXDOMAIN.
+
         """
         if self.flags & dns.flags.QR == 0:
             raise NotQueryResponse
@@ -792,14 +794,15 @@ class QueryMessage(Message):
         """Return the canonical name of the first name in the question
         section.
 
-        Raises dns.message.NotQueryResponse if the message is not a response.
+        Raises ``dns.message.NotQueryResponse`` if the message is not
+        a response.
 
-        Raises dns.message.ChainTooLong if the CNAME chain is too long.
+        Raises ``dns.message.ChainTooLong`` if the CNAME chain is too long.
 
-        Raises AnswerForNXDOMAIN if the rcode is NXDOMAIN but an answer was
-        found.
+        Raises ``dns.message.AnswerForNXDOMAIN`` if the rcode is NXDOMAIN
+        but an answer was found.
 
-        Raises dns.exception.FormError if the question count is not 1.
+        Raises ``dns.exception.FormError`` if the question count is not 1.
         """
         return self.resolve_chaining()[0]
 

--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -19,6 +19,7 @@
 
 import dns.exception
 
+MAX_TTL = 2147483647
 
 class BadTTL(dns.exception.SyntaxError):
     """DNS TTL value is not well-formed."""
@@ -64,6 +65,6 @@ def from_text(text):
                 current = 0
         if not current == 0:
             raise BadTTL("trailing integer")
-    if total < 0 or total > 2147483647:
+    if total < 0 or total > MAX_TTL:
         raise BadTTL("TTL should be between 0 and 2^31 - 1 (inclusive)")
     return total

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -104,6 +104,18 @@ example. 1 IN A 10.0.0.1
 ;ADDITIONAL
 """
 
+message_text_mx = """id 1234
+opcode QUERY
+rcode NOERROR
+flags QR AA RD
+;QUESTION
+example. IN MX
+;ANSWER
+example. 1 IN A 10.0.0.1
+;AUTHORITY
+;ADDITIONAL
+"""
+
 dangling_cname_0_message_text = """id 10000
 opcode QUERY
 rcode NOERROR
@@ -222,7 +234,7 @@ class BaseResolverTests(unittest.TestCase):
 
     def testIndexErrorOnEmptyRRsetAccess(self):
         def bad():
-            message = dns.message.from_text(message_text)
+            message = dns.message.from_text(message_text_mx)
             name = dns.name.from_text('example.')
             answer = dns.resolver.Answer(name, dns.rdatatype.MX,
                                          dns.rdataclass.IN, message,
@@ -232,7 +244,7 @@ class BaseResolverTests(unittest.TestCase):
 
     def testIndexErrorOnEmptyRRsetDelete(self):
         def bad():
-            message = dns.message.from_text(message_text)
+            message = dns.message.from_text(message_text_mx)
             name = dns.name.from_text('example.')
             answer = dns.resolver.Answer(name, dns.rdatatype.MX,
                                          dns.rdataclass.IN, message,


### PR DESCRIPTION
It bothered me that we did the complex "canonical name" computation twice, in two different ways, so I decided to unify the code.

The approach I took was to add a resolve_chaining() method to QueryMessage basing it on the chaining code in Answer, which was the more robust of the two ways.

This code has some improvements to the original code as well:

1) If the CNAME chain is too long, we raise instead of just stopping on the 16th CNAME.
2) If a message claims to be an NXDOMAIN but actually has the answer, we complain about this.  (Probably this never happens, but we can easily notice it as part of chaining, so we do.)

Also, is_response() is augmented/fixed as the prior code said "yes" if the rcode was not NOERROR.  We now insist the question section matches in most error cases, though we still permit FORMERR, SERVFAIL, NOTIMP, and REFUSED to have no question section.  This needed to be done as the revised chaining code wants to use the first question as the starting point, unlike the Answer code which used information passed in as the starting point.

Slight changes were required in the Resolution business logic to deal with the fact that Answer() can now raise.  We treat Answer() raising as a "this nameserver should be removed from the mix" error.  Test coverage was added to bring the Resolution business logic back to 100% coverage (including branches), as well as to cover the new checks.

A few tests trying to provoke IndexErrors on answer.rrset had to be updated as the technique they used to create an "answer to a different question" was not effective after the changes. 