### PR TITLE
Wrap exceptions from rdata from_text() and from_wire().

### DIFF
--- a/dns/exception.py
+++ b/dns/exception.py
@@ -126,3 +126,17 @@ class Timeout(DNSException):
     """The DNS operation timed out."""
     supp_kwargs = {'timeout'}
     fmt = "The DNS operation timed out after {timeout} seconds"
+
+
+class ExceptionWrapper:
+    def __init__(self, exception_class):
+        self.exception_class = exception_class
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None and not isinstance(exc_val,
+                                                   self.exception_class):
+            raise self.exception_class() from exc_val
+        return False


### PR DESCRIPTION
This demonstrates the exception wrapping mechanism proposal discussed in #512, with a little added nuance that instances of the wrapper exception are not wrapped.  Note that because of the "instances are not wrapped" feature, any raised SyntaxError in from_text() or FormError in from_wire() is the last exception in the backtrace.  This includes subclasses, e.g. if UnexpectedEnd is raised.

The patch also contains fixes for the few tests that broke.  I think the fixes are improvements, as the GPOS code (already checking some things in the constructor) was returning FormError to a from_text().

I'm inclined to merge this into 2.1, though I worry about subtle errors in application code.  My expectation, however, is that people are not processing rdata parsing exceptions so finely.  I expect most of the time it is "did the raise or not"?