### PR TITLE
Adds support for reading TSIG text format.

### DIFF
--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -530,6 +530,21 @@ class Tokenizer:
                 '%d is not an unsigned 32-bit integer' % value)
         return value
 
+    def get_uint48(self, base=10):
+        """Read the next token and interpret it as a 48-bit unsigned
+        integer.
+
+        Raises dns.exception.SyntaxError if not a 48-bit unsigned integer.
+
+        Returns an int.
+        """
+
+        value = self.get_int(base=base)
+        if value < 0 or value > 281474976710655:
+            raise dns.exception.SyntaxError(
+                '%d is not an unsigned 48-bit integer' % value)
+        return value
+
     def get_string(self, max_length=None):
         """Read the next token and interpret it as a string.
 

--- a/dns/tsig.py
+++ b/dns/tsig.py
@@ -264,12 +264,9 @@ def sign(wire, key, rdata, time=None, request_mac=None, ctx=None, multi=False):
 
     ctx = _digest(wire, key, rdata, time, request_mac, ctx, multi)
     mac = ctx.sign()
-    tsig = dns.rdtypes.ANY.TSIG.TSIG(dns.rdataclass.ANY, dns.rdatatype.TSIG,
-                                     key.algorithm, time, rdata.fudge, mac,
-                                     rdata.original_id, rdata.error,
-                                     rdata.other)
+    tsig = rdata.replace(time_signed=time, mac=mac)
 
-    return tsig, _maybe_start_digest(key, mac, multi)
+    return (tsig, _maybe_start_digest(key, mac, multi))
 
 
 def validate(wire, key, owner, rdata, now, request_mac, tsig_start, ctx=None,

--- a/dns/wire.py
+++ b/dns/wire.py
@@ -42,6 +42,9 @@ class Parser:
     def get_uint32(self):
         return struct.unpack('!I', self.get_bytes(4))[0]
 
+    def get_uint48(self):
+        return int.from_bytes(self.get_bytes(6), 'big')
+
     def get_struct(self, format):
         return struct.unpack(format, self.get_bytes(struct.calcsize(format)))
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -207,6 +207,9 @@ class TokenizerTestCase(unittest.TestCase):
             tok = dns.tokenizer.Tokenizer('q1234')
             tok.get_int()
         with self.assertRaises(dns.exception.SyntaxError):
+            tok = dns.tokenizer.Tokenizer('281474976710656')
+            tok.get_uint48()
+        with self.assertRaises(dns.exception.SyntaxError):
             tok = dns.tokenizer.Tokenizer('4294967296')
             tok.get_uint32()
         with self.assertRaises(dns.exception.SyntaxError):

--- a/tests/test_tsig.py
+++ b/tests/test_tsig.py
@@ -245,3 +245,22 @@ class TSIGTestCase(unittest.TestCase):
 
     def test_hmac_sha512_256(self):
         self._test_truncated_algorithm(dns.tsig.HMAC_SHA512_256, 256)
+
+    def text_format(self):
+        key = dns.tsig.Key('foo', b'abcdefg', algorithm=alg)
+        q = dns.message.make_query('example', 'a')
+        q.use_tsig(key)
+        _ = q.to_wire()
+
+        text = q.tsig[0].to_text()
+        tsig2 = dns.rdata.from_text('ANY', 'TSIG', text)
+        self.assertEqual(tsig2, q.tsig[0])
+
+        q = dns.message.make_query('example', 'a')
+        q.use_tsig(key, other_data='abc')
+        q.use_tsig(key)
+        _ = q.to_wire()
+
+        text = q.tsig[0].to_text()
+        tsig2 = dns.rdata.from_text('ANY', 'TSIG', text)
+        self.assertEqual(tsig2, q.tsig[0])


### PR DESCRIPTION
Implements from_text for the TSIG record type, and clean up some other
things.

Fixes the text format to emit fields in the right order; fudge and
time_signed were reversed.  This also matches BIND's output format now.

Add get_uint48() to the tokenizer, so that from_text() can use it.  Add
get_uint48() to the wire parser, and use it in from_wire, for
consistency.

Change dns.tsig.sign() to use rdata.replace() rather than constructing a
new TSIG record manually; this couldn't be done before, because
replace() uses text format for validation.