### PR TITLE
Address RRset.match() signature issues

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -351,7 +351,8 @@ class Message:
                     return rrset
             else:
                 for rrset in section:
-                    if rrset.match(name, rdclass, rdtype, covers, deleting):
+                    if rrset.full_match(name, rdclass, rdtype, covers,
+                                        deleting):
                         return rrset
         if not create:
             raise KeyError

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -196,6 +196,9 @@ class Rdataset(dns.set.Set):
         *relativize*, a ``bool``.  If ``True``, names will be relativized
         to *origin*.
 
+        *override_rdclass*, a ``dns.rdataclass.RdataClass`` or ``None``.
+        If not ``None``, use this class instead of the Rdataset's class.
+
         *want_comments*, a ``bool``.  If ``True``, emit comments for rdata
         which have them.  The default is ``False``.
         """

--- a/tests/test_rrset.py
+++ b/tests/test_rrset.py
@@ -79,42 +79,54 @@ class RRsetTestCase(unittest.TestCase):
         self.assertFalse(r1 is r2)
         self.assertTrue(r1 == r2)
 
-    def testMatch1(self):
+    def testFullMatch1(self):
+        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
+                                      ['10.0.0.1', '10.0.0.2'])
+        self.assertTrue(r1.full_match(r1.name, dns.rdataclass.IN,
+                                      dns.rdatatype.A, dns.rdatatype.NONE))
+
+    def testFullMatch2(self):
+        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
+                                      ['10.0.0.1', '10.0.0.2'])
+        r1.deleting = dns.rdataclass.NONE
+        self.assertTrue(r1.full_match(r1.name, dns.rdataclass.IN,
+                                      dns.rdatatype.A, dns.rdatatype.NONE,
+                                      dns.rdataclass.NONE))
+
+    def testNoFullMatch1(self):
+        n = dns.name.from_text('bar', None)
+        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
+                                      ['10.0.0.1', '10.0.0.2'])
+        self.assertFalse(r1.full_match(n, dns.rdataclass.IN,
+                                       dns.rdatatype.A, dns.rdatatype.NONE,
+                                       dns.rdataclass.ANY))
+
+    def testNoFullMatch2(self):
+        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
+                                      ['10.0.0.1', '10.0.0.2'])
+        r1.deleting = dns.rdataclass.NONE
+        self.assertFalse(r1.full_match(r1.name, dns.rdataclass.IN,
+                                       dns.rdatatype.A, dns.rdatatype.NONE,
+                                       dns.rdataclass.ANY))
+
+    def testNoFullMatch3(self):
+        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
+                                      ['10.0.0.1', '10.0.0.2'])
+        self.assertFalse(r1.full_match(r1.name, dns.rdataclass.IN,
+                                       dns.rdatatype.MX, dns.rdatatype.NONE,
+                                       dns.rdataclass.ANY))
+
+    def testMatchCompatibilityWithFullMatch(self):
         r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
                                       ['10.0.0.1', '10.0.0.2'])
         self.assertTrue(r1.match(r1.name, dns.rdataclass.IN,
                                  dns.rdatatype.A, dns.rdatatype.NONE))
 
-    def testMatch2(self):
+    def testMatchCompatibilityWithRdatasetMatch(self):
         r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
                                       ['10.0.0.1', '10.0.0.2'])
-        r1.deleting = dns.rdataclass.NONE
-        self.assertTrue(r1.match(r1.name, dns.rdataclass.IN,
-                                 dns.rdatatype.A, dns.rdatatype.NONE,
-                                 dns.rdataclass.NONE))
-
-    def testNoMatch1(self):
-        n = dns.name.from_text('bar', None)
-        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
-                                      ['10.0.0.1', '10.0.0.2'])
-        self.assertFalse(r1.match(n, dns.rdataclass.IN,
-                                  dns.rdatatype.A, dns.rdatatype.NONE,
-                                  dns.rdataclass.ANY))
-
-    def testNoMatch2(self):
-        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
-                                      ['10.0.0.1', '10.0.0.2'])
-        r1.deleting = dns.rdataclass.NONE
-        self.assertFalse(r1.match(r1.name, dns.rdataclass.IN,
-                                  dns.rdatatype.A, dns.rdatatype.NONE,
-                                  dns.rdataclass.ANY))
-
-    def testNoMatch3(self):
-        r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',
-                                      ['10.0.0.1', '10.0.0.2'])
-        self.assertFalse(r1.match(r1.name, dns.rdataclass.IN,
-                                  dns.rdatatype.MX, dns.rdatatype.NONE,
-                                  dns.rdataclass.ANY))
+        self.assertTrue(r1.match(dns.rdataclass.IN, dns.rdatatype.A,
+                                 dns.rdatatype.NONE))
 
     def testToRdataset(self):
         r1 = dns.rrset.from_text_list('foo', 30, 'in', 'a',


### PR DESCRIPTION
An unfortunate design decision in the past caused RRset.match() to have an incompatible signature with its superclass, Rdataset.match().  This has caused problems in cases where the RRset is being used just as an Rdataset, and required warning suppression.

This PR examines the first argument of the method, and if it is a name calls a new method, full_match(), which behaves exactly as RRset.match did and ensures backwards compatibility.  If the first argument is not a name, then it just calls Rdataset.match() and so behaves as expected when the RRset is treated like an Rdataset.