### PR TITLE
Avoid using deprecated Resolver.query in examples

### DIFF
--- a/examples/mx.py
+++ b/examples/mx.py
@@ -2,6 +2,6 @@
 
 import dns.resolver
 
-answers = dns.resolver.query('nominum.com', 'MX')
+answers = dns.resolver.resolve('nominum.com', 'MX')
 for rdata in answers:
     print('Host', rdata.exchange, 'has preference', rdata.preference)

--- a/examples/query_specific.py
+++ b/examples/query_specific.py
@@ -31,7 +31,7 @@ import dns.resolver
 
 resolver = dns.resolver.Resolver(configure=False)
 resolver.nameservers = ['8.8.8.8']
-answer = resolver.query('amazon.com', 'NS')
+answer = resolver.resolve('amazon.com', 'NS')
 print('The nameservers are:')
 for rr in answer:
     print(rr.target)

--- a/examples/xfr.py
+++ b/examples/xfr.py
@@ -4,8 +4,8 @@ import dns.query
 import dns.resolver
 import dns.zone
 
-soa_answer = dns.resolver.query('dnspython.org', 'SOA')
-master_answer = dns.resolver.query(soa_answer[0].mname, 'A')
+soa_answer = dns.resolver.resolve('dnspython.org', 'SOA')
+master_answer = dns.resolver.resolve(soa_answer[0].mname, 'A')
 
 z = dns.zone.from_xfr(dns.query.xfr(master_answer[0].address, 'dnspython.org'))
 for n in sorted(z.nodes.keys()):


### PR DESCRIPTION
Also, thanks for this library! Made it possible to write [nasebohr](https://github.com/The-Compiler/nasebohr) in just a couple of lines of Python :slightly_smiling_face: 