### PR TITLE
TSIG: don't relativize algorithm name

### DIFF
--- a/dns/rdtypes/ANY/TSIG.py
+++ b/dns/rdtypes/ANY/TSIG.py
@@ -110,7 +110,7 @@ class TSIG(dns.rdata.Rdata):
 
     @classmethod
     def from_wire_parser(cls, rdclass, rdtype, parser, origin=None):
-        algorithm = parser.get_name(origin)
+        algorithm = parser.get_name()
         time_signed = parser.get_uint48()
         fudge = parser.get_uint16()
         mac = parser.get_counted_bytes(2)


### PR DESCRIPTION
The domain name relativization of TSIG's algorithm name breaks TSIG validation when using with the Root zone.

Example for algorithm `hmac-sha224`:

```
zone 'example.com.' -> hmac-sha224.
zone '.'            -> hmac-sha224
```