### PR TITLE
Added support for resolv.conf in windows to support search domains

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -724,10 +724,17 @@ class BaseResolver:
 
         self.reset()
         if configure:
-            if sys.platform == 'win32':
-                self.read_registry()
-            elif filename:
+            if filename != '/etc/resolv.conf':
                 self.read_resolv_conf(filename)
+            elif sys.platform == 'win32':
+                self.read_registry()  # pragma: no cover
+            else:
+                self.read_resolv_conf('/etc/resolv.conf')            
+        else:            
+            if sys.platform == 'win32':                
+                self.read_registry()  # pragma: no cover
+            else:
+                self.read_resolv_conf('/etc/resolv.conf')
 
     def reset(self):
         """Reset all resolver configuration to the defaults."""


### PR DESCRIPTION
I had a usecase where I wanted to search against additional dns suffix that were not pushed through dhcp and specifying 'resolv.conf' was not supported on windows. I modified code in dns/resolver.py to add that support. Now 'resolv.conf' can be specified to change DNS servers and search domains on windows just like linux. 