### PR TITLE
resolve_chaining() now returns a ChainingResult object.

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -210,8 +210,12 @@ class Answer:
         self.response = response
         self.nameserver = nameserver
         self.port = port
-        (self.canonical_name, min_ttl, self.rrset) = response.resolve_chaining()
-        self.expiration = time.time() + min_ttl
+        self.chaining_result = response.resolve_chaining()
+        # Copy some attributes out of chaining_result for backwards
+        # compatibilty and convenience.
+        self.canonical_name = self.chaining_result.canonical_name
+        self.rrset = self.chaining_result.rrset
+        self.expiration = time.time() + self.chaining_result.minimum_ttl
 
     def __getattr__(self, attr):  # pragma: no cover
         if attr == 'name':

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -212,9 +212,9 @@ class Answer:
         self.port = port
         self.chaining_result = response.resolve_chaining()
         # Copy some attributes out of chaining_result for backwards
-        # compatibilty and convenience.
+        # compatibility and convenience.
         self.canonical_name = self.chaining_result.canonical_name
-        self.rrset = self.chaining_result.rrset
+        self.rrset = self.chaining_result.answer
         self.expiration = time.time() + self.chaining_result.minimum_ttl
 
     def __getattr__(self, attr):  # pragma: no cover

--- a/doc/message-query.rst
+++ b/doc/message-query.rst
@@ -3,7 +3,16 @@
 The dns.message.QueryMessage Class
 ----------------------------------
 
-The ``dns.update.QueryMessage`` class is used for ordinary DNS query messages.
+The ``dns.message.QueryMessage`` class is used for ordinary DNS query messages.
 
 .. autoclass:: dns.message.QueryMessage
+   :members:
+
+The dns.message.ChainingResult Class
+------------------------------------
+
+Objects of the ``dns.message.ChainingResult`` class are returned by the
+``dns.message.QueryMessage.resolve_chaining()`` method.
+
+.. autoclass:: dns.message.ChainingResult
    :members:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -563,7 +563,7 @@ example. 300 IN SOA . . 1 2 3 4 5
         self.assertEqual(result.canonical_name,
                          dns.name.from_text('www.example.'))
         self.assertEqual(result.minimum_ttl, 5)
-        self.assertIsNone(result.rrset)
+        self.assertIsNone(result.answer)
 
     def test_bad_text_questions(self):
         with self.assertRaises(dns.exception.SyntaxError):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -559,10 +559,11 @@ www.example. IN CNAME
 example. 300 IN SOA . . 1 2 3 4 5
 ''')
         # passing is actuall not going into an infinite loop in this call
-        (qname, min_ttl, rrset) = r.resolve_chaining()
-        self.assertEqual(qname, dns.name.from_text('www.example.'))
-        self.assertEqual(min_ttl, 5)
-        self.assertIsNone(rrset)
+        result = r.resolve_chaining()
+        self.assertEqual(result.canonical_name,
+                         dns.name.from_text('www.example.'))
+        self.assertEqual(result.minimum_ttl, 5)
+        self.assertIsNone(result.rrset)
 
     def test_bad_text_questions(self):
         with self.assertRaises(dns.exception.SyntaxError):


### PR DESCRIPTION
This is an alternative to #605 that creates a ChainingResult object.

It does not currently attempt to return delegation information, but by returning an object we allow resolve_chaining() to be enhanced in the future without breaking backwards compatibility.  The idea would be to extract delegation info too, and also add some handy methods like is_delegation(), is_nxdomain(), is_dangling_cname(), is_no_error_no_data(), etc.

I propose we do that extra stuff post 2.1.