### PR TITLE
Ensure that DS digest length is consistent with digest type

### DIFF
--- a/dns/rdtypes/dsbase.py
+++ b/dns/rdtypes/dsbase.py
@@ -24,6 +24,15 @@ import dns.rdata
 import dns.rdatatype
 
 
+# Digest types registry: https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
+_digest_length_by_type = {
+    1: 20,  # SHA-1, RFC 3658 Sec. 2.4
+    2: 32,  # SHA-256, RFC 4509 Sec. 2.2
+    3: 32,  # GOST R 34.11-94, RFC 5933 Sec. 4 in conjunction with RFC 4490 Sec. 2.1
+    4: 48,  # SHA-384, RFC 6605 Sec. 2
+}
+
+
 @dns.immutable.immutable
 class DSBase(dns.rdata.Rdata):
 
@@ -38,6 +47,15 @@ class DSBase(dns.rdata.Rdata):
         self.algorithm = dns.dnssec.Algorithm.make(algorithm)
         self.digest_type = self._as_uint8(digest_type)
         self.digest = self._as_bytes(digest)
+
+        try:
+            if self.digest_type == 0:  # reserved, RFC 3658 Sec. 2.4
+                raise ValueError('digest type 0 is reserved')
+            expected_length = _digest_length_by_type[self.digest_type]
+        except KeyError:
+            raise ValueError('unknown digest type')
+        if len(self.digest) != expected_length:
+            raise ValueError('digest length inconsistent with digest type')
 
     def to_text(self, origin=None, relativize=True, **kw):
         kw = kw.copy()


### PR DESCRIPTION
DS/CDS/DLV records with digests of invalid length lead to malformed packages: Wrong length digests violates the wire format specifications which has fixed digest field lengths dependent on the digest type. For example, for digest type 1 (SHA-1), RFC 3658 Sec. 2.4 states:
> The size of the DS RDATA for type 1 (SHA-1) is 24 bytes

This PR fixes the issue, strengthening use cases where dnspython is employed for performing input validation (inspired by https://github.com/PowerDNS/pdns/issues/9988).