### PR TITLE
make `name in zone` consistent with `zone[name]`

### DIFF
--- a/dns/zone.py
+++ b/dns/zone.py
@@ -162,8 +162,9 @@ class Zone(dns.transaction.TransactionManager):
         key = self._validate_name(key)
         return self.nodes.get(key)
 
-    def __contains__(self, other):
-        return other in self.nodes
+    def __contains__(self, key):
+        key = self._validate_name(key)
+        return key in self.nodes
 
     def find_node(self, name, create=False):
         """Find a node in the zone, possibly creating it.

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -872,5 +872,15 @@ class VersionedZoneTestCase(unittest.TestCase):
             rds = txn.get('example.', 'soa')
             self.assertEqual(rds[0].serial, 1)
 
+    def testNameInZoneWithStr(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=False)
+        self.assertTrue('ns1.example.' in z)
+        self.assertTrue('bar.foo.example.' in z)
+
+    def testNameInZoneWhereNameIsNotValid(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=False)
+        with self.assertRaises(KeyError):
+            self.assertTrue(1 in z)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
specifically, allow name to be a str, and raise a KeyError if name
cannot be converted into a dns.name.Name