### PR TITLE
asyncio on Windows requries connected sockets.  [Issue #637]

### DIFF
--- a/dns/_asyncbackend.py
+++ b/dns/_asyncbackend.py
@@ -64,3 +64,6 @@ class Backend:    # pragma: no cover
                           source=None, destination=None, timeout=None,
                           ssl_context=None, server_hostname=None):
         raise NotImplementedError
+
+    def datagram_connection_required(self):
+        return False

--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -4,10 +4,13 @@
 
 import socket
 import asyncio
+import sys
 
 import dns._asyncbackend
 import dns.exception
 
+
+_is_win32 = sys.platform == 'win32'
 
 def _get_running_loop():
     try:
@@ -114,11 +117,16 @@ class Backend(dns._asyncbackend.Backend):
     async def make_socket(self, af, socktype, proto=0,
                           source=None, destination=None, timeout=None,
                           ssl_context=None, server_hostname=None):
+        if destination is None and socktype == socket.SOCK_DGRAM and \
+           _is_win32:
+            raise NotImplementedError('destinationless datagram sockets '
+                                      'are not supported by asyncio '
+                                      'on Windows')
         loop = _get_running_loop()
         if socktype == socket.SOCK_DGRAM:
             transport, protocol = await loop.create_datagram_endpoint(
                 _DatagramProtocol, source, family=af,
-                proto=proto)
+                proto=proto, remote_addr=destination)
             return DatagramSocket(af, transport, protocol)
         elif socktype == socket.SOCK_STREAM:
             (r, w) = await _maybe_wait_for(
@@ -136,3 +144,7 @@ class Backend(dns._asyncbackend.Backend):
 
     async def sleep(self, interval):
         await asyncio.sleep(interval)
+
+    def datagram_connection_required(self):
+        return _is_win32
+        

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -142,7 +142,12 @@ async def udp(q, where, timeout=None, port=53, source=None, source_port=0,
             if not backend:
                 backend = dns.asyncbackend.get_default_backend()
             stuple = _source_tuple(af, source, source_port)
-            s = await backend.make_socket(af, socket.SOCK_DGRAM, 0, stuple)
+            if backend.datagram_connection_required():
+                dtuple = (where, port)
+            else:
+                dtuple = None
+            s = await backend.make_socket(af, socket.SOCK_DGRAM, 0, stuple,
+                                          dtuple)
         await send_udp(s, wire, destination, expiration)
         (r, received_time, _) = await receive_udp(s, destination, expiration,
                                                   ignore_unexpected,


### PR DESCRIPTION
This is a fix for 637 that only affects asyncio on Windows; all other UDP sockets remain as they were, unconnected.