### PR TITLE
Added serial to inbound_xfr arguments

### DIFF
--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -356,7 +356,7 @@ async def tls(q, where, timeout=None, port=853, source=None, source_port=0,
 
 async def inbound_xfr(where, txn_manager, query=None,
                       port=53, timeout=None, lifetime=None, source=None,
-                      source_port=0, udp_mode=UDPMode.NEVER,
+                      source_port=0, udp_mode=UDPMode.NEVER, serial=0,
                       backend=None):
     """Conduct an inbound transfer and apply it via a transaction from the
     txn_manager.

--- a/dns/query.py
+++ b/dns/query.py
@@ -997,7 +997,7 @@ class UDPMode(enum.IntEnum):
 
 def inbound_xfr(where, txn_manager, query=None,
                 port=53, timeout=None, lifetime=None, source=None,
-                source_port=0, udp_mode=UDPMode.NEVER):
+                source_port=0, udp_mode=UDPMode.NEVER, serial=0):
     """Conduct an inbound transfer and apply it via a transaction from the
     txn_manager.
 


### PR DESCRIPTION
When using a custom/predefined query with inbound_xfr, serial will be undefined causing an error. The serial var. is only set internally when "query is None". Without serial=0 / =None, I can't seem to force an AXFR.