### PR TITLE
Fix for #682 - updating MAX_TTL

### DIFF
--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -71,7 +71,7 @@ def from_text(text):
         if not current == 0:
             raise BadTTL("trailing integer")
     if total < 0 or total > MAX_TTL:
-        raise BadTTL("TTL should be between 0 and 2**132 - 1 (inclusive)")
+        raise BadTTL("TTL should be between 0 and 2**32 - 1 (inclusive)")
     return total
 
 

--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -19,7 +19,7 @@
 
 import dns.exception
 
-MAX_TTL = 2147483647
+MAX_TTL = 2**32 - 1  # unsigned 32bit value as per RFC 1035
 
 class BadTTL(dns.exception.SyntaxError):
     """DNS TTL value is not well-formed."""
@@ -71,7 +71,7 @@ def from_text(text):
         if not current == 0:
             raise BadTTL("trailing integer")
     if total < 0 or total > MAX_TTL:
-        raise BadTTL("TTL should be between 0 and 2^31 - 1 (inclusive)")
+        raise BadTTL("TTL should be between 0 and 2**132 - 1 (inclusive)")
     return total
 
 


### PR DESCRIPTION
finally - sorry for the back and forth -.-

Updating MAX_TTL value to 2**32 - 1 and changing the notation in the exception message to python-syntax, in case somebody copy pasted the text into a python shell - as 2^32 evaluates differently. Feel free to change.

RFC1035 is misleading as in some sections it states TTL values to be signed.