### PR TITLE
use of uint32 in SOA values

### DIFF
--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -39,10 +39,10 @@ class SOA(dns.rdata.Rdata):
         self.mname = self._as_name(mname)
         self.rname = self._as_name(rname)
         self.serial = self._as_uint32(serial)
-        self.refresh = self._as_ttl(refresh)
-        self.retry = self._as_ttl(retry)
-        self.expire = self._as_ttl(expire)
-        self.minimum = self._as_ttl(minimum)
+        self.refresh = self._as_uint32(refresh)
+        self.retry = self._as_uint32(retry)
+        self.expire = self._as_uint32(expire)
+        self.minimum = self._as_uint32(minimum)
 
     def to_text(self, origin=None, relativize=True, **kw):
         mname = self.mname.choose_relativity(origin, relativize)
@@ -57,10 +57,10 @@ class SOA(dns.rdata.Rdata):
         mname = tok.get_name(origin, relativize, relativize_to)
         rname = tok.get_name(origin, relativize, relativize_to)
         serial = tok.get_uint32()
-        refresh = tok.get_ttl()
-        retry = tok.get_ttl()
-        expire = tok.get_ttl()
-        minimum = tok.get_ttl()
+        refresh = tok.get_uint32()
+        retry = tok.get_uint32()
+        expire = tok.get_uint32()
+        minimum = tok.get_uint32()
         return cls(rdclass, rdtype, mname, rname, serial, refresh, retry,
                    expire, minimum)
 


### PR DESCRIPTION
Dear maintainer(s),

I am currently doing some DNS measurements for a paper and stumbled upon a bunch of queries that failed,
because the answers contained SOA records with values in one of REFRESH, RETRY, EXPIRE or MINIMUM that
are between 2^31-1 and 2^32-1.

If I understand RFC1035 and the clarifications in RFC 2181, section 8, correctly, only the TTL values of ressource 
records are to be limited to 2^31-1 but REFRESH, RETRY, EXPIRE and MINIMUM in the SOA are still 32 bit unsigned integers. 



I looked through all RFCs updating 1035 and grepped for SOA and EXPIRE as an example, and did not any further clarification.

Thus going back to RFC1035 again:


> SERIAL          The unsigned 32 bit version number of the original copy of the zone.  
> Zone transfers preserve this value.  This  value wraps and should be 
> compared using sequence space arithmetic.
> 
> REFRESH         
> A 32 bit time interval before the zone should be  refreshed.
> 
> RETRY
>  A 32 bit time interval that should elapse before a  failed refresh should be retried.
> 
> EXPIRE
>  A 32 bit time value that specifies the upper limit on the time interval that can 
> elapse before the zone is no longer authoritative.
> 
> MINIMUM
> The unsigned 32 bit minimum TTL field that should be  exported with  any RR from this zone.

Note, how only for  SERIAL and MINIMUM it is explicitely mentioned to be an unsigned.


Powerdns, knot and the dig utility allow such values and there are nameservers on the Internet serving such SOA records.

Example:
```
$ dig +short SOA 17.87.64.in-addr.arpa.
ns1.americanis.net. support.americanis.net. 2541206765 43200 2251427590 43200 7200
```
with  `2^31-1 <  2251427590 < 2^32-1`

I would be happy for this patch to be merged and want to apologize for the mess in the issue I opened earlier.

I did not find any other places in the code where these values are mentioned explicitely and hope the proposed patch is sufficient.

Florian