### PR TITLE
Add id to dns.message.make_query().

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1383,7 +1383,8 @@ def from_file(f, idna_codec=None, one_rr_per_rrset=False):
 
 def make_query(qname, rdtype, rdclass=dns.rdataclass.IN, use_edns=None,
                want_dnssec=False, ednsflags=None, payload=None,
-               request_payload=None, options=None, idna_codec=None):
+               request_payload=None, options=None, idna_codec=None,
+               id=None):
     """Make a query message.
 
     The query name, type, and class may all be specified either
@@ -1425,6 +1426,9 @@ def make_query(qname, rdtype, rdclass=dns.rdataclass.IN, use_edns=None,
     encoder/decoder.  If ``None``, the default IDNA 2003 encoder/decoder
     is used.
 
+    *id*, an ``int`` or ``None``, the desired query id.  The default is
+    ``None``, which generates a random query id.
+
     Returns a ``dns.message.QueryMessage``
     """
 
@@ -1432,7 +1436,7 @@ def make_query(qname, rdtype, rdclass=dns.rdataclass.IN, use_edns=None,
         qname = dns.name.from_text(qname, idna_codec=idna_codec)
     rdtype = dns.rdatatype.RdataType.make(rdtype)
     rdclass = dns.rdataclass.RdataClass.make(rdclass)
-    m = QueryMessage()
+    m = QueryMessage(id=id)
     m.flags |= dns.flags.RD
     m.find_rrset(m.question, qname, rdclass, rdtype, create=True,
                  force_unique=True)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -437,6 +437,10 @@ class MessageTestCase(unittest.TestCase):
         self.assertEqual(q.payload, 4096)
         self.assertEqual(q.options, ())
 
+    def test_setting_id(self):
+        q = dns.message.make_query('www.dnspython.org.', 'a', id=12345)
+        self.assertEqual(q.id, 12345)
+
     def test_generic_message_class(self):
         q1 = dns.message.Message(id=1)
         q1.set_opcode(dns.opcode.NOTIFY)


### PR DESCRIPTION
Allow the caller to supply a message id when building a query.