### PR TITLE
For DoH, use httpx and with HTTP/2 if we can

### DIFF
--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -360,14 +360,14 @@ async def tls(q, where, timeout=None, port=853, source=None, source_port=0,
 
 async def https(q, where, timeout=None, port=443, source=None, source_port=0,
                 one_rr_per_rrset=False, ignore_trailing=False, client=None,
-                path='/dns-query', post=True, verify=True, backend=None):
+                path='/dns-query', post=True, verify=True):
     """Return the response obtained after sending a query via DNS-over-HTTPS.
 
     *client*, a ``httpx.AsyncClient``.  If provided, the client to use for
     the query.
 
-    *backend*, a ``dns.asyncbackend.Backend``, or ``None``.  If ``None``,
-    the default, then dnspython will use the default backend.
+    Unlike the other dnspython async functions, a backend cannot be provided
+    in this function because httpx always auto-detects the async backend.
 
     See :py:func:`dns.query.https()` for the documentation of the other
     parameters, exceptions, and return type of this method.

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -17,9 +17,11 @@
 
 """Talk to a DNS server."""
 
+import base64
 import socket
 import struct
 import time
+import urllib
 
 import dns.asyncbackend
 import dns.exception
@@ -31,8 +33,10 @@ import dns.rdataclass
 import dns.rdatatype
 
 from dns.query import _compute_times, _matches_destination, BadResponse, ssl, \
-    UDPMode
+    UDPMode, have_doh, _have_httpx, _have_http2, NoDOH
 
+if _have_httpx:
+    import httpx
 
 # for brevity
 _lltuple = dns.inet.low_level_address_tuple
@@ -353,6 +357,88 @@ async def tls(q, where, timeout=None, port=853, source=None, source_port=0,
     finally:
         if not sock and s:
             await s.close()
+
+async def https(q, where, timeout=None, port=443, source=None, source_port=0,
+                one_rr_per_rrset=False, ignore_trailing=False, client=None,
+                path='/dns-query', post=True, verify=True, backend=None):
+    """Return the response obtained after sending a query via DNS-over-HTTPS.
+
+    *client*, a ``httpx.AsyncClient``.  If provided, the client to use for
+    the query.
+
+    *backend*, a ``dns.asyncbackend.Backend``, or ``None``.  If ``None``,
+    the default, then dnspython will use the default backend.
+
+    See :py:func:`dns.query.https()` for the documentation of the other
+    parameters, exceptions, and return type of this method.
+    """
+
+    if not _have_httpx:
+        raise NoDOH('httpx is not available.')  # pragma: no cover
+
+    _httpx_ok = True
+
+    wire = q.to_wire()
+    try:
+        af = dns.inet.af_for_address(where)
+    except ValueError:
+        af = None
+    transport = None
+    headers = {
+        "accept": "application/dns-message"
+    }
+    if af is not None:
+        if af == socket.AF_INET:
+            url = 'https://{}:{}{}'.format(where, port, path)
+        elif af == socket.AF_INET6:
+            url = 'https://[{}]:{}{}'.format(where, port, path)
+    else:
+        url = where
+    if source is not None:
+        transport = httpx.AsyncHTTPTransport(local_address=source[0])
+
+    # After 3.6 is no longer supported, this can use an AsyncExitStack
+    client_to_close = None
+    try:
+        if not client:
+            client = httpx.AsyncClient(http1=True, http2=_have_http2,
+                                       verify=verify, transport=transport)
+            client_to_close = client
+
+        # see https://tools.ietf.org/html/rfc8484#section-4.1.1 for DoH
+        # GET and POST examples
+        if post:
+            headers.update({
+                "content-type": "application/dns-message",
+                "content-length": str(len(wire))
+            })
+            response = await client.post(url, headers=headers, content=wire,
+                                         timeout=timeout)
+        else:
+            wire = base64.urlsafe_b64encode(wire).rstrip(b"=")
+            wire = wire.decode()  # httpx does a repr() if we give it bytes
+            response = await client.get(url, headers=headers, timeout=timeout,
+                                        params={"dns": wire})
+    finally:
+        if client_to_close:
+            await client.aclose()
+
+    # see https://tools.ietf.org/html/rfc8484#section-4.2.1 for info about DoH
+    # status codes
+    if response.status_code < 200 or response.status_code > 299:
+        raise ValueError('{} responded with status code {}'
+                         '\nResponse body: {}'.format(where,
+                                                      response.status_code,
+                                                      response.content))
+    r = dns.message.from_wire(response.content,
+                              keyring=q.keyring,
+                              request_mac=q.request_mac,
+                              one_rr_per_rrset=one_rr_per_rrset,
+                              ignore_trailing=ignore_trailing)
+    r.time = response.elapsed
+    if not q.is_response(r):
+        raise BadResponse
+    return r
 
 async def inbound_xfr(where, txn_manager, query=None,
                       port=53, timeout=None, lifetime=None, source=None,

--- a/dns/asyncresolver.py
+++ b/dns/asyncresolver.py
@@ -87,8 +87,9 @@ class Resolver(dns.resolver.BaseResolver):
                                                   raise_on_truncation=True,
                                                   backend=backend)
                     else:
-                        # We don't do DoH yet.
-                        raise NotImplementedError
+                        response = await dns.asyncquery.https(request,
+                                                              nameserver,
+                                                              timeout=timeout)
                 except Exception as ex:
                     (_, done) = resolution.query_result(None, ex)
                     continue

--- a/dns/query.py
+++ b/dns/query.py
@@ -328,7 +328,10 @@ def https(q, where, timeout=None, port=443, source=None, source_port=0,
             transport_adapter = SourceAddressAdapter(source)
 
     if session:
-        _is_httpx = isinstance(session, httpx.Client)
+        if _have_httpx:
+            _is_httpx = isinstance(session, httpx.Client)
+        else:
+            _is_httpx = False
         if _is_httpx and not _httpx_ok:
             raise NoDOH('Session is httpx, but httpx cannot be used for '
                         'the requested operation.')

--- a/dns/query.py
+++ b/dns/query.py
@@ -274,8 +274,8 @@ def https(q, where, timeout=None, port=443, source=None, source_port=0,
     *ignore_trailing*, a ``bool``. If ``True``, ignore trailing
     junk at end of the received message.
 
-    *session*, a ``requests.session.Session``.  If provided, the session to use
-    to send the queries.
+    *session*, an ``httpx.Client`` or ``requests.session.Session``.  If
+    provided, the client/session to use to send the queries.
 
     *path*, a ``str``. If *where* is an IP address, then *path* will be used to
     construct the URL to send the DNS query to.

--- a/doc/async-query.rst
+++ b/doc/async-query.rst
@@ -9,8 +9,10 @@ processing their responses.  If you want "stub resolver" behavior, then
 you should use the higher level ``dns.asyncresolver`` module; see
 :ref:`async_resolver`.
 
-There is currently no support for DNS-over-HTTPS using asynchronous
-I/O but we hope to offer this in the future.
+For UDP and TCP, the module provides a single "do everything" query
+function, and also provides the send and receive halves of this function
+individually for situations where more sophisticated I/O handling is
+being used by the application.
 
 UDP
 ---
@@ -31,6 +33,12 @@ TLS
 ---
 
 .. autofunction:: dns.asyncquery.tls
+
+HTTPS
+-----
+
+.. autofunction:: dns.asyncquery.https
+
 
 Zone Transfers
 --------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,6 +15,8 @@ What's New in dnspython
   an error trace like the NoNameservers exception.  This class is a subclass of
   dns.exception.Timeout for backwards compatibility.
 
+* DNS-over-HTTPS is now supported for asynchronous queries and resolutions.
+
 2.1.0
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ wheel = "^0.35.0"
 pylint = "^2.7.4"
 
 [tool.poetry.extras]
-doh = ['requests', 'requests-toolbelt']
+doh = ['httpx[http2]', 'requests', 'requests-toolbelt']
 idna = ['idna']
 dnssec = ['cryptography']
 trio = ['trio']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+httpx = {version=">=0.21.1", optional=true, python=">=3.6.2"}
+h2 = {version=">=4.1.0", optional=true, python=">=3.6.2"}
 requests-toolbelt = {version="^0.9.1", optional=true}
 requests = {version="^2.23.0", optional=true}
 idna = {version=">=2.1,<4.0", optional=true}
@@ -50,7 +52,7 @@ wheel = "^0.35.0"
 pylint = "^2.7.4"
 
 [tool.poetry.extras]
-doh = ['httpx[http2]', 'requests', 'requests-toolbelt']
+doh = ['httpx', 'h2', 'requests', 'requests-toolbelt']
 idna = ['idna']
 dnssec = ['cryptography']
 trio = ['trio']

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ test_suite = tests
 setup_requires = setuptools>=44; wheel; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
-DOH = requests; requests-toolbelt
+DOH = httpx>=0.21.1; h2>=4.1.0; requests; requests-toolbelt
 IDNA = idna>=2.1
 DNSSEC = cryptography>=2.6
 trio = trio>=0.14.0; sniffio>=1.1

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -23,9 +23,12 @@ import dns.query
 import dns.rdatatype
 import dns.resolver
 
-if dns.query.have_doh:
+if dns.query._have_requests:
     import requests
     from requests.exceptions import SSLError
+
+if dns.query._have_httpx:
+    import httpx
 
 # Probe for IPv4 and IPv6
 resolver_v4_addresses = []
@@ -66,9 +69,10 @@ try:
 except socket.gaierror:
     _network_available = False
 
-@unittest.skipUnless(dns.query.have_doh and _network_available,
+
+@unittest.skipUnless(dns.query._have_requests and _network_available,
                      "Python requests cannot be imported; no DNS over HTTPS (DOH)")
-class DNSOverHTTPSTestCase(unittest.TestCase):
+class DNSOverHTTPSTestCaseRequests(unittest.TestCase):
     def setUp(self):
         self.session = requests.sessions.Session()
 
@@ -118,6 +122,80 @@ class DNSOverHTTPSTestCase(unittest.TestCase):
             # make sure CleanBrowsing's IP address will fail TLS certificate
             # check
             with self.assertRaises(SSLError):
+                dns.query.https(q, invalid_tls_url, session=self.session,
+                                timeout=4)
+            # use host header
+            r = dns.query.https(q, valid_tls_url, session=self.session,
+                                bootstrap_address=ip, timeout=4)
+            self.assertTrue(q.is_response(r))
+
+    def test_new_session(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url, timeout=4)
+        self.assertTrue(q.is_response(r))
+
+    def test_resolver(self):
+        res = dns.resolver.Resolver(configure=False)
+        res.nameservers = ['https://dns.google/dns-query']
+        answer = res.resolve('dns.google', 'A')
+        seen = set([rdata.address for rdata in answer])
+        self.assertTrue('8.8.8.8' in seen)
+        self.assertTrue('8.8.4.4' in seen)
+
+
+@unittest.skipUnless(dns.query._have_httpx and _network_available,
+                     "Python httpx cannot be imported; no DNS over HTTPS (DOH)")
+class DNSOverHTTPSTestCaseHttpx(unittest.TestCase):
+    def setUp(self):
+        self.session = httpx.Client(http1=True, http2=True, verify=True)
+
+    def tearDown(self):
+        self.session.close()
+
+    def test_get_request(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url, session=self.session, post=False,
+                            timeout=4)
+        self.assertTrue(q.is_response(r))
+
+    def test_post_request(self):
+        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
+        q = dns.message.make_query('example.com.', dns.rdatatype.A)
+        r = dns.query.https(q, nameserver_url, session=self.session, post=True,
+                            timeout=4)
+        self.assertTrue(q.is_response(r))
+
+    def test_build_url_from_ip(self):
+        self.assertTrue(resolver_v4_addresses or resolver_v6_addresses)
+        if resolver_v4_addresses:
+            nameserver_ip = random.choice(resolver_v4_addresses)
+            q = dns.message.make_query('example.com.', dns.rdatatype.A)
+            # For some reason Google's DNS over HTTPS fails when you POST to
+            # https://8.8.8.8/dns-query
+            # So we're just going to do GET requests here
+            r = dns.query.https(q, nameserver_ip, session=self.session,
+                                post=False, timeout=4)
+
+            self.assertTrue(q.is_response(r))
+        if resolver_v6_addresses:
+            nameserver_ip = random.choice(resolver_v6_addresses)
+            q = dns.message.make_query('example.com.', dns.rdatatype.A)
+            r = dns.query.https(q, nameserver_ip, session=self.session,
+                                post=False, timeout=4)
+            self.assertTrue(q.is_response(r))
+
+    def test_bootstrap_address(self):
+        # We test this to see if v4 is available
+        if resolver_v4_addresses:
+            ip = '185.228.168.168'
+            invalid_tls_url = 'https://{}/doh/family-filter/'.format(ip)
+            valid_tls_url = 'https://doh.cleanbrowsing.org/doh/family-filter/'
+            q = dns.message.make_query('example.com.', dns.rdatatype.A)
+            # make sure CleanBrowsing's IP address will fail TLS certificate
+            # check
+            with self.assertRaises(httpx.ConnectError):
                 dns.query.https(q, invalid_tls_url, session=self.session,
                                 timeout=4)
             # use host header


### PR DESCRIPTION
Use httpx if we can, which is everything but the bootstrap IP case or if source_port != 0.  If we can't use httpx, try to fall back to requests.  This will use HTTP/2 in most cases.