### PR TITLE
Allow unsigned 32 bit values for SOA refresh, retry, and expire [#724].

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -513,6 +513,15 @@ class Rdata:
             raise ValueError('not a TTL')
 
     @classmethod
+    def _as_interval(cls, value):
+        if isinstance(value, int):
+            return cls._as_int(value, 0, dns.ttl.MAX_INTERVAL)
+        elif isinstance(value, str):
+            return dns.ttl.interval_from_text(value)
+        else:
+            raise ValueError('not a valid interval')
+
+    @classmethod
     def _as_tuple(cls, value, as_value):
         try:
             # For user convenience, if value is a singleton of the list

--- a/dns/rdtypes/ANY/SOA.py
+++ b/dns/rdtypes/ANY/SOA.py
@@ -39,9 +39,9 @@ class SOA(dns.rdata.Rdata):
         self.mname = self._as_name(mname)
         self.rname = self._as_name(rname)
         self.serial = self._as_uint32(serial)
-        self.refresh = self._as_ttl(refresh)
-        self.retry = self._as_ttl(retry)
-        self.expire = self._as_ttl(expire)
+        self.refresh = self._as_interval(refresh)
+        self.retry = self._as_interval(retry)
+        self.expire = self._as_interval(expire)
         self.minimum = self._as_ttl(minimum)
 
     def to_text(self, origin=None, relativize=True, **kw):
@@ -57,9 +57,9 @@ class SOA(dns.rdata.Rdata):
         mname = tok.get_name(origin, relativize, relativize_to)
         rname = tok.get_name(origin, relativize, relativize_to)
         serial = tok.get_uint32()
-        refresh = tok.get_ttl()
-        retry = tok.get_ttl()
-        expire = tok.get_ttl()
+        refresh = tok.get_interval()
+        retry = tok.get_interval()
+        expire = tok.get_interval()
         minimum = tok.get_ttl()
         return cls(rdclass, rdtype, mname, rname, serial, refresh, retry,
                    expire, minimum)

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -673,3 +673,17 @@ class Tokenizer:
         if not token.is_identifier():
             raise dns.exception.SyntaxError('expecting an identifier')
         return dns.ttl.from_text(token.value)
+
+    def get_interval(self):
+        """Read the next token and interpret it as a DNS time interval.
+
+        Raises dns.exception.SyntaxError or ValueError if not an
+        identifier or badly formed.
+
+        Returns an int.
+        """
+
+        token = self.get().unescape()
+        if not token.is_identifier():
+            raise dns.exception.SyntaxError('expecting an identifier')
+        return dns.ttl.interval_from_text(token.value)

--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -80,17 +80,12 @@ def interval_from_text(text, maximum=MAX_INTERVAL, description='interval',
 def from_text(text):
     return interval_from_text(text, MAX_TTL, 'TTL', BadTTL)
 
-def make_interval(value, maximum=MAX_INTERVAL, description='interval',
-                  exception=ValueError):
+def make(value):
     if isinstance(value, int):
-        if value < 0 or value > maximum:
-            raise exception(f'{description} should be between 0 and {maximum} '
-                            '(inclusive)')
+        # Note we do NOT bounds check here as OPT RRs can have invalid TTLs.
+        # XXXRTH Perhaps we should have a "enforce bounds" parameter?
         return value
     elif isinstance(value, str):
-        return interval_from_text(value, maximum, description, exception)
+        return from_text(value)
     else:
-        raise ValueError(f'cannot convert value to {description}')
-
-def make(value):
-    return make_interval(value, MAX_TTL, 'TTL', BadTTL)
+        raise ValueError(f'cannot convert value to a TTL')

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -696,7 +696,7 @@ class RdataTestCase(unittest.TestCase):
                     rr = dns.rdata.from_text('IN', 'DNSKEY', input_variation)
                     new_text = rr.to_text(chunksize=chunksize)
                     self.assertEqual(output, new_text)
-                    
+
     def test_relative_vs_absolute_compare_unstrict(self):
         try:
             saved = dns.rdata._allow_relative_comparisons
@@ -888,6 +888,20 @@ class UtilTestCase(unittest.TestCase):
             dns.rdataset.from_text('in', 'a', 1.6, '10.0.0.1')
         with self.assertRaises(dns.ttl.BadTTL):
             dns.rdataset.from_text('in', 'a', '10.0.0.1', '10.0.0.2')
+
+    def test_soa_interval_conversion(self):
+        rd = dns.rdata.from_text('in', 'soa', '. . 1 4294967295 3 4 5')
+        self.assertEqual(rd.refresh, 4294967295)
+        with self.assertRaises(dns.exception.SyntaxError):
+            rd = dns.rdata.from_text('in', 'soa', '. . 1 4294967296 3 4 5')
+        rd = dns.rdata.from_text('in', 'soa', '. . 1 2 4294967295 4 5')
+        self.assertEqual(rd.retry, 4294967295)
+        with self.assertRaises(dns.exception.SyntaxError):
+            rd = dns.rdata.from_text('in', 'soa', '. . 1 2 4294967296 4 5')
+        rd = dns.rdata.from_text('in', 'soa', '. . 1 2 3 4294967295 5')
+        self.assertEqual(rd.expire, 4294967295)
+        with self.assertRaises(dns.exception.SyntaxError):
+            rd = dns.rdata.from_text('in', 'soa', '. . 1 2 3 4294967296 5')
 
 
 Rdata = dns.rdata.Rdata


### PR DESCRIPTION
refresh, retry, and expire are uint32s