### PR TITLE
First draft of CNAME and other data handling in zones.

### DIFF
--- a/dns/node.py
+++ b/dns/node.py
@@ -26,7 +26,20 @@ import dns.renderer
 
 class Node:
 
-    """A Node is a set of rdatasets."""
+    """A Node is a set of rdatasets.
+
+    A node is either a CNAME node or an "other data" node.  A CNAME
+    node contains only CNAME, RRSIG(CNAME), NSEC, RRSIG(NSEC), NSEC3,
+    or RRSIG(NSEC3) rdatasets.  An "other data" node contains any
+    rdataset other than a CNAME or RRSIG(CNAME) rdataset.  When
+    changes are made to a node, the CNAME or "other data" state is
+    always consistent with the update, i.e. the most recent change
+    wins.  For example, if you have a node which contains a CNAME
+    rdataset, and then add an MX rdataset to it, then the CNAME
+    rdataset will be deleted.  Likewise if you have a node containing
+    an MX rdataset and add a CNAME rdataset, the MX rdataset will be
+    deleted.
+    """
 
     __slots__ = ['rdatasets']
 

--- a/dns/node.py
+++ b/dns/node.py
@@ -69,8 +69,8 @@ class Node:
     """A Node is a set of rdatasets.
 
     A node is either a CNAME node or an "other data" node.  A CNAME
-    node contains only CNAME, KEY, RRSIG(CNAME), NSEC, RRSIG(NSEC), NSEC3,
-    or RRSIG(NSEC3) rdatasets.  An "other data" node contains any
+    node contains only CNAME, KEY, NSEC, and NSEC3 rdatasets along with their
+    covering RRSIG rdatasets.  An "other data" node contains any
     rdataset other than a CNAME or RRSIG(CNAME) rdataset.  When
     changes are made to a node, the CNAME or "other data" state is
     always consistent with the update, i.e. the most recent change
@@ -138,7 +138,7 @@ class Node:
         Specifically, if the rdataset being appended has ``NodeKind.CNAME``,
         then all rdatasets other than KEY, NSEC, NSEC3, and their covering
         RRSIGs are deleted.  If the rdataset being appended has
-        ``NodeKind.REGUALAR`` then CNAME and RRSIG(CNAME) are deleted.
+        ``NodeKind.REGULAR`` then CNAME and RRSIG(CNAME) are deleted.
         """
         # Make having just one rdataset at the node fast.
         if len(self.rdatasets) > 0:

--- a/dns/node.py
+++ b/dns/node.py
@@ -290,7 +290,7 @@ class Node:
         return False
 
 
-dns.immutable.immutable
+@dns.immutable.immutable
 class ImmutableNode(Node):
     def __init__(self, node):
         super().__init__()

--- a/dns/node.py
+++ b/dns/node.py
@@ -29,7 +29,7 @@ class Node:
     """A Node is a set of rdatasets.
 
     A node is either a CNAME node or an "other data" node.  A CNAME
-    node contains only CNAME, RRSIG(CNAME), NSEC, RRSIG(NSEC), NSEC3,
+    node contains only CNAME, KEY, RRSIG(CNAME), NSEC, RRSIG(NSEC), NSEC3,
     or RRSIG(NSEC3) rdatasets.  An "other data" node contains any
     rdataset other than a CNAME or RRSIG(CNAME) rdataset.  When
     changes are made to a node, the CNAME or "other data" state is

--- a/dns/node.py
+++ b/dns/node.py
@@ -17,11 +17,51 @@
 
 """DNS nodes.  A node is a set of rdatasets."""
 
+import enum
 import io
 
+import dns.immutable
 import dns.rdataset
 import dns.rdatatype
 import dns.renderer
+
+
+_cname_types = {
+    dns.rdatatype.CNAME,
+}
+
+# "neutral" types can coexist with a CNAME and thus are not "other data"
+_neutral_types = {
+    dns.rdatatype.NSEC,   # RFC 4035 section 2.5
+    dns.rdatatype.NSEC3,  # This is not likely to happen, but not impossible!
+    dns.rdatatype.KEY,    # RFC 4035 section 2.5, RFC 3007
+}
+
+def _matches_type_or_its_signature(rdtypes, rdtype, covers):
+    return rdtype in rdtypes or \
+           (rdtype == dns.rdatatype.RRSIG and covers in rdtypes)
+
+
+@enum.unique
+class NodeKind(enum.Enum):
+    """Rdatasets in nodes
+    """
+    REGULAR = 0      # a.k.a "other data"
+    NEUTRAL = 1
+    CNAME = 2
+
+    @classmethod
+    def classify(cls, rdtype, covers):
+        if _matches_type_or_its_signature(_cname_types, rdtype, covers):
+            return NodeKind.CNAME
+        elif _matches_type_or_its_signature(_neutral_types, rdtype, covers):
+            return NodeKind.NEUTRAL
+        else:
+            return NodeKind.REGULAR
+
+    @classmethod
+    def classify_rdataset(cls, rdataset):
+        return cls.classify(rdataset.rdtype, rdataset.covers)
 
 
 class Node:
@@ -95,21 +135,25 @@ class Node:
         """Append rdataset to the node with special handling for CNAME and
         other data conditions.
 
-        Specifically, if the rdataset being appended is a CNAME, then
-        all rdatasets other than NSEC, NSEC3, and their covering RRSIGs
-        are deleted.  If the rdataset being appended is NOT a CNAME, then
-        CNAME and RRSIG(CNAME) are deleted.
+        Specifically, if the rdataset being appended has ``NodeKind.CNAME``,
+        then all rdatasets other than KEY, NSEC, NSEC3, and their covering
+        RRSIGs are deleted.  If the rdataset being appended has
+        ``NodeKind.REGUALAR`` then CNAME and RRSIG(CNAME) are deleted.
         """
         # Make having just one rdataset at the node fast.
         if len(self.rdatasets) > 0:
-            if rdataset.implies_cname():
-                self.rdatasets = [rds for rds in self.rdatasets
-                                  if rds.ok_for_cname()]
-            elif rdataset.implies_other_data():
-                self.rdatasets = [rds for rds in self.rdatasets
-                                  if rds.ok_for_other_data()]
+            kind = NodeKind.classify_rdataset(rdataset)
+            if kind == NodeKind.CNAME:
+                self.rdatasets = [rds for rds in self.rdatasets if
+                                  NodeKind.classify_rdataset(rds) !=
+                                  NodeKind.REGULAR]
+            elif kind == NodeKind.REGULAR:
+                self.rdatasets = [rds for rds in self.rdatasets if
+                                  NodeKind.classify_rdataset(rds) !=
+                                  NodeKind.CNAME]
+            # Otherwise the rdataset is NodeKind.NEUTRAL and we do not need to
+            # edit self.rdatasets.
         self.rdatasets.append(rdataset)
-
 
     def find_rdataset(self, rdclass, rdtype, covers=dns.rdatatype.NONE,
                       create=False):
@@ -221,11 +265,56 @@ class Node:
                              replacement.covers)
         self._append_rdataset(replacement)
 
-    def is_cname(self):
-        """Is this a CNAME node?
+    def classify(self):
+        """Classify a node.
 
-        If the node has a CNAME or an RRSIG(CNAME) it is considered a CNAME
-        node for CNAME-and-other-data purposes, and ``True`` is returned.
-        Otherwise the node is an "other data" node, and ``False`` is returned.
+        A node which contains a CNAME or RRSIG(CNAME) is a
+        ``NodeKind.CNAME`` node.
+
+        A node which contains only "neutral" types, i.e. types allowed to
+        co-exist with a CNAME, is a ``NodeKind.NEUTRAL`` node.  The neutral
+        types are NSEC, NSEC3, KEY, and their associated RRSIGS.  An empty node
+        is also considered neutral.
+
+        A node which contains some rdataset which is not a CNAME, RRSIG(CNAME),
+        or a neutral type is a a ``NodeKind.REGULAR`` node.  Regular nodes are
+        also commonly referred to as "other data".
         """
-        return any(rdataset.implies_cname() for rdataset in self.rdatasets)
+        for rdataset in self.rdatasets:
+            kind = NodeKind.classify(rdataset.rdtype, rdataset.covers)
+            if kind != NodeKind.NEUTRAL:
+                return kind
+        return NodeKind.NEUTRAL
+
+    def is_immutable(self):
+        return False
+
+
+dns.immutable.immutable
+class ImmutableNode(Node):
+    def __init__(self, node):
+        super().__init__()
+        self.rdatasets = tuple(
+            [dns.rdataset.ImmutableRdataset(rds) for rds in node.rdatasets]
+        )
+
+    def find_rdataset(self, rdclass, rdtype, covers=dns.rdatatype.NONE,
+                      create=False):
+        if create:
+            raise TypeError("immutable")
+        return super().find_rdataset(rdclass, rdtype, covers, False)
+
+    def get_rdataset(self, rdclass, rdtype, covers=dns.rdatatype.NONE,
+                     create=False):
+        if create:
+            raise TypeError("immutable")
+        return super().get_rdataset(rdclass, rdtype, covers, False)
+
+    def delete_rdataset(self, rdclass, rdtype, covers=dns.rdatatype.NONE):
+        raise TypeError("immutable")
+
+    def replace_rdataset(self, replacement):
+        raise TypeError("immutable")
+
+    def is_immutable(self):
+        return True

--- a/dns/node.py
+++ b/dns/node.py
@@ -226,3 +226,15 @@ class Node:
         self.delete_rdataset(replacement.rdclass, replacement.rdtype,
                              replacement.covers)
         self._append_rdataset(replacement)
+
+    def is_cname(self):
+        """Is this a CNAME node?
+
+        If the node has a CNAME or an RRSIG(CNAME) it is considered a CNAME
+        node for CNAME-and-other-data purposes, and ``True`` is returned.
+        Otherwise the node is an "other data" node, and ``False`` is returned.
+        """
+        for rdataset in self.rdatasets:
+            if rdataset.implies_cname():
+                return True
+        return False

--- a/dns/node.py
+++ b/dns/node.py
@@ -102,7 +102,13 @@ class Node:
         """
         # Make having just one rdataset at the node fast.
         if len(self.rdatasets) > 0:
-            if rdataset.rdtype == dns.rdatatype.CNAME:
+            # We don't want adding RRSIG(CNAME) to delete CNAMEs,
+            # so we treat it as expressing "CNAME intent" for classifying
+            # the node as a CNAME node, even if we haven't added the CNAME
+            # yet.
+            if rdataset.rdtype == dns.rdatatype.CNAME or \
+               (rdataset.rdtype == dns.rdatatype.RRSIG and
+                rdataset.covers == dns.rdatatype.CNAME):
                 self.rdatasets = [rds for rds in self.rdatasets
                                   if rds.ok_for_cname()]
             else:

--- a/dns/node.py
+++ b/dns/node.py
@@ -228,7 +228,4 @@ class Node:
         node for CNAME-and-other-data purposes, and ``True`` is returned.
         Otherwise the node is an "other data" node, and ``False`` is returned.
         """
-        for rdataset in self.rdatasets:
-            if rdataset.implies_cname():
-                return True
-        return False
+        return any(rdataset.implies_cname() for rdataset in self.rdatasets)

--- a/dns/node.py
+++ b/dns/node.py
@@ -102,16 +102,10 @@ class Node:
         """
         # Make having just one rdataset at the node fast.
         if len(self.rdatasets) > 0:
-            # We don't want adding RRSIG(CNAME) to delete CNAMEs,
-            # so we treat it as expressing "CNAME intent" for classifying
-            # the node as a CNAME node, even if we haven't added the CNAME
-            # yet.
-            if rdataset.rdtype == dns.rdatatype.CNAME or \
-               (rdataset.rdtype == dns.rdatatype.RRSIG and
-                rdataset.covers == dns.rdatatype.CNAME):
+            if rdataset.implies_cname():
                 self.rdatasets = [rds for rds in self.rdatasets
                                   if rds.ok_for_cname()]
-            else:
+            elif rdataset.implies_other_data():
                 self.rdatasets = [rds for rds in self.rdatasets
                                   if rds.ok_for_other_data()]
         self.rdatasets.append(rdataset)

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -41,14 +41,6 @@ class IncompatibleTypes(dns.exception.DNSException):
     """An attempt was made to add DNS RR data of an incompatible type."""
 
 
-_ok_for_cname = {
-    dns.rdatatype.CNAME,
-    dns.rdatatype.NSEC,   # RFC 4035 section 2.5
-    dns.rdatatype.NSEC3,  # This is not likely to happen, but not impossible!
-    dns.rdatatype.KEY,    # RFC 4035 section 2.5, RFC 3007
-}
-
-
 class Rdataset(dns.set.Set):
 
     """A DNS rdataset."""
@@ -330,36 +322,6 @@ class Rdataset(dns.set.Set):
             return []
         else:
             return self[0]._processing_order(iter(self))
-
-    def ok_for_cname(self):
-        """Is this rdataset compatible with a CNAME node?"""
-        return self.rdtype in _ok_for_cname or \
-               (self.rdtype == dns.rdatatype.RRSIG and
-                self.covers in _ok_for_cname)
-
-    def implies_cname(self):
-        """Does this rdataset imply a node is a CNAME node?
-
-        If the rdataset's type is CNAME or RRSIG(CNAME) then it implies a
-        node is a CNAME node, and ``True`` is returned.  Otherwise it implies
-        the node is an an "other data" node, and ``False`` is returned.
-        """
-        return self.rdtype == dns.rdatatype.CNAME or \
-            (self.rdtype == dns.rdatatype.RRSIG and
-            self.covers == dns.rdatatype.CNAME)
-
-    def ok_for_other_data(self):
-        """Is this rdataset compatible with an 'other data' (i.e. not CNAME)
-        node?"""
-        return not self.implies_cname()
-
-    def implies_other_data(self):
-        """Does this rdataset imply a node is an other data node?
-
-        Note that implies_other_data() is not simply "not implies_cname()" as
-        some types, e.g. NSEC and RRSIG(NSEC) are neutral.
-        """
-        return not self.ok_for_cname()
 
 
 @dns.immutable.immutable

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -41,6 +41,20 @@ class IncompatibleTypes(dns.exception.DNSException):
     """An attempt was made to add DNS RR data of an incompatible type."""
 
 
+_ok_for_cname = {
+    (dns.rdatatype.CNAME, dns.rdatatype.NONE),
+    (dns.rdatatype.RRSIG, dns.rdatatype.CNAME),
+    (dns.rdatatype.NSEC, dns.rdatatype.NONE),
+    (dns.rdatatype.RRSIG, dns.rdatatype.NSEC),
+    (dns.rdatatype.NSEC3, dns.rdatatype.NONE),
+    (dns.rdatatype.RRSIG, dns.rdatatype.NSEC3),
+}
+
+_delete_for_other_data = {
+    (dns.rdatatype.CNAME, dns.rdatatype.NONE),
+    (dns.rdatatype.RRSIG, dns.rdatatype.CNAME),
+}
+
 class Rdataset(dns.set.Set):
 
     """A DNS rdataset."""
@@ -322,6 +336,15 @@ class Rdataset(dns.set.Set):
             return []
         else:
             return self[0]._processing_order(iter(self))
+
+    def ok_for_cname(self):
+        """Is this rdataset compatible with a CNAME node?"""
+        return (self.rdtype, self.covers) in _ok_for_cname
+
+    def ok_for_other_data(self):
+        """Is this rdataset compatible with an 'other data' (i.e. not CNAME)
+        node?"""
+        return (self.rdtype, self.covers) not in _delete_for_other_data
 
 
 @dns.immutable.immutable

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -42,18 +42,17 @@ class IncompatibleTypes(dns.exception.DNSException):
 
 
 _ok_for_cname = {
-    (dns.rdatatype.CNAME, dns.rdatatype.NONE),
-    (dns.rdatatype.RRSIG, dns.rdatatype.CNAME),
-    (dns.rdatatype.NSEC, dns.rdatatype.NONE),
-    (dns.rdatatype.RRSIG, dns.rdatatype.NSEC),
-    (dns.rdatatype.NSEC3, dns.rdatatype.NONE),
-    (dns.rdatatype.RRSIG, dns.rdatatype.NSEC3),
+    dns.rdatatype.CNAME,
+    dns.rdatatype.NSEC,   # RFC 4035 section 2.5
+    dns.rdatatype.NSEC3,  # This is not likely to happen, but not impossible!
+    dns.rdatatype.KEY,    # RFC 4035 section 2.5, RFC 3007
 }
 
 _delete_for_other_data = {
     (dns.rdatatype.CNAME, dns.rdatatype.NONE),
     (dns.rdatatype.RRSIG, dns.rdatatype.CNAME),
 }
+
 
 class Rdataset(dns.set.Set):
 
@@ -339,7 +338,9 @@ class Rdataset(dns.set.Set):
 
     def ok_for_cname(self):
         """Is this rdataset compatible with a CNAME node?"""
-        return (self.rdtype, self.covers) in _ok_for_cname
+        return self.rdtype in _ok_for_cname or \
+               (self.rdtype == dns.rdatatype.RRSIG and
+                self.covers in _ok_for_cname)
 
     def ok_for_other_data(self):
         """Is this rdataset compatible with an 'other data' (i.e. not CNAME)

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -48,11 +48,6 @@ _ok_for_cname = {
     dns.rdatatype.KEY,    # RFC 4035 section 2.5, RFC 3007
 }
 
-_delete_for_other_data = {
-    (dns.rdatatype.CNAME, dns.rdatatype.NONE),
-    (dns.rdatatype.RRSIG, dns.rdatatype.CNAME),
-}
-
 
 class Rdataset(dns.set.Set):
 
@@ -342,10 +337,21 @@ class Rdataset(dns.set.Set):
                (self.rdtype == dns.rdatatype.RRSIG and
                 self.covers in _ok_for_cname)
 
+    def implies_cname(self):
+        """Does this rdataset imply a node is a CNAME node?
+
+        If the rdataset's type is CNAME or RRSIG(CNAME) then it implies a
+        node is a CNAME node, and ``True`` is returned.  Otherwise it implies
+        the node is an an "other data" node, and ``False`` is returned.
+        """
+        return self.rdtype == dns.rdatatype.CNAME or \
+            (self.rdtype == dns.rdatatype.RRSIG and
+            self.covers == dns.rdatatype.CNAME)
+
     def ok_for_other_data(self):
         """Is this rdataset compatible with an 'other data' (i.e. not CNAME)
         node?"""
-        return (self.rdtype, self.covers) not in _delete_for_other_data
+        return not self.implies_cname()
 
 
 @dns.immutable.immutable

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -353,6 +353,14 @@ class Rdataset(dns.set.Set):
         node?"""
         return not self.implies_cname()
 
+    def implies_other_data(self):
+        """Does this rdataset imply a node is an other data node?
+
+        Note that implies_other_data() is not simply "not implies_cname()" as
+        some types, e.g. NSEC and RRSIG(NSEC) are neutral.
+        """
+        return not self.ok_for_cname()
+
 
 @dns.immutable.immutable
 class ImmutableRdataset(Rdataset):

--- a/dns/transaction.py
+++ b/dns/transaction.py
@@ -79,10 +79,15 @@ class AlreadyEnded(dns.exception.DNSException):
     """Tried to use an already-ended transaction."""
 
 
-def _ensure_immutable(rdataset):
+def _ensure_immutable_rdataset(rdataset):
     if rdataset is None or isinstance(rdataset, dns.rdataset.ImmutableRdataset):
         return rdataset
     return dns.rdataset.ImmutableRdataset(rdataset)
+
+def _ensure_immutable_node(node):
+    if node is None or node.is_immutable():
+        return node
+    return dns.node.ImmutableNode(node)
 
 
 class Transaction:
@@ -111,15 +116,14 @@ class Transaction:
             name = dns.name.from_text(name, None)
         rdtype = dns.rdatatype.RdataType.make(rdtype)
         rdataset = self._get_rdataset(name, rdtype, covers)
-        return _ensure_immutable(rdataset)
+        return _ensure_immutable_rdataset(rdataset)
 
-    def get_rdatasets(self, name):
-        """Return the rdatasets at *name*, if any.
+    def get_node(self, name):
+        """Return the node at *name*, if any.
 
-        The returned rdatasets are immutable.
-        An empty list is returned if the name doesn't exist.
+        Returns an immutable node or ``None``.
         """
-        return [_ensure_immutable(rds) for rds in self._get_rdatasets(name)]
+        return _ensure_immutable_node(self._get_node(name))
 
     def _check_read_only(self):
         if self.read_only:
@@ -575,9 +579,9 @@ class Transaction:
         """
         raise NotImplementedError  # pragma: no cover
 
-    def _get_rdatasets(self, name):
-        """Return the rdatasets at *name*, if any.
+    def _get_node(self, name):
+        """Return the node at *name*, if any.
 
-        An empty list is returned if the name doesn't exist.
+        Returns a node or ``None``.
         """
         raise NotImplementedError  # pragma: no cover

--- a/dns/transaction.py
+++ b/dns/transaction.py
@@ -117,7 +117,7 @@ class Transaction:
         """Return the rdatasets at *name*, if any.
 
         The returned rdatasets are immutable.
-        An empty tuple is returned if the name doesn't exist.
+        An empty list is returned if the name doesn't exist.
         """
         return [_ensure_immutable(rds) for rds in self._get_rdatasets(name)]
 
@@ -301,7 +301,7 @@ class Transaction:
         """Call *check* before deleting an rdataset.
 
         The function is called with the transaction, the name, the rdatatype,
-        covered rdatatype.
+        and the covered rdatatype.
 
         The check function may safely make non-mutating transaction method
         calls, but behavior is undefined if mutating transaction methods are

--- a/dns/transaction.py
+++ b/dns/transaction.py
@@ -79,6 +79,12 @@ class AlreadyEnded(dns.exception.DNSException):
     """Tried to use an already-ended transaction."""
 
 
+def _ensure_immutable(rdataset):
+    if rdataset is None or isinstance(rdataset, dns.rdataset.ImmutableRdataset):
+        return rdataset
+    return dns.rdataset.ImmutableRdataset(rdataset)
+
+
 class Transaction:
 
     def __init__(self, manager, replacement=False, read_only=False):
@@ -86,6 +92,9 @@ class Transaction:
         self.replacement = replacement
         self.read_only = read_only
         self._ended = False
+        self._check_put_rdataset = []
+        self._check_delete_rdataset = []
+        self._check_delete_name = []
 
     #
     # This is the high level API
@@ -102,10 +111,15 @@ class Transaction:
             name = dns.name.from_text(name, None)
         rdtype = dns.rdatatype.RdataType.make(rdtype)
         rdataset = self._get_rdataset(name, rdtype, covers)
-        if rdataset is not None and \
-           not isinstance(rdataset, dns.rdataset.ImmutableRdataset):
-            rdataset = dns.rdataset.ImmutableRdataset(rdataset)
-        return rdataset
+        return _ensure_immutable(rdataset)
+
+    def get_rdatasets(self, name):
+        """Return the rdatasets at *name*, if any.
+
+        The returned rdatasets are immutable.
+        An empty tuple is returned if the name doesn't exist.
+        """
+        return [_ensure_immutable(rds) for rds in self._get_rdatasets(name)]
 
     def _check_read_only(self):
         if self.read_only:
@@ -271,6 +285,43 @@ class Transaction:
         """
         self._end(False)
 
+    def check_put_rdataset(self, check):
+        """Call *check* before putting (storing) an rdataset.
+
+        The function is called with the transaction, the name, and the rdataset.
+
+        The check function may safely make non-mutating transaction method
+        calls, but behavior is undefined if mutating transaction methods are
+        called.  The check function should raise an exception if it objects to
+        the put, and otherwise should return ``None``.
+        """
+        self._check_put_rdataset.append(check)
+
+    def check_delete_rdataset(self, check):
+        """Call *check* before deleting an rdataset.
+
+        The function is called with the transaction, the name, the rdatatype,
+        covered rdatatype.
+
+        The check function may safely make non-mutating transaction method
+        calls, but behavior is undefined if mutating transaction methods are
+        called.  The check function should raise an exception if it objects to
+        the put, and otherwise should return ``None``.
+        """
+        self._check_delete_rdataset.append(check)
+
+    def check_delete_name(self, check):
+        """Call *check* before putting (storing) an rdataset.
+
+        The function is called with the transaction and the name.
+
+        The check function may safely make non-mutating transaction method
+        calls, but behavior is undefined if mutating transaction methods are
+        called.  The check function should raise an exception if it objects to
+        the put, and otherwise should return ``None``.
+        """
+        self._check_delete_name.append(check)
+
     #
     # Helper methods
     #
@@ -349,7 +400,7 @@ class Transaction:
                         trds.update(existing)
                         existing = trds
                     rdataset = existing.union(rdataset)
-            self._put_rdataset(name, rdataset)
+            self._checked_put_rdataset(name, rdataset)
         except IndexError:
             raise TypeError(f'not enough parameters to {method}')
 
@@ -403,16 +454,16 @@ class Transaction:
                             raise DeleteNotExact(f'{method}: missing rdatas')
                     rdataset = existing.difference(rdataset)
                     if len(rdataset) == 0:
-                        self._delete_rdataset(name, rdataset.rdtype,
-                                              rdataset.covers)
+                        self._checked_delete_rdataset(name, rdataset.rdtype,
+                                                      rdataset.covers)
                     else:
-                        self._put_rdataset(name, rdataset)
+                        self._checked_put_rdataset(name, rdataset)
                 elif exact:
                     raise DeleteNotExact(f'{method}: missing rdataset')
             else:
                 if exact and not self._name_exists(name):
                     raise DeleteNotExact(f'{method}: name not known')
-                self._delete_name(name)
+                self._checked_delete_name(name)
         except IndexError:
             raise TypeError(f'not enough parameters to {method}')
 
@@ -428,6 +479,21 @@ class Transaction:
             self._end_transaction(commit)
         finally:
             self._ended = True
+
+    def _checked_put_rdataset(self, name, rdataset):
+        for check in self._check_put_rdataset:
+            check(self, name, rdataset)
+        self._put_rdataset(name, rdataset)
+
+    def _checked_delete_rdataset(self, name, rdtype, covers):
+        for check in self._check_delete_rdataset:
+            check(self, name, rdtype, covers)
+        self._delete_rdataset(name, rdtype, covers)
+
+    def _checked_delete_name(self, name):
+        for check in self._check_delete_name:
+            check(self, name)
+        self._delete_name(name)
 
     #
     # Transactions are context managers.
@@ -462,7 +528,7 @@ class Transaction:
     def _delete_name(self, name):
         """Delete all data associated with *name*.
 
-        It is not an error if the rdataset does not exist.
+        It is not an error if the name does not exist.
         """
         raise NotImplementedError  # pragma: no cover
 
@@ -506,7 +572,12 @@ class Transaction:
 
     def _iterate_rdatasets(self):
         """Return an iterator that yields (name, rdataset) tuples.
+        """
+        raise NotImplementedError  # pragma: no cover
 
-        Not all Transaction subclasses implement this.
+    def _get_rdatasets(self, name):
+        """Return the rdatasets at *name*, if any.
+
+        An empty list is returned if the name doesn't exist.
         """
         raise NotImplementedError  # pragma: no cover

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -854,6 +854,9 @@ class ImmutableVersionedNode(VersionedNode):
     def replace_rdataset(self, replacement):
         raise TypeError("immutable")
 
+    def is_immutable(self):
+        return True
+
 
 class Version:
     def __init__(self, zone, id, nodes=None, origin=None):
@@ -1024,11 +1027,8 @@ class Transaction(dns.transaction.Transaction):
             for rdataset in node:
                 yield (name, rdataset)
 
-    def _get_rdatasets(self, name):
-        node = self.version.get_node(name)
-        if node is None:
-            return []
-        return node.rdatasets
+    def _get_node(self, name):
+        return self.version.get_node(name)
 
 
 def from_text(text, origin=None, rdclass=dns.rdataclass.IN,

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -1024,6 +1024,12 @@ class Transaction(dns.transaction.Transaction):
             for rdataset in node:
                 yield (name, rdataset)
 
+    def _get_rdatasets(self, name):
+        node = self.version.get_node(name)
+        if node is None:
+            return []
+        return node.rdatasets
+
 
 def from_text(text, origin=None, rdclass=dns.rdataclass.IN,
               relativize=True, zone_factory=Zone, filename=None,

--- a/dns/zonefile.py
+++ b/dns/zonefile.py
@@ -45,10 +45,10 @@ class CNAMEAndOtherData(dns.exception.DNSException):
 def _check_cname_and_other_data(txn, name, rdataset):
     rdataset_kind = dns.node.NodeKind.classify_rdataset(rdataset)
     node = txn.get_node(name)
-    if node is not None:
-        node_kind = node.classify()
-    else:
-        node_kind = dns.node.NodeKind.NEUTRAL
+    if node is None:
+        # empty nodes are neutral.
+        return
+    node_kind = node.classify()
     if node_kind == dns.node.NodeKind.CNAME and \
        rdataset_kind == dns.node.NodeKind.REGULAR:
         raise CNAMEAndOtherData('rdataset type is not compatible with a '

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,6 +34,16 @@ What's New in dnspython
 
 * The CDS rdatatype now allows digest type 0.
 
+* Dnspython zones now enforces that a node is either a CNAME node or
+  an "other data" node.  A CNAME node contains only CNAME,
+  RRSIG(CNAME), NSEC, RRSIG(NSEC), NSEC3, or RRSIG(NSEC3) rdatasets.
+  An "other data" node contains any rdataset other than a CNAME or
+  RRSIG(CNAME) rdataset.  The enforcement is "last update wins".  For
+  example, if you have a node which contains a CNAME rdataset, and
+  then add an MX rdataset to it, then the CNAME rdataset will be deleted.
+  Likewise if you have a node containing an MX rdataset and add a
+  CNAME rdataset, the MX rdataset will be deleted.
+
 2.1.0
 ----------------------
 

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -192,6 +192,42 @@ ns1 3600 IN A 10.0.0.1 ; comment1
 ns2 3600 IN A 10.0.0.2 ; comment2
 """
 
+
+example_cname = """$TTL 3600
+$ORIGIN example.
+@ soa foo bar (1 2 3 4 5)
+@ ns ns1
+@ ns ns2
+ns1 a 10.0.0.1
+ns2 a 10.0.0.2
+www a 10.0.0.3
+web cname www
+    nsec @ CNAME RRSIG
+    rrsig NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+    rrsig CNAME 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+web2 cname www
+    nsec3 1 1 12 aabbccdd 2t7b4g4vsa5smi47k61mv5bv1a22bojr CNAME RRSIG
+    rrsig NSEC3 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+    rrsig CNAME 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+"""
+
+
+example_other_data = """$TTL 3600
+$ORIGIN example.
+@ soa foo bar (1 2 3 4 5)
+@ ns ns1
+@ ns ns2
+ns1 a 10.0.0.1
+ns2 a 10.0.0.2
+www a 10.0.0.3
+web a 10.0.0.4
+    nsec @ A RRSIG
+    rrsig A 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+    rrsig NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+    rrsig CNAME 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+"""
+
+
 _keep_output = True
 
 def _rdata_sort(a):
@@ -839,6 +875,58 @@ class ZoneTestCase(unittest.TestCase):
         self.assertTrue(rds is not rrs)
         self.assertFalse(isinstance(rds, dns.rrset.RRset))
 
+    def testCnameAndOtherDataAddOther(self):
+        z = dns.zone.from_text(example_cname, 'example.', relativize=True)
+        rds = dns.rdataset.from_text('in', 'a', 300, '10.0.0.1')
+        z.replace_rdataset('web', rds)
+        z.replace_rdataset('web2', rds.copy())
+        n = z.find_node('web')
+        self.assertEqual(len(n.rdatasets), 3)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN, dns.rdatatype.A),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC))
+        n = z.find_node('web2')
+        self.assertEqual(len(n.rdatasets), 3)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN, dns.rdatatype.A),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC3))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC3))
+
+    def testCnameAndOtherDataAddCname(self):
+        z = dns.zone.from_text(example_other_data, 'example.', relativize=True)
+        rds = dns.rdataset.from_text('in', 'cname', 300, 'www')
+        z.replace_rdataset('web', rds)
+        n = z.find_node('web')
+        self.assertEqual(len(n.rdatasets), 4)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN,
+                                         dns.rdatatype.CNAME),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.CNAME))
+
+    def testNameInZoneWithStr(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=False)
+        self.assertTrue('ns1.example.' in z)
+        self.assertTrue('bar.foo.example.' in z)
+
+    def testNameInZoneWhereNameIsNotValid(self):
+        z = dns.zone.from_text(example_text, 'example.', relativize=False)
+        with self.assertRaises(KeyError):
+            self.assertTrue(1 in z)
+
 
 class VersionedZoneTestCase(unittest.TestCase):
     def testUseTransaction(self):
@@ -909,15 +997,52 @@ class VersionedZoneTestCase(unittest.TestCase):
             rds = txn.get('example.', 'soa')
             self.assertEqual(rds[0].serial, 1)
 
-    def testNameInZoneWithStr(self):
-        z = dns.zone.from_text(example_text, 'example.', relativize=False)
-        self.assertTrue('ns1.example.' in z)
-        self.assertTrue('bar.foo.example.' in z)
+    def testCnameAndOtherDataAddOther(self):
+        z = dns.zone.from_text(example_cname, 'example.', relativize=True,
+                               zone_factory=dns.versioned.Zone)
+        rds = dns.rdataset.from_text('in', 'a', 300, '10.0.0.1')
+        with z.writer() as txn:
+            txn.replace('web', rds)
+            txn.replace('web2', rds.copy())
+        n = z.find_node('web')
+        self.assertEqual(len(n.rdatasets), 3)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN, dns.rdatatype.A),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC))
+        n = z.find_node('web2')
+        self.assertEqual(len(n.rdatasets), 3)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN, dns.rdatatype.A),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC3))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC3))
 
-    def testNameInZoneWhereNameIsNotValid(self):
-        z = dns.zone.from_text(example_text, 'example.', relativize=False)
-        with self.assertRaises(KeyError):
-            self.assertTrue(1 in z)
+    def testCnameAndOtherDataAddCname(self):
+        z = dns.zone.from_text(example_other_data, 'example.', relativize=True,
+                               zone_factory=dns.versioned.Zone)
+        rds = dns.rdataset.from_text('in', 'cname', 300, 'www')
+        with z.writer() as txn:
+            txn.replace('web', rds)
+        n = z.find_node('web')
+        self.assertEqual(len(n.rdatasets), 4)
+        self.assertEqual(n.find_rdataset(dns.rdataclass.IN,
+                                         dns.rdatatype.CNAME),
+                         rds)
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.NSEC))
+        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
+                                            dns.rdatatype.RRSIG,
+                                            dns.rdatatype.CNAME))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -224,9 +224,22 @@ web a 10.0.0.4
     nsec @ A RRSIG
     rrsig A 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
     rrsig NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
-    rrsig CNAME 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
 """
 
+example_cname_and_other_data = """$TTL 3600
+$ORIGIN example.
+@ soa foo bar (1 2 3 4 5)
+@ ns ns1
+@ ns ns2
+ns1 a 10.0.0.1
+ns2 a 10.0.0.2
+www a 10.0.0.3
+web a 10.0.0.4
+    cname www
+    nsec @ A RRSIG
+    rrsig A 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+    rrsig NSEC 1 3 3600 20200101000000 20030101000000 2143 foo MxFcby9k/yvedMfQgKzhH5er0Mu/vILz 45IkskceFGgiWCn/GxHhai6VAuHAoNUz 4YoU1tVfSCSqQYn6//11U6Nld80jEeC8 aTrO+KKmCaY=
+"""
 
 _keep_output = True
 
@@ -904,7 +917,7 @@ class ZoneTestCase(unittest.TestCase):
         rds = dns.rdataset.from_text('in', 'cname', 300, 'www')
         z.replace_rdataset('web', rds)
         n = z.find_node('web')
-        self.assertEqual(len(n.rdatasets), 4)
+        self.assertEqual(len(n.rdatasets), 3)
         self.assertEqual(n.find_rdataset(dns.rdataclass.IN,
                                          dns.rdatatype.CNAME),
                          rds)
@@ -913,9 +926,11 @@ class ZoneTestCase(unittest.TestCase):
         self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
                                             dns.rdatatype.RRSIG,
                                             dns.rdatatype.NSEC))
-        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
-                                            dns.rdatatype.RRSIG,
-                                            dns.rdatatype.CNAME))
+
+    def testCnameAndOtherDataInZonefile(self):
+        with self.assertRaises(dns.zonefile.CNAMEAndOtherData):
+            dns.zone.from_text(example_cname_and_other_data, 'example.',
+                               relativize=True)
 
     def testNameInZoneWithStr(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=False)
@@ -1030,7 +1045,7 @@ class VersionedZoneTestCase(unittest.TestCase):
         with z.writer() as txn:
             txn.replace('web', rds)
         n = z.find_node('web')
-        self.assertEqual(len(n.rdatasets), 4)
+        self.assertEqual(len(n.rdatasets), 3)
         self.assertEqual(n.find_rdataset(dns.rdataclass.IN,
                                          dns.rdatatype.CNAME),
                          rds)
@@ -1039,9 +1054,6 @@ class VersionedZoneTestCase(unittest.TestCase):
         self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
                                             dns.rdatatype.RRSIG,
                                             dns.rdatatype.NSEC))
-        self.assertIsNotNone(n.get_rdataset(dns.rdataclass.IN,
-                                            dns.rdatatype.RRSIG,
-                                            dns.rdatatype.CNAME))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR imposes a "last one wins" policy for CNAME and other data in zones.  The policy is imposed by the node.

Specifically, if the rdataset being appended is a CNAME, then all rdatasets other than NSEC, NSEC3, and their covering RRSIGs are deleted.  If the rdataset being appended is NOT a CNAME, then CNAME and RRSIG(CNAME) are deleted.
