### PR TITLE
Fix handling non-relativized zones

### DIFF
--- a/dns/transaction.py
+++ b/dns/transaction.py
@@ -389,7 +389,9 @@ class Transaction:
             if rdataset.rdclass != self.manager.get_class():
                 raise ValueError(f'{method} has objects of wrong RdataClass')
             if rdataset.rdtype == dns.rdatatype.SOA:
-                (_, _, origin) = self.manager.origin_information()
+                (_, relativize, origin) = self.manager.origin_information()
+                if not relativize:
+                    origin = self.version.origin
                 if name != origin:
                     raise ValueError(f'{method} has non-origin SOA')
             self._raise_if_not_empty(method, args)

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -870,7 +870,7 @@ class Version:
 
     def _validate_name(self, name):
         if name.is_absolute():
-            if not name.is_subdomain(self.zone.origin):
+            if self.zone.origin and not name.is_subdomain(self.zone.origin):
                 raise KeyError("name is not a subdomain of the zone origin")
             if self.zone.relativize:
                 # XXXRTH should it be an error if self.origin is still None?

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -58,6 +58,14 @@ ns1 3600 IN A 10.0.0.1
 ns2 3600 IN A 10.0.0.2
 """
 
+example_norel_text_output = """example. 3600 IN SOA foo.example. bar.example. 1 2 3 4 5
+example. 3600 IN NS ns1.example.
+example. 3600 IN NS ns2.example.
+bar.foo.example. 300 IN MX 0 blaz.foo.example.
+ns1.example. 3600 IN A 10.0.0.1
+ns2.example. 3600 IN A 10.0.0.2
+"""
+
 something_quite_similar = """@ 3600 IN SOA foo bar 1 2 3 4 5
 @ 3600 IN NS ns1
 @ 3600 IN NS ns2
@@ -173,6 +181,13 @@ $ORIGIN example.
 @ soa foo bar 1 2 3 4 5
 @ 300 ns ns1
 @ 300 ns ns2
+"""
+
+origin_sets_input_norel = """
+$ORIGIN example.
+example. soa foo.example. bar.example. 1 2 3 4 5
+example. 300 ns ns1.example.
+example. 300 ns ns2.example.
 """
 
 example_comments_text = """$TTL 3600
@@ -418,6 +433,16 @@ class ZoneTestCase(unittest.TestCase):
             f.write(z[n].to_text(n))
             f.write('\n')
         self.assertEqual(f.getvalue(), example_text_output)
+
+    def testFromTextNoOrigin(self):
+        z = dns.zone.from_text(example_text, relativize=False)
+        f = StringIO()
+        names = list(z.nodes.keys())
+        names.sort()
+        for n in names:
+            f.write(z[n].to_text(n))
+            f.write('\n')
+        self.assertEqual(f.getvalue(), example_norel_text_output)
 
     def testTorture1(self):
         #
@@ -849,6 +874,10 @@ class ZoneTestCase(unittest.TestCase):
 
     def testDollarOriginSetsZoneOriginIfUnknown(self):
         z = dns.zone.from_text(origin_sets_input)
+        self.assertEqual(z.origin, dns.name.from_text('example'))
+
+    def testDollarOriginSetsZoneOriginIfUnknownRelative(self):
+        z = dns.zone.from_text(origin_sets_input_norel, relativize=False)
         self.assertEqual(z.origin, dns.name.from_text('example'))
 
     def testValidateNameRelativizesNameInZone(self):


### PR DESCRIPTION
After the refactoring done in [0], handling zones with relativize=False
was partially broken, because the origin check was using outdated
information. Fix this and add some tests to cover this situation.

[0] https://github.com/rthalley/dnspython/commit/9a16076cb3b7d36efaabff030688693dd56f0ee6

Closes: #766
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>