### PR TITLE
Require 4th field in rdata of TLSA and friends

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -557,7 +557,7 @@ class GenericRdata(Rdata):
             raise dns.exception.SyntaxError(
                 r'generic rdata does not start with \#')
         length = tok.get_int()
-        hex = tok.concatenate_remaining_identifiers().encode()
+        hex = tok.concatenate_remaining_identifiers(True).encode()
         data = binascii.unhexlify(hex)
         if len(data) != length:
             raise dns.exception.SyntaxError(

--- a/dns/rdtypes/ANY/TKEY.py
+++ b/dns/rdtypes/ANY/TKEY.py
@@ -63,7 +63,7 @@ class TKEY(dns.rdata.Rdata):
         error = tok.get_uint16()
         key_b64 = tok.get_string().encode()
         key = base64.b64decode(key_b64)
-        other_b64 = tok.concatenate_remaining_identifiers().encode()
+        other_b64 = tok.concatenate_remaining_identifiers(True).encode()
         other = base64.b64decode(other_b64)
 
         return cls(rdclass, rdtype, algorithm, inception, expiration, mode,

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -600,8 +600,11 @@ class Tokenizer:
                 break
         return tokens
 
-    def concatenate_remaining_identifiers(self):
+    def concatenate_remaining_identifiers(self, allow_empty=False):
         """Read the remaining tokens on the line, which should be identifiers.
+
+        Raises dns.exception.SyntaxError if there are no remaining tokens,
+        unless `allow_empty=True` is given.
 
         Raises dns.exception.SyntaxError if a token is seen that is not an
         identifier.
@@ -618,6 +621,8 @@ class Tokenizer:
             if not token.is_identifier():
                 raise dns.exception.SyntaxError
             s += token.value
+        if not (allow_empty or s):
+            raise dns.exception.SyntaxError('expecting another identifier')
         return s
 
     def as_name(self, token, origin=None, relativize=False, relativize_to=None):

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -533,7 +533,8 @@ class DNSSECMakeDSTestCase(unittest.TestCase):
         dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.CDS, f'0 0 0 00')
 
         test_records = {
-            'digest length inconsistent with digest type': ['0 0 0', '0 0 0 0000'],
+            'expecting another identifier': ['0 0 0', '0 0 0 '],
+            'digest length inconsistent with digest type': ['0 0 0 0000'],
             'Odd-length string': ['0 0 0 0', '0 0 0 000'],
         }
         for msg, records in test_records.items():

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -539,6 +539,9 @@ class RdataTestCase(unittest.TestCase):
         with self.assertRaises(dns.exception.SyntaxError):
             dns.rdata.from_text('in', 'type45678', '\\# 6 000a03666f6f00')
 
+    def test_empty_generic(self):
+        dns.rdata.from_text('in', 'type45678', r'\# 0')
+
     def test_covered_repr(self):
         text = 'NSEC 1 3 3600 20190101000000 20030101000000 ' + \
             '2143 foo Ym9ndXM='


### PR DESCRIPTION
We have customers trying to provision TLSA records with content `1 1 1`, with the base64 key/cert part missing. dnspython should not accept such records.