### PR TITLE
Fix missing import.

### DIFF
--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -20,6 +20,7 @@
 import base64
 
 import dns.name
+import dns.tsig
 
 
 def from_text(textring):


### PR DESCRIPTION
Missing import causes error:
```
Traceback (most recent call last):
  File "./ddns.py", line 47, in read_tsigkey
    keyring = dns.tsigkeyring.from_text({
  File "/home/horakmar/.local/lib/python3.8/site-packages/dns/tsigkeyring.py", line 36, in from_text
    keyring[name] = dns.tsig.Key(name, value).secret
AttributeError: module 'dns' has no attribute 'tsig'
```