### PR TITLE
Reduce the number of digits after the decimal point for the Timeout DNSException from 15 to 1

### DIFF
--- a/dns/exception.py
+++ b/dns/exception.py
@@ -125,7 +125,7 @@ class TooBig(DNSException):
 class Timeout(DNSException):
     """The DNS operation timed out."""
     supp_kwargs = {'timeout'}
-    fmt = "The DNS operation timed out after {timeout} seconds"
+    fmt = "The DNS operation timed out after {timeout:.1f} seconds"
 
 
 class ExceptionWrapper:

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -125,7 +125,7 @@ class TooBig(DNSException):
 class Timeout(DNSException):
     """The DNS operation timed out."""
     supp_kwargs = {'timeout'}
-    fmt = "The DNS operation timed out after {timeout:.1f} seconds"
+    fmt = "The DNS operation timed out after {timeout:.3f} seconds"
 
 
 class ExceptionWrapper:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -145,7 +145,7 @@ class LifetimeTimeout(dns.exception.Timeout):
     """The resolution lifetime expired."""
 
     msg = "The resolution lifetime expired."
-    fmt = "%s after {timeout} seconds: {errors}" % msg[:-1]
+    fmt = "%s after {timeout:.3f} seconds: {errors}" % msg[:-1]
     supp_kwargs = {'timeout', 'errors'}
 
     def _fmt_kwargs(self, **kwargs):


### PR DESCRIPTION
I noticed the timeout exception prints a ridiculous number digits after the decimal point, for example:
```
ice 164 % cat t.py 
#!/usr/local/bin/python

import dns.resolver

tresolver = dns.resolver.Resolver()
tresolver.nameservers = ['10.254.0.87']

try:
    answers = tresolver.resolve('github.com', 'A')
except dns.exception.Timeout as e:
    print(str(e))
else:
    print('success')
ice 165 % ./t.py 
The DNS operation timed out after 5.411804437637329 seconds
```
I see that LifetimeTimeout probably has the same issue but I couldn't quickly write a script to verify.