### PR TITLE
resolve() docstring - fix `lifetime` var rendering

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1024,7 +1024,7 @@ class Resolver(BaseResolver):
         *source_port*, an ``int``, the port from which to send the message.
 
         *lifetime*, a ``float``, how many seconds a query should run
-         before timing out.
+        before timing out.
 
         *search*, a ``bool`` or ``None``, determines whether the
         search list configured in the system's resolver configuration


### PR DESCRIPTION
Really minor thing:
https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.resolve

the leading whitespace in the docstring for resolve() `lifetime` causes RST doc gen to render the line item as a header
<img width="768" alt="image" src="https://user-images.githubusercontent.com/5124946/152091070-681bb2bd-179d-4a8c-8a1b-143f779237a0.png">