### PR TITLE
Use contextlib.nullcontext().

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1585,9 +1585,11 @@ def from_file(
     Returns a ``dns.message.Message object``
     """
 
-    with contextlib.ExitStack() as stack:
-        if isinstance(f, str):
-            f = stack.enter_context(open(f))
+    if isinstance(f, str):
+        cm = open(f)
+    else:
+        cm = contextlib.nullcontext(f)
+    with cm as f:
         return from_text(f, idna_codec, one_rr_per_rrset)
     assert False  # for mypy  lgtm[py/unreachable-statement]
 

--- a/dns/message.py
+++ b/dns/message.py
@@ -1586,7 +1586,7 @@ def from_file(
     """
 
     if isinstance(f, str):
-        cm = open(f)
+        cm: contextlib.AbstractContextManager = open(f)
     else:
         cm = contextlib.nullcontext(f)
     with cm as f:

--- a/dns/query.py
+++ b/dns/query.py
@@ -380,7 +380,7 @@ def https(
         )
 
     if session:
-        cm = contextlib.nullcontext(session)
+        cm: contextlib.AbstractContextManager = contextlib.nullcontext(session)
     elif _is_httpx:
         cm = httpx.Client(
             http1=True, http2=_have_http2, verify=verify, transport=transport
@@ -631,7 +631,7 @@ def udp(
     )
     (begin_time, expiration) = _compute_times(timeout)
     if sock:
-        cm = contextlib.nullcontext(sock)
+        cm: contextlib.AbstractContextManager = contextlib.nullcontext(sock)
     else:
         cm = _make_socket(af, socket.SOCK_DGRAM, source)
     with cm as s:
@@ -914,7 +914,7 @@ def tcp(
     wire = q.to_wire()
     (begin_time, expiration) = _compute_times(timeout)
     if sock:
-        cm = contextlib.nullcontext(sock)
+        cm: contextlib.AbstractContextManager = contextlib.nullcontext(sock)
     else:
         (af, destination, source) = _destination_and_source(
             where, port, source, source_port

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -905,7 +905,7 @@ class BaseResolver:
 
         if isinstance(f, str):
             try:
-                cm = open(f)
+                cm: contextlib.AbstractContextManager = open(f)
             except OSError:
                 # /etc/resolv.conf doesn't exist, can't be read, etc.
                 raise NoResolverConfiguration(f"cannot open {f}")

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -903,14 +903,15 @@ class BaseResolver:
 
         """
 
-        with contextlib.ExitStack() as stack:
-            if isinstance(f, str):
-                try:
-                    f = stack.enter_context(open(f))
-                except OSError:
-                    # /etc/resolv.conf doesn't exist, can't be read, etc.
-                    raise NoResolverConfiguration(f"cannot open {f}")
-
+        if isinstance(f, str):
+            try:
+                cm = open(f)
+            except OSError:
+                # /etc/resolv.conf doesn't exist, can't be read, etc.
+                raise NoResolverConfiguration(f"cannot open {f}")
+        else:
+            cm = contextlib.nullcontext(f)
+        with cm as f:
             for l in f:
                 if len(l) == 0 or l[0] == "#" or l[0] == ";":
                     continue

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -642,7 +642,7 @@ class Zone(dns.transaction.TransactionManager):
         """
 
         if isinstance(f, str):
-            cm = open(f, "wb")
+            cm: contextlib.AbstractContextManager = open(f, "wb")
         else:
             cm = contextlib.nullcontext(f)
         with cm as f:
@@ -1294,7 +1294,7 @@ def from_file(
     if isinstance(f, str):
         if filename is None:
             filename = f
-        cm = open(f)
+        cm: contextlib.AbstractContextManager = open(f)
     else:
         cm = contextlib.nullcontext(f)
     with cm as f:

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -641,10 +641,11 @@ class Zone(dns.transaction.TransactionManager):
         one.
         """
 
-        with contextlib.ExitStack() as stack:
-            if isinstance(f, str):
-                f = stack.enter_context(open(f, "wb"))
-
+        if isinstance(f, str):
+            cm = open(f, "wb")
+        else:
+            cm = contextlib.nullcontext(f)
+        with cm as f:
             # must be in this way, f.encoding may contain None, or even
             # attribute may not be there
             file_enc = getattr(f, "encoding", None)
@@ -1290,11 +1291,13 @@ def from_file(
     Returns a subclass of ``dns.zone.Zone``.
     """
 
-    with contextlib.ExitStack() as stack:
-        if isinstance(f, str):
-            if filename is None:
-                filename = f
-            f = stack.enter_context(open(f))
+    if isinstance(f, str):
+        if filename is None:
+            filename = f
+        cm = open(f)
+    else:
+        cm = contextlib.nullcontext(f)
+    with cm as f:
         return from_text(
             f,
             origin,


### PR DESCRIPTION
Replaces uses of contextlib.ExitStack, since nullcontext() is available
in 3.7.