### PR TITLE
style(asyncquery): change the ``httpx.AsyncClient`` type annotation to a string literal

### DIFF
--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -485,7 +485,7 @@ async def https(
     source_port: int = 0,
     one_rr_per_rrset: bool = False,
     ignore_trailing: bool = False,
-    client: Optional[httpx.AsyncClient] = None,
+    client: Optional["httpx.AsyncClient"] = None,
     path: str = "/dns-query",
     post: bool = True,
     verify: bool = True,


### PR DESCRIPTION
Check: https://legacy.python.org/dev/peps/pep-0484/#forward-references

The httpx module is sometimes optional.

It can be used without the httpx module, but there was a problem that it had to be installed because of the type annotation.