### PR TITLE
Padding (RFC 7830, RFC 8467)

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -288,37 +288,36 @@ def https(
 
     *q*, a ``dns.message.Message``, the query to send.
 
-    *where*, a ``str``, the nameserver IP address or the full URL. If an IP
-    address is given, the URL will be constructed using the following schema:
+    *where*, a ``str``, the nameserver IP address or the full URL. If an IP address is
+    given, the URL will be constructed using the following schema:
     https://<IP-address>:<port>/<path>.
 
-    *timeout*, a ``float`` or ``None``, the number of seconds to
-    wait before the query times out. If ``None``, the default, wait forever.
+    *timeout*, a ``float`` or ``None``, the number of seconds to wait before the query
+    times out. If ``None``, the default, wait forever.
 
     *port*, a ``int``, the port to send the query to. The default is 443.
 
-    *source*, a ``str`` containing an IPv4 or IPv6 address, specifying
-    the source address.  The default is the wildcard address.
+    *source*, a ``str`` containing an IPv4 or IPv6 address, specifying the source
+    address.  The default is the wildcard address.
 
-    *source_port*, an ``int``, the port from which to send the message.
-    The default is 0.
+    *source_port*, an ``int``, the port from which to send the message. The default is
+    0.
 
-    *one_rr_per_rrset*, a ``bool``. If ``True``, put each RR into its own
-    RRset.
+    *one_rr_per_rrset*, a ``bool``. If ``True``, put each RR into its own RRset.
 
-    *ignore_trailing*, a ``bool``. If ``True``, ignore trailing
-    junk at end of the received message.
+    *ignore_trailing*, a ``bool``. If ``True``, ignore trailing junk at end of the
+    received message.
 
-    *session*, an ``httpx.Client`` or ``requests.session.Session``.  If
-    provided, the client/session to use to send the queries.
+    *session*, an ``httpx.Client`` or ``requests.session.Session``.  If provided, the
+    client/session to use to send the queries.
 
     *path*, a ``str``. If *where* is an IP address, then *path* will be used to
     construct the URL to send the DNS query to.
 
     *post*, a ``bool``. If ``True``, the default, POST method will be used.
 
-    *bootstrap_address*, a ``str``, the IP address to use to bypass the
-    system's DNS resolver.
+    *bootstrap_address*, a ``str``, the IP address to use to bypass the system's DNS
+    resolver.
 
     *verify*, a ``str``, containing a path to a certificate file or directory.
 

--- a/dns/tsig.py
+++ b/dns/tsig.py
@@ -88,6 +88,19 @@ GSS_TSIG = dns.name.from_text("gss-tsig")
 
 default_algorithm = HMAC_SHA256
 
+mac_sizes = {
+    HMAC_SHA1: 20,
+    HMAC_SHA224: 28,
+    HMAC_SHA256: 32,
+    HMAC_SHA256_128: 16,
+    HMAC_SHA384: 48,
+    HMAC_SHA384_192: 24,
+    HMAC_SHA512: 64,
+    HMAC_SHA512_256: 32,
+    HMAC_MD5: 16,
+    GSS_TSIG: 128,  # This is what we assume to be the worst case!
+}
+
 
 class GSSTSig:
     """

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -103,3 +103,14 @@ class RendererTestCase(unittest.TestCase):
             r.add_rdataset(dns.renderer.ANSWER, qname, rds)
 
         self.assertRaises(dns.exception.FormError, bad)
+
+    def test_reservation(self):
+        r = dns.renderer.Renderer(flags=dns.flags.QR, max_size=512)
+        r.reserve(100)
+        assert r.max_size == 412
+        r.release_reserved()
+        assert r.max_size == 512
+        with self.assertRaises(ValueError):
+            r.reserve(-1)
+        with self.assertRaises(ValueError):
+            r.reserve(513)


### PR DESCRIPTION
This is a first attempt on the DPRIV padding scheme, which is something we might like to have for DoH.  For future DNS-over-QUIC, we'd be better off padding at QUIC level as padding is surprisingly complicated when you have to do it in an OPT RR potentially in the middle of the message.  There's a comment with more detail on the horrors and how we punt in one situation instead of attempting padding.

I still have to write tests.

This code works at the basic level; if I query 1.1.1.1 or 8.8.8.8 with DoH and padding, they understand and reply correctly.  9.9.9.9 doesn't seem to implement padding yet.