### PR TITLE
fix missing version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = dnspython
+version = 2.2.1
 author = Bob Halley
 author_email = halley@dnspython.org
 license = ISC


### PR DESCRIPTION
since da279dec, move the metadata into setup.cfg from setup.py,
 but it missed version ，which will result in python3-dns providing ‘python3.9dist(dnspython) = 0’ instead of ‘python3.9dist(dnspython) = 2.2.1’

Signed-off-by: eaglegai <eaglegai@163.com>