### PR TITLE
Remove spurious wheel build dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ packages =
     dns.rdtypes.CH
 python_requires = >=3.7
 test_suite = tests
-setup_requires = setuptools>=44; wheel; setuptools_scm[toml]>=3.4.3
+setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
 DOH = httpx>=0.21.1; h2>=4.1.0; requests; requests-toolbelt


### PR DESCRIPTION
Wheel isn't a build dependency so it shouldn't be in `setup_requires`.