### PR TITLE
changed docs dns.resolver.Answer response to QueryMessage

### DIFF
--- a/doc/resolver-class.rst
+++ b/doc/resolver-class.rst
@@ -121,7 +121,7 @@ The dns.resolver.Resolver and dns.resolver.Answer Classes
 
    .. attribute:: response
 
-      A ``dns.message.Message``, the response message.
+      A ``dns.message.QueryMessage``, the response message.
 
    .. attribute:: rrset
 


### PR DESCRIPTION
I started building a tool based on the dns.resolver.resolve (docs links here - https://dnspython.readthedocs.io/en/stable/_modules/dns/resolver.html#Resolver.resolve).  It specifies that it returns a `dns.resolver.Answer`

When looking at the dns.resolver.Answer class to begin extracting answer information it pointed me to the dns.resolver.Answer.response as a `dns.message.Message`. However, when I run looked that class, I did not see what I was expected and checked the type. It showed `dns.message.QueryMessage`. 

This pull request, updates the docs page for resolver-class.rst to reflect `QueryMessage` instead of just `Message`.

![image](https://user-images.githubusercontent.com/57331546/204598119-a886284d-3003-4f51-be81-4343f11028f7.png)
