### PR TITLE
Remove unsupported python case

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -150,10 +150,7 @@ class QueryTests(unittest.TestCase):
                 base_s.settimeout(2)
                 base_s.connect(ll)
                 ctx = ssl.create_default_context()
-                if sys.version_info >= (3, 7):
-                    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
-                else:
-                    ctx.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                ctx.minimum_version = ssl.TLSVersion.TLSv1_2
                 with ctx.wrap_socket(
                     base_s, server_hostname="dns.google"
                 ) as s:  # lgtm[py/insecure-protocol]


### PR DESCRIPTION
The minimal python version is [3.7](https://github.com/rthalley/dnspython/blob/master/setup.cfg#L47) so there is no need to keep cases for release under 3.7.
I found only one in tests. This PR removes it.
