### PR TITLE
Resolver "nameserver" object support.

### DIFF
--- a/dns/nameserver.py
+++ b/dns/nameserver.py
@@ -1,0 +1,315 @@
+from urllib.parse import urlparse
+
+from typing import Optional, Union
+
+import dns.asyncbackend
+import dns.asyncquery
+import dns.inet
+import dns.message
+import dns.query
+
+
+class Nameserver:
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def is_always_max_size(self) -> bool:
+        raise NotImplementedError
+
+    def answer_nameserver(self) -> str:
+        raise NotImplementedError
+
+    def answer_port(self) -> int:
+        raise NotImplementedError
+
+    def query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        raise NotImplementedError
+
+    async def async_query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        backend: dns.asyncbackend.Backend,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        raise NotImplementedError
+
+
+class AddressAndPortNameserver(Nameserver):
+    def __init__(self, address: str, port: int):
+        super().__init__()
+        self.address = address
+        self.port = port
+
+    def kind(self) -> str:
+        raise NotImplementedError
+
+    def is_always_max_size(self) -> bool:
+        return False
+
+    def __str__(self):
+        ns_kind = self.kind()
+        return f"{ns_kind}:{self.address}@{self.port}"
+
+    def answer_nameserver(self) -> str:
+        return self.address
+
+    def answer_port(self) -> int:
+        return self.port
+
+
+class Do53Nameserver(AddressAndPortNameserver):
+    def __init__(self, address: str, port: int = 53):
+        super().__init__(address, port)
+
+    def kind(self):
+        return "Do53"
+
+    def query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        if max_size:
+            response = dns.query.tcp(
+                request,
+                self.address,
+                timeout=timeout,
+                port=self.port,
+                source=source,
+                source_port=source_port,
+                one_rr_per_rrset=one_rr_per_rrset,
+                ignore_trailing=ignore_trailing,
+            )
+        else:
+            response = dns.query.udp(
+                request,
+                self.address,
+                timeout=timeout,
+                port=self.port,
+                source=source,
+                source_port=source_port,
+                raise_on_truncation=True,
+                one_rr_per_rrset=one_rr_per_rrset,
+                ignore_trailing=ignore_trailing,
+            )
+        return response
+
+    async def async_query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        backend: dns.asyncbackend.Backend,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        if max_size:
+            response = await dns.asyncquery.tcp(
+                request,
+                self.address,
+                timeout=timeout,
+                port=self.port,
+                source=source,
+                source_port=source_port,
+                backend=backend,
+                one_rr_per_rrset=one_rr_per_rrset,
+                ignore_trailing=ignore_trailing,
+            )
+        else:
+            response = await dns.asyncquery.udp(
+                request,
+                self.address,
+                timeout=timeout,
+                port=self.port,
+                source=source,
+                source_port=source_port,
+                raise_on_truncation=True,
+                backend=backend,
+                one_rr_per_rrset=one_rr_per_rrset,
+                ignore_trailing=ignore_trailing,
+            )
+        return response
+
+
+class DoHNameserver(Nameserver):
+    def __init__(self, url: str, bootstrap_address: Optional[str] = None):
+        super().__init__()
+        self.url = url
+        self.bootstrap_address = bootstrap_address
+
+    def is_always_max_size(self) -> bool:
+        return True
+
+    def __str__(self):
+        return self.url
+
+    def answer_nameserver(self) -> str:
+        return self.url
+
+    def answer_port(self) -> int:
+        port = urlparse(self.url).port
+        if port is None:
+            port = 443
+        return port
+
+    def query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool = False,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return dns.query.https(
+            request,
+            self.url,
+            timeout=timeout,
+            bootstrap_address=self.bootstrap_address,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+        )
+
+    async def async_query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        backend: dns.asyncbackend.Backend,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return await dns.asyncquery.https(
+            request,
+            self.url,
+            timeout=timeout,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+        )
+
+
+class DoTNameserver(AddressAndPortNameserver):
+    def __init__(self, address: str, port: int = 853, hostname: Optional[str] = None):
+        super().__init__(address, port)
+        self.hostname = hostname
+
+    def kind(self):
+        return "DoT"
+
+    def query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool = False,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return dns.query.tls(
+            request,
+            self.address,
+            port=self.port,
+            timeout=timeout,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+            server_hostname=self.hostname,
+        )
+
+    async def async_query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        backend: dns.asyncbackend.Backend,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return await dns.asyncquery.tls(
+            request,
+            self.address,
+            port=self.port,
+            timeout=timeout,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+            server_hostname=self.hostname,
+        )
+
+
+class DoQNameserver(AddressAndPortNameserver):
+    def __init__(self, address: str, port: int = 853, verify: Union[bool, str] = True):
+        super().__init__(address, port)
+        self.verify = verify
+
+    def kind(self):
+        return "DoQ"
+
+    def query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool = False,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return dns.query.quic(
+            request,
+            self.address,
+            port=self.port,
+            timeout=timeout,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+            verify=self.verify,
+        )
+
+    async def async_query(
+        self,
+        request: dns.message.QueryMessage,
+        timeout: float,
+        source: Optional[str],
+        source_port: int,
+        max_size: bool,
+        backend: dns.asyncbackend.Backend,
+        one_rr_per_rrset: bool = False,
+        ignore_trailing: bool = False,
+    ) -> dns.message.Message:
+        return await dns.asyncquery.quic(
+            request,
+            self.address,
+            port=self.port,
+            timeout=timeout,
+            one_rr_per_rrset=one_rr_per_rrset,
+            ignore_trailing=ignore_trailing,
+            verify=self.verify,
+        )

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -864,7 +864,7 @@ class BaseResolver:
     retry_servfail: bool
     rotate: bool
     ndots: Optional[int]
-    _nameservers: List[str]
+    _nameservers: List[Union[str, dns.nameserver.Nameserver]]
 
     def __init__(
         self, filename: str = "/etc/resolv.conf", configure: bool = True
@@ -1117,7 +1117,9 @@ class BaseResolver:
 
         self.flags = flags
 
-    def _enrich_nameservers(self, nameservers):
+    def _enrich_nameservers(
+        self, nameservers: List[Union[str, dns.nameserver.Nameserver]]
+    ) -> List[dns.nameserver.Nameserver]:
         enriched_nameservers = []
         if isinstance(nameservers, list):
             for nameserver in nameservers:
@@ -1156,7 +1158,9 @@ class BaseResolver:
         return self._nameservers
 
     @nameservers.setter
-    def nameservers(self, nameservers: List[str]) -> None:
+    def nameservers(
+        self, nameservers: List[Union[str, dns.nameserver.Nameserver]]
+    ) -> None:
         """
         *nameservers*, a ``list`` of nameservers, where a nameserver is either
         a string interpretable as a nameserver, or a ``dns.nameserver.Nameserver``

--- a/doc/resolver-class.rst
+++ b/doc/resolver-class.rst
@@ -42,11 +42,7 @@ The dns.resolver.Resolver and dns.resolver.Answer Classes
       A ``dict`` mapping an IPv4 or IPv6 address ``str`` to an ``int``.
       This specifies the port to use when sending to a nameserver.  If
       a port is not defined for an address, the value of the *port*
-      attribute will be used.  With the introduction of the
-      ``dns.nameserver.Nameserver``, this field is now obsolete, but is still
-      used when constructing ``dns.nameserver.Nameserver`` instances.
-      For this to work correctly, *nameserver_ports* must be set before
-      assigning to *nameservers*.
+      attribute will be used.
 
    .. attribute:: timeout
 

--- a/doc/resolver-class.rst
+++ b/doc/resolver-class.rst
@@ -12,11 +12,12 @@ The dns.resolver.Resolver and dns.resolver.Answer Classes
 
    .. attribute:: nameservers
 
-      A ``list`` of ``str``, each item containing an IPv4 or IPv6 address.
+      A ``list`` of ``str`` or ``dns.nameserver.Nameserver``.  A string may be
+      an IPv4 or IPv6 address, or an https URL.
 
-      This field is planned to become a property in dnspython 2.4.  Writing to this
-      field other than by direct assignment is deprecated, and so is depending on the
-      mutability and form of the iterable returned when it is read.
+      This field is actually a property, and returns a tuple as of dnspython 2.4.
+      Assigning this this field converts any strings into
+      ``dns.nameserver.Nameserver`` instances.
 
    .. attribute:: search
 
@@ -41,7 +42,11 @@ The dns.resolver.Resolver and dns.resolver.Answer Classes
       A ``dict`` mapping an IPv4 or IPv6 address ``str`` to an ``int``.
       This specifies the port to use when sending to a nameserver.  If
       a port is not defined for an address, the value of the *port*
-      attribute will be used.
+      attribute will be used.  With the introduction of the
+      ``dns.nameserver.Nameserver``, this field is now obsolete, but is still
+      used when constructing ``dns.nameserver.Nameserver`` instances.
+      For this to work correctly, *nameserver_ports* must be set before
+      assigning to *nameservers*.
 
    .. attribute:: timeout
 

--- a/doc/resolver-nameserver.rst
+++ b/doc/resolver-nameserver.rst
@@ -1,0 +1,46 @@
+.. _resolver-nameserver:
+
+The dns.nameserver.Nameserver Classes
+-------------------------------------
+
+The ``dns.nameserver.Nameserver`` abstract class represents a remote recursive resolver,
+and is used by the stub resolver to answer queries.
+
+.. autoclass:: dns.nameserver.Nameserver
+   :members:
+
+The dns.nameserver.Do53Nameserver Class
+---------------------------------------
+
+The ``dns.nameserver.Do53Nameserver`` class is a ``dns.nameserver.Nameserver`` class use
+to make regular port 53 (Do53) DNS queries to a recursive server.
+
+.. autoclass:: dns.nameserver.Do53Nameserver
+   :members:
+
+The dns.nameserver.DoTNameserver Class
+---------------------------------------
+
+The ``dns.nameserver.DoTNameserver`` class is a ``dns.nameserver.Nameserver`` class use
+to make DNS-over-TLS (DoT) queries to a recursive server.
+
+.. autoclass:: dns.nameserver.DoTNameserver
+   :members:
+
+The dns.nameserver.DoHNameserver Class
+---------------------------------------
+
+The ``dns.nameserver.DoHNameserver`` class is a ``dns.nameserver.Nameserver`` class use
+to make DNS-over-HTTPS (DoH) queries to a recursive server.
+
+.. autoclass:: dns.nameserver.DoHNameserver
+   :members:
+
+The dns.nameserver.DoQNameserver Class
+---------------------------------------
+
+The ``dns.nameserver.DoQNameserver`` class is a ``dns.nameserver.Nameserver`` class use
+to make DNS-over-QUIC (DoQ) queries to a recursive server.
+
+.. autoclass:: dns.nameserver.DoQNameserver
+   :members:

--- a/doc/resolver.rst
+++ b/doc/resolver.rst
@@ -13,6 +13,7 @@ be used simply by setting the *nameservers* attribute.
 .. toctree::
 
    resolver-class
+   resolver-nameserver
    resolver-functions
    resolver-caching
    resolver-override

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,13 +7,13 @@ What's New in dnspython
 ----------------------
 
 * The stub resolver uses instances of ``dns.nameserver.Nameserver`` to represent
-remote recursive resolvers.  The stub resolver can now communicate using ordinary
-DNS over port 53, HTTPS, TLS, and QUIC.  This change is NOT completely backwards
-compatible!  The resolver *nameservers* field is now a tuple instead of a list when read,
-and so cannot be mutated, for example by appending.  Because the old text forms of
-nameservers are "enriched" into ``dns.nameserver.Nameserver`` instances when the
-*nameservers* field is assigned, you must now ensure that you set *nameserver_ports*
-before assigning nameservers if you want it to have any effect.
+  remote recursive resolvers.  The stub resolver can now communicate using ordinary
+  DNS over port 53, HTTPS, TLS, and QUIC.  This change is NOT completely backwards
+  compatible!  The resolver *nameservers* field is now a tuple instead of a list when read,
+  and so cannot be mutated, for example by appending.  Because the old text forms of
+  nameservers are "enriched" into ``dns.nameserver.Nameserver`` instances when the
+  *nameservers* field is assigned, you must now ensure that you set *nameserver_ports*
+  before assigning nameservers if you want it to have any effect.
 
 
 2.3.0

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,6 +6,15 @@ What's New in dnspython
 2.4.0 (in development)
 ----------------------
 
+* The stub resolver uses instances of ``dns.nameserver.Nameserver`` to represent
+remote recursive resolvers.  The stub resolver can now communicate using ordinary
+DNS over port 53, HTTPS, TLS, and QUIC.  This change is NOT completely backwards
+compatible!  The resolver *nameservers* field is now a tuple instead of a list when read,
+and so cannot be mutated, for example by appending.  Because the old text forms of
+nameservers are "enriched" into ``dns.nameserver.Nameserver`` instances when the
+*nameservers* field is assigned, you must now ensure that you set *nameserver_ports*
+before assigning nameservers if you want it to have any effect.
+
 2.3.0
 -----
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,6 +15,7 @@ nameservers are "enriched" into ``dns.nameserver.Nameserver`` instances when the
 *nameservers* field is assigned, you must now ensure that you set *nameserver_ports*
 before assigning nameservers if you want it to have any effect.
 
+
 2.3.0
 -----
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,15 +6,11 @@ What's New in dnspython
 2.4.0 (in development)
 ----------------------
 
-* The stub resolver uses instances of ``dns.nameserver.Nameserver`` to represent
-  remote recursive resolvers.  The stub resolver can now communicate using ordinary
-  DNS over port 53, HTTPS, TLS, and QUIC.  This change is NOT completely backwards
-  compatible!  The resolver *nameservers* field is now a tuple instead of a list when read,
-  and so cannot be mutated, for example by appending.  Because the old text forms of
-  nameservers are "enriched" into ``dns.nameserver.Nameserver`` instances when the
-  *nameservers* field is assigned, you must now ensure that you set *nameserver_ports*
-  before assigning nameservers if you want it to have any effect.
-
+* The stub resolver now uses instances of ``dns.nameserver.Nameserver`` to represent
+  remote recursive resolvers, and can communicate using
+  DNS over port 53, HTTPS, TLS, and QUIC.  In additional to being able to specify
+  an IPv4, IPv6, or HTTPS URL as a nameserver, instances of ``dns.nameserver.Nameserver``
+  are now permitted.
 
 2.3.0
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ coverage = "^7.0"
 twine = "^4.0.0"
 wheel = "^0.38.1"
 pylint = "^2.7.4"
-mypy = ">=0.940"
+mypy = ">=1.0.1"
 black = "^23.1.0"
 
 [tool.poetry.extras]

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -267,12 +267,10 @@ class ResolutionTestCase(unittest.TestCase):
     def test_next_nameserver_udp(self):
         (request, answer) = self.resn.next_request()
         (nameserver1, tcp, backoff) = self.resn.next_nameserver()
-        self.assertTrue(nameserver1 in self.resolver._enriched_nameservers)
         self.assertEqual(nameserver1.port, 53)
         self.assertFalse(tcp)
         self.assertEqual(backoff, 0.0)
         (nameserver2, tcp, backoff) = self.resn.next_nameserver()
-        self.assertTrue(nameserver2 in self.resolver._enriched_nameservers)
         self.assertTrue(nameserver2 != nameserver1)
         self.assertEqual(nameserver2.port, 53)
         self.assertFalse(tcp)
@@ -293,7 +291,6 @@ class ResolutionTestCase(unittest.TestCase):
     def test_next_nameserver_retry_with_tcp(self):
         (request, answer) = self.resn.next_request()
         (nameserver1, tcp, backoff) = self.resn.next_nameserver()
-        self.assertTrue(nameserver1 in self.resolver._enriched_nameservers)
         self.assertEqual(nameserver1.port, 53)
         self.assertFalse(tcp)
         self.assertEqual(backoff, 0.0)
@@ -303,7 +300,6 @@ class ResolutionTestCase(unittest.TestCase):
         self.assertTrue(tcp)
         self.assertEqual(backoff, 0.0)
         (nameserver3, tcp, backoff) = self.resn.next_nameserver()
-        self.assertTrue(nameserver3 in self.resolver._enriched_nameservers)
         self.assertTrue(nameserver3 != nameserver1)
         self.assertEqual(nameserver3.port, 53)
         self.assertFalse(tcp)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -221,14 +221,14 @@ class BaseResolverTests(unittest.TestCase):
         f = StringIO(resolv_conf)
         r = dns.resolver.Resolver(configure=False)
         r.read_resolv_conf(f)
-        self.assertEqual(r.nameservers, ("10.0.0.1", "10.0.0.2"))
+        self.assertEqual(r.nameservers, ["10.0.0.1", "10.0.0.2"])
         self.assertEqual(r.domain, dns.name.from_text("foo"))
 
     def testReadOptions(self):
         f = StringIO(resolv_conf_options1)
         r = dns.resolver.Resolver(configure=False)
         r.read_resolv_conf(f)
-        self.assertEqual(r.nameservers, ("10.0.0.1", "10.0.0.2"))
+        self.assertEqual(r.nameservers, ["10.0.0.1", "10.0.0.2"])
         self.assertTrue(r.rotate)
         self.assertEqual(r.timeout, 1)
         self.assertEqual(r.ndots, 2)
@@ -271,14 +271,14 @@ class BaseResolverTests(unittest.TestCase):
         f = StringIO(unknown_and_bad_directives)
         r = dns.resolver.Resolver(configure=False)
         r.read_resolv_conf(f)
-        self.assertEqual(r.nameservers, ("10.0.0.1",))
+        self.assertEqual(r.nameservers, ["10.0.0.1"])
 
     def testReadUnknownOption(self):
         # The real test here is ignoring the unknown option
         f = StringIO(unknown_option)
         r = dns.resolver.Resolver(configure=False)
         r.read_resolv_conf(f)
-        self.assertEqual(r.nameservers, ("10.0.0.1",))
+        self.assertEqual(r.nameservers, ["10.0.0.1"])
 
     def testCacheExpiration(self):
         with FakeTime() as fake_time:
@@ -756,7 +756,7 @@ class LiveResolverTests(unittest.TestCase):
 
     def testNameserverSetting(self):
         res = dns.resolver.Resolver(configure=False)
-        ns = ("1.2.3.4", "::1", "https://ns.example")
+        ns = ["1.2.3.4", "::1", "https://ns.example"]
         res.nameservers = ns[:]
         self.assertEqual(res.nameservers, ns)
         for ns in ["999.999.999.999", "ns.example.", "bogus://ns.example"]:
@@ -794,7 +794,6 @@ if hasattr(selectors, "PollSelector"):
 
 
 class NXDOMAINExceptionTestCase(unittest.TestCase):
-
     # pylint: disable=broad-except
 
     def test_nxdomain_compatible(self):
@@ -959,22 +958,12 @@ class ResolverNameserverValidTypeTestCase(unittest.TestCase):
     def test_set_nameservers_to_list(self):
         resolver = dns.resolver.Resolver(configure=False)
         resolver.nameservers = ["1.2.3.4"]
-        self.assertEqual(resolver.nameservers, ("1.2.3.4",))
+        self.assertEqual(resolver.nameservers, ["1.2.3.4"])
 
     def test_set_namservers_to_empty_list(self):
         resolver = dns.resolver.Resolver(configure=False)
         resolver.nameservers = []
-        self.assertEqual(resolver.nameservers, ())
-
-    def test_set_nameservers_to_tuple(self):
-        resolver = dns.resolver.Resolver(configure=False)
-        resolver.nameservers = ("1.2.3.4",)
-        self.assertEqual(resolver.nameservers, ("1.2.3.4",))
-
-    def test_set_namservers_to_empty_list(self):
-        resolver = dns.resolver.Resolver(configure=False)
-        resolver.nameservers = ()
-        self.assertEqual(resolver.nameservers, ())
+        self.assertEqual(resolver.nameservers, [])
 
     def test_set_nameservers_invalid_type(self):
         resolver = dns.resolver.Resolver(configure=False)
@@ -983,6 +972,7 @@ class ResolverNameserverValidTypeTestCase(unittest.TestCase):
             "1.2.3.4",
             1234,
             (1, 2, 3, 4),
+            (),
             {"invalid": "nameserver"},
         ]
         for invalid_nameserver in invalid_nameservers:


### PR DESCRIPTION
This turns the list of nameserver strings in the resolver into a list of nameserver objects, which abstract away making queries to a nameserver of a given type.  There is a handy text form that is purposely not a URI.  Supported nameservers are:

```
Regular RFC 1035 DNS:  regular|<address>|<port>
DNS-over-HTTPS:  https|<url>
DNS-over-TLS:  tls|<address>|<port>
DNS-over-QUIC:  quic|<address>|<port>
```

The resolver's legacy nameserver list is "enriched" into a list of nameserver objects whenever it is set.  Note that you cannot mutate the object other than by setting,
e.g. res.nameservers.append("1.2.3.4") will not work.  We don't currently detext such mutations.

Error message accumulation has been updated to refer to the nameservers using the text forms above.