### PR TITLE
Add dns.resolver.resolve_name().

### DIFF
--- a/dns/asyncresolver.py
+++ b/dns/asyncresolver.py
@@ -17,8 +17,9 @@
 
 """Asynchronous DNS stub resolver."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
+import socket
 import time
 
 import dns.asyncbackend
@@ -31,7 +32,7 @@ import dns.rdatatype
 import dns.resolver  # lgtm[py/import-and-import-from]
 
 # import some resolver symbols for brevity
-from dns.resolver import NXDOMAIN, NoAnswer, NotAbsolute, NoRootSOA
+from dns.resolver import Answer, NXDOMAIN, NoAnswer, NotAbsolute, NoRootSOA
 
 
 # for indentation purposes below
@@ -135,6 +136,67 @@ class Resolver(dns.resolver.BaseResolver):
             dns.reversename.from_address(ipaddr), *args, **modified_kwargs
         )
 
+
+    async def resolve_name(
+        self,
+        name: Union[dns.name.Name, str],
+        family: int = socket.AF_UNSPEC,
+        **kwargs: Any
+    ) -> List[Answer]:
+        """Use an asynchronous resolver to query for address records.
+
+        This utilizes the resolve() method to perform A and/or AAAA lookups on
+        the specified name.
+
+        *qname*, a ``dns.name.Name`` or ``str``, the name to resolve.
+
+        *family*, an ``int``, the address family.  If socket.AF_UNSPEC
+        (the default), both A and AAAA records will be retrieved.
+
+        All other arguments that can be passed to the resolve() function
+        except for rdtype and rdclass are also supported by this
+        function.
+        """
+        # We make a modified kwargs for type checking happiness, as otherwise
+        # we get a legit warning about possibly having rdtype and rdclass
+        # in the kwargs more than once.
+        modified_kwargs: Dict[str, Any] = {}
+        modified_kwargs.update(kwargs)
+        modified_kwargs.pop("rdtype", None)
+        modified_kwargs["rdclass"] = dns.rdataclass.IN
+
+        if family == socket.AF_INET:
+            return [await self.resolve(name, dns.rdatatype.A, **modified_kwargs)]
+        elif family == socket.AF_INET6:
+            return [await self.resolve(name, dns.rdatatype.AAAA, **modified_kwargs)]
+        elif family != socket.AF_UNSPEC:
+            raise NotImplementedError(f"unknown address family {family}")
+
+        raise_on_no_answer = modified_kwargs.pop('raise_on_no_answer', True)
+        lifetime = modified_kwargs.pop('lifetime', None)
+        start = time.time()
+        v6 = await self.resolve(name, dns.rdatatype.AAAA,
+                                raise_on_no_answer=False,
+                                lifetime=self._compute_timeout(start, lifetime),
+                                **modified_kwargs)
+        # Note that setting name ensures we query the same name
+        # for A as we did for AAAA.  (This is just in case search lists
+        # are active by default in the resolver configuration and
+        # we might be talking to a server that says NXDOMAIN when it
+        # wants to say NOERROR no data.
+        name = v6.qname
+        v4 = await self.resolve(name, dns.rdatatype.A,
+                                raise_on_no_answer=False,
+                                lifetime=self._compute_timeout(start, lifetime),
+                                **modified_kwargs)
+        if not raise_on_no_answer:
+            return [v6, v4]
+        answers = [a for a in (v6, v4) if a.rrset is not None]
+        if not answers:
+            raise NoAnswer(response=v6.response)
+        return answers
+
+
     # pylint: disable=redefined-outer-name
 
     async def canonical_name(self, name: Union[dns.name.Name, str]) -> dns.name.Name:
@@ -226,6 +288,20 @@ async def resolve_address(
     """
 
     return await get_default_resolver().resolve_address(ipaddr, *args, **kwargs)
+
+
+async def resolve_name(
+    name: Union[dns.name.Name, str],
+    family: int = socket.AF_UNSPEC,
+    **kwargs: Any
+) -> List[Answer]:
+    """Use a resolver to asynchronously query for address records.
+
+    See :py:func:`dns.asyncresolver.Resolver.resolve_name` for more
+    information on the parameters.
+    """
+
+    return await get_default_resolver().resolve_name(name, family, **kwargs)
 
 
 async def canonical_name(name: Union[dns.name.Name, str]) -> dns.name.Name:

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -339,7 +339,7 @@ class HostAnswers(Answers):
     def addresses_and_families(
         self,
         family : int = socket.AF_UNSPEC
-    ) -> Iterator[Tuple[int, str]]:
+    ) -> Iterator[Tuple[str, int]]:
         if family == socket.AF_UNSPEC:
             yield from self.addresses_and_families(socket.AF_INET6)
             yield from self.addresses_and_families(socket.AF_INET)
@@ -352,12 +352,12 @@ class HostAnswers(Answers):
             raise NotImplementedError(f"unknown address family {family}")
         if answer:
             for rdata in answer:
-                yield (family, rdata.address)
+                yield (rdata.address, family)
 
     # Returns addresses from this result, potentially filtering by
     # address family.
     def addresses(self, family : int = socket.AF_UNSPEC) -> Iterator[str]:
-        return (pair[1] for pair in self.addresses_and_families(family))
+        return (pair[0] for pair in self.addresses_and_families(family))
 
     # Returns the canonical name from this result.
     def canonical_name(self) -> dns.name.Name:
@@ -1785,7 +1785,7 @@ def _getaddrinfo(
         cname = canonical_name
     else:
         cname = ""
-    for af, addr in addrs:
+    for addr, af in addrs:
         for socktype in socktypes:
             for proto in _protocols_for_socktype[socktype]:
                 addr_tuple = dns.inet.low_level_address_tuple((addr, port), af)

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1346,7 +1346,7 @@ class Resolver(BaseResolver):
     def resolve_name(
         self,
         name: Union[dns.name.Name, str],
-        family=socket.AF_UNSPEC,
+        family: int = socket.AF_UNSPEC,
         **kwargs: Any
     ) -> List[Answer]:
         """Use a resolver to query for address records.
@@ -1530,7 +1530,7 @@ def resolve_address(ipaddr: str, *args: Any, **kwargs: Any) -> Answer:
 
 def resolve_name(
     name: Union[dns.name.Name, str],
-    family=socket.AF_UNSPEC,
+    family: int = socket.AF_UNSPEC,
     **kwargs: Any
 ) -> List[Answer]:
     """Use a resolver to query for address records.

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -334,8 +334,8 @@ class HostAnswers(Answers):
         return answers
 
 
-    # Returns pairs of (af, address) from this result, potentially filtering by
-    # address family.
+    # Returns pairs of (address, family) from this result, potentiallys
+    # filtering by address family.
     def addresses_and_families(
         self,
         family : int = socket.AF_UNSPEC

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -16,6 +16,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import asyncio
+import itertools
 import random
 import socket
 import sys
@@ -186,6 +187,48 @@ class AsyncTests(unittest.TestCase):
         answer = self.async_run(run)
         dnsgoogle = dns.name.from_text("dns.google.")
         self.assertEqual(answer[0].target, dnsgoogle)
+
+    def testResolveName(self):
+        async def run1():
+            return await dns.asyncresolver.resolve_name("dns.google.")
+
+        answers = self.async_run(run1)
+        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        self.assertEqual(len(seen), 4)
+        self.assertIn("8.8.8.8", seen)
+        self.assertIn("8.8.4.4", seen)
+        self.assertIn("2001:4860:4860::8844", seen)
+        self.assertIn("2001:4860:4860::8888", seen)
+
+        async def run2():
+            return await dns.asyncresolver.resolve_name("dns.google.", socket.AF_INET)
+
+        answers = self.async_run(run2)
+        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        self.assertEqual(len(seen), 2)
+        self.assertIn("8.8.8.8", seen)
+        self.assertIn("8.8.4.4", seen)
+
+        async def run3():
+            return await dns.asyncresolver.resolve_name("dns.google.", socket.AF_INET6)
+
+        answers = self.async_run(run3)
+        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        self.assertEqual(len(seen), 2)
+        self.assertIn("2001:4860:4860::8844", seen)
+        self.assertIn("2001:4860:4860::8888", seen)
+
+        async def run4():
+            return await dns.asyncresolver.resolve_name("nxdomain.dnspython.org")
+
+        with self.assertRaises(dns.resolver.NXDOMAIN):
+            self.async_run(run4)
+
+        async def run5():
+            return await dns.asyncresolver.resolve_name(dns.reversename.from_address("8.8.8.8"))
+
+        with self.assertRaises(dns.resolver.NoAnswer):
+            self.async_run(run5)
 
     def testCanonicalNameNoCNAME(self):
         cname = dns.name.from_text("www.google.com")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -16,7 +16,6 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import asyncio
-import itertools
 import random
 import socket
 import sys
@@ -193,7 +192,7 @@ class AsyncTests(unittest.TestCase):
             return await dns.asyncresolver.resolve_name("dns.google.")
 
         answers = self.async_run(run1)
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 4)
         self.assertIn("8.8.8.8", seen)
         self.assertIn("8.8.4.4", seen)
@@ -204,7 +203,7 @@ class AsyncTests(unittest.TestCase):
             return await dns.asyncresolver.resolve_name("dns.google.", socket.AF_INET)
 
         answers = self.async_run(run2)
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 2)
         self.assertIn("8.8.8.8", seen)
         self.assertIn("8.8.4.4", seen)
@@ -213,19 +212,19 @@ class AsyncTests(unittest.TestCase):
             return await dns.asyncresolver.resolve_name("dns.google.", socket.AF_INET6)
 
         answers = self.async_run(run3)
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 2)
         self.assertIn("2001:4860:4860::8844", seen)
         self.assertIn("2001:4860:4860::8888", seen)
 
         async def run4():
-            return await dns.asyncresolver.resolve_name("nxdomain.dnspython.org")
+            await dns.asyncresolver.resolve_name("nxdomain.dnspython.org")
 
         with self.assertRaises(dns.resolver.NXDOMAIN):
             self.async_run(run4)
 
         async def run5():
-            return await dns.asyncresolver.resolve_name(dns.reversename.from_address("8.8.8.8"))
+            await dns.asyncresolver.resolve_name(dns.reversename.from_address("8.8.8.8"))
 
         with self.assertRaises(dns.resolver.NoAnswer):
             self.async_run(run5)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -16,7 +16,6 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from io import StringIO
-import itertools
 import selectors
 import sys
 import socket
@@ -669,7 +668,7 @@ class LiveResolverTests(unittest.TestCase):
 
     def testResolveName(self):
         answers = dns.resolver.resolve_name("dns.google.")
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 4)
         self.assertIn("8.8.8.8", seen)
         self.assertIn("8.8.4.4", seen)
@@ -677,22 +676,22 @@ class LiveResolverTests(unittest.TestCase):
         self.assertIn("2001:4860:4860::8888", seen)
 
         answers = dns.resolver.resolve_name("dns.google.", socket.AF_INET)
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 2)
         self.assertIn("8.8.8.8", seen)
         self.assertIn("8.8.4.4", seen)
 
         answers = dns.resolver.resolve_name("dns.google.", socket.AF_INET6)
-        seen = set(rdata.address for rdata in itertools.chain(*answers))
+        seen = set(answers.addresses())
         self.assertEqual(len(seen), 2)
         self.assertIn("2001:4860:4860::8844", seen)
         self.assertIn("2001:4860:4860::8888", seen)
 
         with self.assertRaises(dns.resolver.NXDOMAIN):
-            answers = dns.resolver.resolve_name("nxdomain.dnspython.org")
+            dns.resolver.resolve_name("nxdomain.dnspython.org")
 
         with self.assertRaises(dns.resolver.NoAnswer):
-            answers = dns.resolver.resolve_name(dns.reversename.from_address("8.8.8.8"))
+            dns.resolver.resolve_name(dns.reversename.from_address("8.8.8.8"))
 
     @patch.object(dns.message.Message, "use_edns")
     def testResolveEdnsOptions(self, message_use_edns_mock):


### PR DESCRIPTION
This adds the `dns.resolver.resolve_name` and `dns.resolver.Resolver.resolve_name()` methods, which are designed to be wrappers around host name resolution.  They will query for A, AAAA, or both, depending on the requested address family.

This refactors `getaddrinfo` to use `resolve_name`, and simplifies it overall.  It should also be usable for some of the new logic  in the better-doh branch.