### PR TITLE
Better DNS-over-HTTPS support.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,7 +60,7 @@ jobs:
         sudo apt install -y gnome-keyring
         python -m pip install --upgrade pip
         python -m pip install poetry
-        poetry install -E dnssec -E doh -E idna -E trio
+        poetry install -E dnssec -E doh -E idna -E trio -E curio
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/dns/_asyncbackend.py
+++ b/dns/_asyncbackend.py
@@ -61,6 +61,11 @@ class StreamSocket(Socket):  # pragma: no cover
         raise NotImplementedError
 
 
+class NullTransport:
+    async def connect_tcp(self, host, port, timeout, local_address):
+        raise NotImplementedError
+
+
 class Backend:  # pragma: no cover
     def name(self):
         return "unknown"
@@ -82,4 +87,7 @@ class Backend:  # pragma: no cover
         return False
 
     async def sleep(self, interval):
+        raise NotImplementedError
+
+    def get_transport_class(self):
         raise NotImplementedError

--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -113,6 +113,82 @@ class StreamSocket(dns._asyncbackend.StreamSocket):
         return self.writer.get_extra_info("sockname")
 
 
+try:
+    import anyio
+    import httpx
+
+    import httpcore
+    import httpcore.backends.base
+    import httpcore.backends.asyncio
+
+    from dns.query import _compute_times, _remaining, _expiration_for_this_attempt
+
+    class _NetworkBackend(httpcore.backends.base.AsyncNetworkBackend):
+        def __init__(self, resolver, local_port, bootstrap_address, family):
+            super().__init__()
+            self._local_port = local_port
+            self._resolver = resolver
+            self._bootstrap_address = bootstrap_address
+            self._family = family
+            if local_port != 0:
+                raise NotImplementedError(
+                    "the asyncio transport for HTTPX cannot set the local port"
+                )
+
+        async def connect_tcp(self, host, port, timeout, local_address):
+            addresses = []
+            now, expiration = _compute_times(timeout)
+            if dns.inet.is_address(host):
+                addresses.append(host)
+            elif self._bootstrap_address is not None:
+                addresses.append(self._bootstrap_address)
+            else:
+                timeout = _remaining(expiration)
+                family = self._family
+                if local_address:
+                    family = dns.inet.af_for_address(local_address)
+                answers = await self._resolver.resolve_name(
+                    host, family=family, lifetime=timeout
+                )
+                addresses = answers.addresses()
+            for address in addresses:
+                try:
+                    attempt_expiration = _expiration_for_this_attempt(2.0, expiration)
+                    timeout = _remaining(attempt_expiration)
+                    with anyio.fail_after(timeout):
+                        stream = await anyio.connect_tcp(
+                            remote_host=host,
+                            remote_port=port,
+                            local_host=local_address,
+                        )
+                    return httpcore.backends.asyncio.AsyncIOStream(stream)
+                except Exception:
+                    pass
+            raise httpcore.ConnectError
+
+    class _HTTPTransport(httpx.AsyncHTTPTransport):
+        def __init__(
+            self,
+            *args,
+            local_port=0,
+            bootstrap_address=None,
+            resolver=None,
+            family=socket.AF_UNSPEC,
+            **kwargs,
+        ):
+            if resolver is None:
+                import dns.asyncresolver
+
+                resolver = dns.asyncresolver.Resolver()
+            super().__init__(*args, **kwargs)
+            self._pool._network_backend = _NetworkBackend(
+                resolver, local_port, bootstrap_address, family
+            )
+
+except ImportError:
+    _HTTPTransport = dns._asyncbackend.NullTransport  # type: ignore
+
+
 class Backend(dns._asyncbackend.Backend):
     def name(self):
         return "asyncio"
@@ -171,3 +247,6 @@ class Backend(dns._asyncbackend.Backend):
 
     def datagram_connection_required(self):
         return _is_win32
+
+    def get_transport_class(self):
+        return _HTTPTransport

--- a/dns/_trio_backend.py
+++ b/dns/_trio_backend.py
@@ -83,6 +83,80 @@ class StreamSocket(dns._asyncbackend.StreamSocket):
             return self.stream.socket.getsockname()
 
 
+try:
+    import httpx
+
+    import httpcore
+    import httpcore.backends.base
+    import httpcore.backends.trio
+
+    from dns.query import _compute_times, _remaining, _expiration_for_this_attempt
+
+    class _NetworkBackend(httpcore.backends.base.AsyncNetworkBackend):
+        def __init__(self, resolver, local_port, bootstrap_address, family):
+            super().__init__()
+            self._local_port = local_port
+            self._resolver = resolver
+            self._bootstrap_address = bootstrap_address
+            self._family = family
+
+        async def connect_tcp(self, host, port, timeout, local_address):
+            addresses = []
+            now, expiration = _compute_times(timeout)
+            if dns.inet.is_address(host):
+                addresses.append(host)
+            elif self._bootstrap_address is not None:
+                addresses.append(self._bootstrap_address)
+            else:
+                timeout = _remaining(expiration)
+                family = self._family
+                if local_address:
+                    family = dns.inet.af_for_address(local_address)
+                answers = await self._resolver.resolve_name(
+                    host, family=family, lifetime=timeout
+                )
+                addresses = answers.addresses()
+            for address in addresses:
+                try:
+                    af = dns.inet.af_for_address(address)
+                    if local_address is not None or self._local_port != 0:
+                        source = (local_address, self._local_port)
+                    else:
+                        source = None
+                    destination = (address, port)
+                    attempt_expiration = _expiration_for_this_attempt(2.0, expiration)
+                    timeout = _remaining(attempt_expiration)
+                    sock = await Backend().make_socket(
+                        af, socket.SOCK_STREAM, 0, source, destination, timeout
+                    )
+                    return httpcore.backends.trio.TrioStream(sock.stream)
+                except Exception:
+                    continue
+            raise httpcore.ConnectError
+
+    class _HTTPTransport(httpx.AsyncHTTPTransport):
+        def __init__(
+            self,
+            *args,
+            local_port=0,
+            bootstrap_address=None,
+            resolver=None,
+            family=socket.AF_UNSPEC,
+            **kwargs,
+        ):
+            if resolver is None:
+                import dns.asyncresolver
+
+                resolver = dns.asyncresolver.Resolver()
+            super().__init__(*args, **kwargs)
+            self._pool._network_backend = _NetworkBackend(
+                resolver, local_port, bootstrap_address, family
+            )
+
+except ImportError:
+    _HTTPTransport = dns._asyncbackend.NullTransport  # type: ignore
+
+
 class Backend(dns._asyncbackend.Backend):
     def name(self):
         return "trio"
@@ -104,8 +178,14 @@ class Backend(dns._asyncbackend.Backend):
             if source:
                 await s.bind(_lltuple(source, af))
             if socktype == socket.SOCK_STREAM:
+                connected = False
                 with _maybe_timeout(timeout):
                     await s.connect(_lltuple(destination, af))
+                    connected = True
+                if not connected:
+                    raise dns.exception.Timeout(
+                        timeout=timeout
+                    )  # lgtm[py/unreachable-statement]
         except Exception:  # pragma: no cover
             s.close()
             raise
@@ -130,3 +210,6 @@ class Backend(dns._asyncbackend.Backend):
 
     async def sleep(self, interval):
         await trio.sleep(interval)
+
+    def get_transport_class(self):
+        return _HTTPTransport

--- a/dns/inet.py
+++ b/dns/inet.py
@@ -171,3 +171,12 @@ def low_level_address_tuple(
             return tup
     else:
         raise NotImplementedError(f"unknown address family {af}")
+
+
+def any_for_af(af):
+    """Return the 'any' address for the specified address family."""
+    if af == socket.AF_INET:
+        return "0.0.0.0"
+    elif af == socket.AF_INET6:
+        return "::"
+    raise NotImplementedError(f"unknown address family {af}")

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -45,10 +45,11 @@ Optional Modules
 
 The following modules are optional, but recommended for full functionality.
 
-If ``requests`` and ``requests-toolbelt`` are installed, then DNS-over-HTTPS
-will be available.
+If ``httpx`` is installed, then DNS-over-HTTPS will be available.
 
 If ``cryptography`` is installed, then dnspython will be
-able to do low-level DNSSEC RSA, DSA, ECDSA and EdDSA signature validation.
+able to do low-level DNSSEC signature generation and validation.
 
 If ``idna`` is installed, then IDNA 2008 will be available.
+
+If ``aioquic`` is installed, the DNS-over-QUIC will be available.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,6 +12,11 @@ What's New in dnspython
   an IPv4, IPv6, or HTTPS URL as a nameserver, instances of ``dns.nameserver.Nameserver``
   are now permitted.
 
+* The DNS-over-HTTPS bootstrap address no longer causes URL rewriting.
+
+* DNS-over-HTTPS now only uses httpx; support for requests has been dropped.  A source
+  port may now be supplied when using httpx.
+
 2.3.0
 -----
 

--- a/examples/doh-json.py
+++ b/examples/doh-json.py
@@ -2,7 +2,7 @@
 
 import copy
 import json
-import requests
+import httpx
 
 import dns.flags
 import dns.message
@@ -92,7 +92,7 @@ def from_doh_simple(simple, add_qr=False):
 a = dns.resolver.resolve("www.dnspython.org", "a")
 p = to_doh_simple(a.response)
 print(json.dumps(p, indent=4))
-response = requests.get(
+response = httpx.get(
     "https://dns.google/resolve?",
     verify=True,
     params={"name": "www.dnspython.org", "type": 1},

--- a/examples/doh.py
+++ b/examples/doh.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 #
 # This is an example of sending DNS queries over HTTPS (DoH) with dnspython.
-# Requires use of the requests module's Session object.
-#
-# See https://2.python-requests.org/en/latest/user/advanced/#session-objects
-# for more details about Session objects
-import requests
+import httpx
 
 import dns.message
 import dns.query
@@ -13,30 +9,15 @@ import dns.rdatatype
 
 
 def main():
-    where = "1.1.1.1"
+    where = "https://dns.google/dns-query"
     qname = "example.com."
-    # one method is to use context manager, session will automatically close
-    with requests.sessions.Session() as session:
+    with httpx.Client() as client:
         q = dns.message.make_query(qname, dns.rdatatype.A)
-        r = dns.query.https(q, where, session=session)
+        r = dns.query.https(q, where, session=client)
         for answer in r.answer:
             print(answer)
 
         # ... do more lookups
-
-    where = "https://dns.google/dns-query"
-    qname = "example.net."
-    # second method, close session manually
-    session = requests.sessions.Session()
-    q = dns.message.make_query(qname, dns.rdatatype.A)
-    r = dns.query.https(q, where, session=session)
-    for answer in r.answer:
-        print(answer)
-
-    # ... do more lookups
-
-    # close the session when you're done
-    session.close()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ documentation = "https://dnspython.readthedocs.io/en/stable/"
 python = "^3.7"
 httpx = {version=">=0.21.1", optional=true, python=">=3.6.2"}
 h2 = {version=">=4.1.0", optional=true, python=">=3.6.2"}
-requests-toolbelt = {version=">=0.9.1,<0.11.0", optional=true}
-requests = {version="^2.23.0", optional=true}
 idna = {version=">=2.1,<4.0", optional=true}
 cryptography = {version=">=2.6,<40.0", optional=true}
 trio = {version=">=0.14,<0.23", optional=true}
@@ -63,7 +61,7 @@ mypy = ">=1.0.1"
 black = "^23.1.0"
 
 [tool.poetry.extras]
-doh = ['httpx', 'h2', 'requests', 'requests-toolbelt']
+doh = ['httpx', 'h2']
 idna = ['idna']
 dnssec = ['cryptography']
 trio = ['trio']

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ test_suite = tests
 setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
-DOH = httpx>=0.21.1; h2>=4.1.0; requests; requests-toolbelt
+DOH = httpx>=0.21.1; h2>=4.1.0
 IDNA = idna>=2.1
 DNSSEC = cryptography>=2.6
 trio = trio>=0.14.0

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -31,10 +31,6 @@ import dns.query
 import dns.rdatatype
 import dns.resolver
 
-if dns.query._have_requests:
-    import requests
-    from requests.exceptions import SSLError
-
 if dns.query._have_httpx:
     import httpx
 
@@ -42,18 +38,26 @@ import tests.util
 
 resolver_v4_addresses = []
 resolver_v6_addresses = []
+family = socket.AF_UNSPEC
 if tests.util.have_ipv4():
     resolver_v4_addresses = [
         "1.1.1.1",
         "8.8.8.8",
         # '9.9.9.9',
     ]
+    family = socket.AF_INET
 if tests.util.have_ipv6():
     resolver_v6_addresses = [
         "2606:4700:4700::1111",
         "2001:4860:4860::8888",
         # '2620:fe::fe',
     ]
+    if family == socket.AF_INET:
+        # we have both working, go back to UNSPEC
+        family = socket.AF_UNSPEC
+    else:
+        # v6 only
+        family = socket.AF_INET6
 
 KNOWN_ANYCAST_DOH_RESOLVER_URLS = [
     "https://cloudflare-dns.com/dns-query",
@@ -65,86 +69,6 @@ KNOWN_PAD_AWARE_DOH_RESOLVER_URLS = [
     "https://cloudflare-dns.com/dns-query",
     "https://dns.google/dns-query",
 ]
-
-
-@unittest.skipUnless(
-    dns.query._have_requests and tests.util.is_internet_reachable(),
-    "Python requests cannot be imported; no DNS over HTTPS (DOH)",
-)
-class DNSOverHTTPSTestCaseRequests(unittest.TestCase):
-    def setUp(self):
-        self.session = requests.sessions.Session()
-
-    def tearDown(self):
-        self.session.close()
-
-    def test_get_request(self):
-        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
-        q = dns.message.make_query("example.com.", dns.rdatatype.A)
-        r = dns.query.https(
-            q, nameserver_url, session=self.session, post=False, timeout=4
-        )
-        self.assertTrue(q.is_response(r))
-
-    def test_post_request(self):
-        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
-        q = dns.message.make_query("example.com.", dns.rdatatype.A)
-        r = dns.query.https(
-            q, nameserver_url, session=self.session, post=True, timeout=4
-        )
-        self.assertTrue(q.is_response(r))
-
-    def test_build_url_from_ip(self):
-        self.assertTrue(resolver_v4_addresses or resolver_v6_addresses)
-        if resolver_v4_addresses:
-            nameserver_ip = random.choice(resolver_v4_addresses)
-            q = dns.message.make_query("example.com.", dns.rdatatype.A)
-            # For some reason Google's DNS over HTTPS fails when you POST to
-            # https://8.8.8.8/dns-query
-            # So we're just going to do GET requests here
-            r = dns.query.https(
-                q, nameserver_ip, session=self.session, post=False, timeout=4
-            )
-
-            self.assertTrue(q.is_response(r))
-        if resolver_v6_addresses:
-            nameserver_ip = random.choice(resolver_v6_addresses)
-            q = dns.message.make_query("example.com.", dns.rdatatype.A)
-            r = dns.query.https(
-                q, nameserver_ip, session=self.session, post=False, timeout=4
-            )
-            self.assertTrue(q.is_response(r))
-
-    def test_bootstrap_address(self):
-        # We test this to see if v4 is available
-        if resolver_v4_addresses:
-            ip = "185.228.168.168"
-            invalid_tls_url = "https://{}/doh/family-filter/".format(ip)
-            valid_tls_url = "https://doh.cleanbrowsing.org/doh/family-filter/"
-            q = dns.message.make_query("example.com.", dns.rdatatype.A)
-            # make sure CleanBrowsing's IP address will fail TLS certificate
-            # check
-            with self.assertRaises(SSLError):
-                dns.query.https(q, invalid_tls_url, session=self.session, timeout=4)
-            # use host header
-            r = dns.query.https(
-                q, valid_tls_url, session=self.session, bootstrap_address=ip, timeout=4
-            )
-            self.assertTrue(q.is_response(r))
-
-    def test_new_session(self):
-        nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
-        q = dns.message.make_query("example.com.", dns.rdatatype.A)
-        r = dns.query.https(q, nameserver_url, timeout=4)
-        self.assertTrue(q.is_response(r))
-
-    def test_resolver(self):
-        res = dns.resolver.Resolver(configure=False)
-        res.nameservers = ["https://dns.google/dns-query"]
-        answer = res.resolve("dns.google", "A")
-        seen = set([rdata.address for rdata in answer])
-        self.assertTrue("8.8.8.8" in seen)
-        self.assertTrue("8.8.4.4" in seen)
 
 
 @unittest.skipUnless(
@@ -162,7 +86,12 @@ class DNSOverHTTPSTestCaseHttpx(unittest.TestCase):
         nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
         q = dns.message.make_query("example.com.", dns.rdatatype.A)
         r = dns.query.https(
-            q, nameserver_url, session=self.session, post=False, timeout=4
+            q,
+            nameserver_url,
+            session=self.session,
+            post=False,
+            timeout=4,
+            family=family,
         )
         self.assertTrue(q.is_response(r))
 
@@ -173,7 +102,12 @@ class DNSOverHTTPSTestCaseHttpx(unittest.TestCase):
             nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
             q = dns.message.make_query("example.com.", dns.rdatatype.A)
             r = dns.query.https(
-                q, nameserver_url, session=self.session, post=False, timeout=4
+                q,
+                nameserver_url,
+                session=self.session,
+                post=False,
+                timeout=4,
+                family=family,
             )
             self.assertTrue(q.is_response(r))
         finally:
@@ -183,7 +117,12 @@ class DNSOverHTTPSTestCaseHttpx(unittest.TestCase):
         nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)
         q = dns.message.make_query("example.com.", dns.rdatatype.A)
         r = dns.query.https(
-            q, nameserver_url, session=self.session, post=True, timeout=4
+            q,
+            nameserver_url,
+            session=self.session,
+            post=True,
+            timeout=4,
+            family=family,
         )
         self.assertTrue(q.is_response(r))
 
@@ -219,17 +158,15 @@ class DNSOverHTTPSTestCaseHttpx(unittest.TestCase):
             # check.
             with self.assertRaises(httpx.ConnectError):
                 dns.query.https(q, invalid_tls_url, session=self.session, timeout=4)
-            # We can't do the Host header and SNI magic with httpx, but
-            # we are demanding httpx be used by providing a session, so
-            # we should get a NoDOH exception.
-            with self.assertRaises(dns.query.NoDOH):
-                dns.query.https(
-                    q,
-                    valid_tls_url,
-                    session=self.session,
-                    bootstrap_address=ip,
-                    timeout=4,
-                )
+            # And if we don't mangle the URL, it should work.
+            r = dns.query.https(
+                q,
+                valid_tls_url,
+                session=self.session,
+                bootstrap_address=ip,
+                timeout=4,
+            )
+            self.assertTrue(q.is_response(r))
 
     def test_new_session(self):
         nameserver_url = random.choice(KNOWN_ANYCAST_DOH_RESOLVER_URLS)


### PR DESCRIPTION
This change:

Allows resolution hostnames in URLs using dnspython's resolver or via a bootstrap address, without rewriting URLs.

Adds full support for source addresses and ports to httpx, except for asyncio I/O where only the source address can be specified.

Removes support for requests.