### PR TITLE
Improve get_rrset/find_rrset API.

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -392,13 +392,13 @@ class Message:
 
         if isinstance(section, int):
             section_number = section
-            the_section = self.section_from_number(section_number)
+            section = self.section_from_number(section_number)
         elif isinstance(section, str):
             section_number = MessageSection.from_text(section)
-            the_section = self.section_from_number(section_number)
+            section = self.section_from_number(section_number)
         else:
             section_number = self.section_number(section)
-            the_section = section
+            section = section
         if isinstance(name, str):
             name = dns.name.from_text(name, idna_codec=idna_codec)
         rdtype = dns.rdatatype.RdataType.make(rdtype)
@@ -413,13 +413,13 @@ class Message:
                 if rrset is not None:
                     return rrset
             else:
-                for rrset in the_section:
+                for rrset in section:
                     if rrset.full_match(name, rdclass, rdtype, covers, deleting):
                         return rrset
         if not create:
             raise KeyError
         rrset = dns.rrset.RRset(name, rdclass, rdtype, covers, deleting)
-        the_section.append(rrset)
+        section.append(rrset)
         if self.index is not None:
             self.index[key] = rrset
         return rrset

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -285,6 +285,14 @@ class MessageTestCase(unittest.TestCase):
         self.assertTrue(rrs1 is None)
         self.assertEqual(rrs1, rrs2)
 
+    def test_GetRRsetStrings(self):
+        a = dns.message.from_text(answer_text)
+        a.index = None
+        n = dns.name.from_text("dnspython.org.")
+        rrs1 = a.get_rrset(a.answer, n, dns.rdataclass.IN, dns.rdatatype.SOA)
+        rrs2 = a.get_rrset("ANSWER", "dnspython.org.", "IN", "SOA")
+        self.assertEqual(rrs1, rrs2)
+
     def test_CleanTruncated(self):
         def bad():
             a = dns.message.from_text(answer_text)


### PR DESCRIPTION
This allows most of the parameters to be specified as strings, matching the interface for dns.message.make_query().