### PR TITLE
pass policy to rrset_signer

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -1234,6 +1234,7 @@ def default_rrset_signer(
     inception: Optional[Union[datetime, str, int, float]] = None,
     expiration: Optional[Union[datetime, str, int, float]] = None,
     lifetime: Optional[int] = None,
+    policy: Optional[Policy] = None,
 ) -> None:
     """Default RRset signer"""
 
@@ -1257,6 +1258,7 @@ def default_rrset_signer(
             expiration=expiration,
             lifetime=lifetime,
             signer=signer,
+            policy=policy,
         )
         txn.add(rrset.name, rrset.ttl, rrsig)
 
@@ -1272,6 +1274,7 @@ def sign_zone(
     lifetime: Optional[int] = None,
     nsec3: Optional[NSEC3PARAM] = None,
     rrset_signer: Optional[RRsetSigner] = None,
+    policy: Optional[Policy] = None,
 ) -> None:
     """Sign zone.
 
@@ -1360,6 +1363,7 @@ def sign_zone(
                 inception=inception,
                 expiration=expiration,
                 lifetime=lifetime,
+                policy=policy,
             )
             return _sign_zone_nsec(zone, _txn, _rrset_signer)
 


### PR DESCRIPTION
Add policy argument so that one can test signing with legacy algorithms.