### PR TITLE
Add shebang for ecs.py

### DIFF
--- a/examples/ecs.py
+++ b/examples/ecs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import dns.edns
 import dns.message
 import dns.query


### PR DESCRIPTION
I know this is trivial, but the Debian QA tools get slightly grumpy when there's no shebang for an executable script, so it would make things slightly easier for me if you would add this.

Thanks,

Scott K