### PR TITLE
Split TXT records that are > 255

### DIFF
--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -17,8 +17,9 @@
 
 """TXT-like base class."""
 
-import struct
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
+
+import struct
 
 import dns.exception
 import dns.immutable
@@ -84,9 +85,15 @@ class TXTBase(dns.rdata.Rdata):
                 token.is_quoted_string() or token.is_identifier()
             ):  # pragma: no cover
                 raise dns.exception.SyntaxError("expected a string")
-            if len(token.value) > 255:
-                raise dns.exception.SyntaxError("string too long")
-            strings.append(token.value)
+            token_length = len(token.value)
+            if token_length > 255:
+                start = 0
+                while start < len(token.value):
+                    end = (start + 254) if token_length > (start + 254) else token_length
+                    strings.append(token.value[start:end])
+                    start = end
+            else:
+                strings.append(token.value)
         if len(strings) == 0:
             raise dns.exception.UnexpectedEnd
         return cls(rdclass, rdtype, strings)

--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -17,9 +17,8 @@
 
 """TXT-like base class."""
 
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
-
 import struct
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import dns.exception
 import dns.immutable


### PR DESCRIPTION
Split longer TXT records into smaller chunks for nsupdate, this way long records (like DKIM keys) remain one record.

nsupdate supports getting multiple smaller chunks of data - https://lists.isc.org/pipermail/bind-users/2020-June/103237.html

There is currently as far as I can tell no obvious way to leverage this and create a single record that is longer than 255 characters, this patch alleviates the issue.

Tested with ansible.community.general.nsupdate and DKIM keys.