### PR TITLE
DNSSEC rrsig_expiration calculation

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -549,7 +549,7 @@ def _sign(
     if expiration is not None:
         rrsig_expiration = to_timestamp(expiration)
     elif lifetime is not None:
-        rrsig_expiration = int(time.time()) + lifetime
+        rrsig_expiration = rrsig_inception + lifetime
     else:
         raise ValueError("expiration or lifetime must be specified")
 


### PR DESCRIPTION
In the DNSSEC module, the `rrsig_expiration` calculation did not take into account inception date when using `lifetime` in the `_sign()` function