### PR TITLE
drop cryptography limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ httpx = {version=">=0.24.1", optional=true}
 httpcore = {version=">=0.17.3", optional=true}
 h2 = {version=">=4.1.0", optional=true}
 idna = {version=">=2.1,<4.0", optional=true}
-cryptography = {version=">=2.6,<42.0", optional=true}
+cryptography = {version=">=2.6", optional=true}
 trio = {version=">=0.14,<0.23", optional=true}
 wmi = {version="^1.5.1", optional=true}
 aioquic = {version=">=0.9.20", optional=true}


### PR DESCRIPTION
There seems to be no reason to keep the current limitation for the cryptography dependency, works just fine with the latest version.