### PR TITLE
When scanning interfaces with WMI, include networks without a domain.

### DIFF
--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -51,9 +51,10 @@ if sys.platform == "win32":
                 try:
                     system = wmi.WMI()
                     for interface in system.Win32_NetworkAdapterConfiguration():
-                        if interface.IPEnabled and interface.DNSDomain:
-                            self.info.domain = _config_domain(interface.DNSDomain)
+                        if interface.IPEnabled:
                             self.info.nameservers = list(interface.DNSServerSearchOrder)
+                            if interface.DNSDomain:
+                                self.info.domain = _config_domain(interface.DNSDomain)
                             if interface.DNSDomainSuffixSearchOrder:
                                 self.info.search = [
                                     _config_domain(x)

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -51,7 +51,7 @@ if sys.platform == "win32":
                 try:
                     system = wmi.WMI()
                     for interface in system.Win32_NetworkAdapterConfiguration():
-                        if interface.IPEnabled:
+                        if interface.IPEnabled and interface.DNSServerSearchOrder:
                             self.info.nameservers = list(interface.DNSServerSearchOrder)
                             if interface.DNSDomain:
                                 self.info.domain = _config_domain(interface.DNSDomain)


### PR DESCRIPTION
Looks like the domain is only used when resolving relative names is enabled, as a potential fallback (if present) for when no search suffixes are provided.

Fixes  #975