### PR TITLE
Change QUIC backend from 'aioquic' to 'qh3' (fork of aioquic)

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -197,7 +197,7 @@ class NoDOH(dns.exception.DNSException):
 
 
 class NoDOQ(dns.exception.DNSException):
-    """DNS over QUIC (DOQ) was requested but the aioquic module is not
+    """DNS over QUIC (DOQ) was requested but the qh3 module is not
     available."""
 
 

--- a/dns/quic/__init__.py
+++ b/dns/quic/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
 
 try:
-    import aioquic.quic.configuration  # type: ignore
+    import qh3.quic.configuration  # type: ignore
 
     import dns.asyncbackend
     from dns._asyncbackend import NullContext

--- a/dns/quic/_asyncio.py
+++ b/dns/quic/_asyncio.py
@@ -6,9 +6,9 @@ import ssl
 import struct
 import time
 
-import aioquic.quic.configuration  # type: ignore
-import aioquic.quic.connection  # type: ignore
-import aioquic.quic.events  # type: ignore
+import qh3.quic.configuration  # type: ignore
+import qh3.quic.connection  # type: ignore
+import qh3.quic.events  # type: ignore
 
 import dns.asyncbackend
 import dns.exception
@@ -139,16 +139,16 @@ class AsyncioQuicConnection(AsyncQuicConnection):
             event = self._connection.next_event()
             if event is None:
                 return
-            if isinstance(event, aioquic.quic.events.StreamDataReceived):
+            if isinstance(event, qh3.quic.events.StreamDataReceived):
                 stream = self._streams.get(event.stream_id)
                 if stream:
                     await stream._add_input(event.data, event.end_stream)
-            elif isinstance(event, aioquic.quic.events.HandshakeCompleted):
+            elif isinstance(event, qh3.quic.events.HandshakeCompleted):
                 self._handshake_complete.set()
-            elif isinstance(event, aioquic.quic.events.ConnectionTerminated):
+            elif isinstance(event, qh3.quic.events.ConnectionTerminated):
                 self._done = True
                 self._receiver_task.cancel()
-            elif isinstance(event, aioquic.quic.events.StreamReset):
+            elif isinstance(event, qh3.quic.events.StreamReset):
                 stream = self._streams.get(event.stream_id)
                 if stream:
                     await stream._add_input(b"", True)

--- a/dns/quic/_common.py
+++ b/dns/quic/_common.py
@@ -7,8 +7,8 @@ import struct
 import time
 from typing import Any, Optional
 
-import aioquic.quic.configuration  # type: ignore
-import aioquic.quic.connection  # type: ignore
+import qh3.quic.configuration  # type: ignore
+import qh3.quic.connection  # type: ignore
 
 import dns.inet
 
@@ -157,7 +157,7 @@ class BaseQuicManager:
             if isinstance(verify_mode, str):
                 verify_path = verify_mode
                 verify_mode = True
-            conf = aioquic.quic.configuration.QuicConfiguration(
+            conf = qh3.quic.configuration.QuicConfiguration(
                 alpn_protocols=["doq", "doq-i03"],
                 verify_mode=verify_mode,
                 server_name=server_name,
@@ -189,7 +189,7 @@ class BaseQuicManager:
             )
         else:
             session_ticket_handler = None
-        qconn = aioquic.quic.connection.QuicConnection(
+        qconn = qh3.quic.connection.QuicConnection(
             configuration=conf,
             session_ticket_handler=session_ticket_handler,
         )

--- a/dns/quic/_sync.py
+++ b/dns/quic/_sync.py
@@ -7,9 +7,9 @@ import struct
 import threading
 import time
 
-import aioquic.quic.configuration  # type: ignore
-import aioquic.quic.connection  # type: ignore
-import aioquic.quic.events  # type: ignore
+import qh3.quic.configuration  # type: ignore
+import qh3.quic.connection  # type: ignore
+import qh3.quic.events  # type: ignore
 
 import dns.exception
 import dns.inet
@@ -149,17 +149,17 @@ class SyncQuicConnection(BaseQuicConnection):
                 event = self._connection.next_event()
             if event is None:
                 return
-            if isinstance(event, aioquic.quic.events.StreamDataReceived):
+            if isinstance(event, qh3.quic.events.StreamDataReceived):
                 with self._lock:
                     stream = self._streams.get(event.stream_id)
                 if stream:
                     stream._add_input(event.data, event.end_stream)
-            elif isinstance(event, aioquic.quic.events.HandshakeCompleted):
+            elif isinstance(event, qh3.quic.events.HandshakeCompleted):
                 self._handshake_complete.set()
-            elif isinstance(event, aioquic.quic.events.ConnectionTerminated):
+            elif isinstance(event, qh3.quic.events.ConnectionTerminated):
                 with self._lock:
                     self._done = True
-            elif isinstance(event, aioquic.quic.events.StreamReset):
+            elif isinstance(event, qh3.quic.events.StreamReset):
                 with self._lock:
                     stream = self._streams.get(event.stream_id)
                 if stream:

--- a/dns/quic/_trio.py
+++ b/dns/quic/_trio.py
@@ -5,9 +5,9 @@ import ssl
 import struct
 import time
 
-import aioquic.quic.configuration  # type: ignore
-import aioquic.quic.connection  # type: ignore
-import aioquic.quic.events  # type: ignore
+import qh3.quic.configuration  # type: ignore
+import qh3.quic.connection  # type: ignore
+import qh3.quic.events  # type: ignore
 import trio
 
 import dns.exception
@@ -121,16 +121,16 @@ class TrioQuicConnection(AsyncQuicConnection):
             event = self._connection.next_event()
             if event is None:
                 return
-            if isinstance(event, aioquic.quic.events.StreamDataReceived):
+            if isinstance(event, qh3.quic.events.StreamDataReceived):
                 stream = self._streams.get(event.stream_id)
                 if stream:
                     await stream._add_input(event.data, event.end_stream)
-            elif isinstance(event, aioquic.quic.events.HandshakeCompleted):
+            elif isinstance(event, qh3.quic.events.HandshakeCompleted):
                 self._handshake_complete.set()
-            elif isinstance(event, aioquic.quic.events.ConnectionTerminated):
+            elif isinstance(event, qh3.quic.events.ConnectionTerminated):
                 self._done = True
                 self._socket.close()
-            elif isinstance(event, aioquic.quic.events.StreamReset):
+            elif isinstance(event, qh3.quic.events.StreamReset):
                 stream = self._streams.get(event.stream_id)
                 if stream:
                     await stream._add_input(b"", True)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -52,4 +52,4 @@ able to do low-level DNSSEC signature generation and validation.
 
 If ``idna`` is installed, then IDNA 2008 will be available.
 
-If ``aioquic`` is installed, the DNS-over-QUIC will be available.
+If ``qh3`` is installed, the DNS-over-QUIC will be available.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -93,7 +93,7 @@ What's New in dnspython
   in zonefiles are processed.
 
 * A preliminary implementation of DNS-over-QUIC has been added, and will be
-  available if the aioquic library is present.  See ``dns.query.quic()``,
+  available if the qh3 library is present.  See ``dns.query.quic()``,
   ``dns.asyncquery.quic()``, and examples/doq.py for more info.  This API
   is subject to change in future releases.  For asynchronous I/O, both
   asyncio and Trio are supported, but Curio is not.

--- a/examples/doq.py
+++ b/examples/doq.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     have_trio = False
 
-# This demo assumes you have the aioquic example doq_server.py running on localhost
+# This demo assumes you have the qh3 example doq_server.py running on localhost
 # on port 4784 on localhost.
 peer_address = "127.0.0.1"
 peer_port = 4784

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ idna = {version=">=2.1,<4.0", optional=true}
 cryptography = {version=">=2.6", optional=true}
 trio = {version=">=0.14,<0.23", optional=true}
 wmi = {version="^1.5.1", optional=true}
-aioquic = {version=">=0.9.20", optional=true}
+qh3 = {version=">=0.13.0", optional=true}
 
 [tool.poetry.dev-dependencies]
 pytest = ">=5.4.1,<8"
@@ -66,7 +66,7 @@ idna = ['idna']
 dnssec = ['cryptography']
 trio = ['trio']
 wmi = ['wmi']
-doq = ['aioquic']
+doq = ['qh3']
 
 [build-system]
 requires = ["poetry-core"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ IDNA = idna>=2.1
 DNSSEC = cryptography>=2.6
 trio = trio>=0.14.0
 wmi = wmi>=1.5.1
-DOQ = aioquic>=0.9.20
+DOQ = qh3>=0.13.0
 
 [options.package_data]
 dns = py.typed

--- a/tests/nanoquic.py
+++ b/tests/nanoquic.py
@@ -6,10 +6,10 @@ try:
     import struct
     import threading
 
-    import aioquic.asyncio
-    import aioquic.asyncio.server
-    import aioquic.quic.configuration
-    import aioquic.quic.events
+    import qh3.asyncio
+    import qh3.asyncio.server
+    import qh3.quic.configuration
+    import qh3.quic.events
 
     import dns.asyncquery
     import dns.message
@@ -39,10 +39,10 @@ try:
         def qtype(self):
             return self.question.rdtype
 
-    class NanoQuic(aioquic.asyncio.QuicConnectionProtocol):
+    class NanoQuic(qh3.asyncio.QuicConnectionProtocol):
         def quic_event_received(self, event):
             # This is a bit hackish and not fully general, but this is a test server!
-            if isinstance(event, aioquic.quic.events.StreamDataReceived):
+            if isinstance(event, qh3.quic.events.StreamDataReceived):
                 data = bytes(event.data)
                 (wire_len,) = struct.unpack("!H", data[:2])
                 wire = self.handle_wire(data[2 : 2 + wire_len])
@@ -107,14 +107,14 @@ try:
 
         async def arun(self):
             reader, _ = await asyncio.open_connection(sock=self.right)
-            conf = aioquic.quic.configuration.QuicConfiguration(
+            conf = qh3.quic.configuration.QuicConfiguration(
                 alpn_protocols=["doq"],
                 is_client=False,
             )
             conf.load_cert_chain(here("tls/public.crt"), here("tls/private.pem"))
             loop = asyncio.get_event_loop()
             (self.transport, self.protocol) = await loop.create_datagram_endpoint(
-                lambda: aioquic.asyncio.server.QuicServer(
+                lambda: qh3.asyncio.server.QuicServer(
                     configuration=conf, create_protocol=NanoQuic
                 ),
                 local_addr=(self.address, 0),

--- a/tests/test_doq.py
+++ b/tests/test_doq.py
@@ -1,6 +1,6 @@
 # Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
 
-import asyncio
+import qh3
 import sys
 
 import pytest
@@ -34,7 +34,7 @@ if len(addresses) == 0:
     _nanoquic_available = False
 
 
-@pytest.mark.skipif(not _nanoquic_available, reason="requires aioquic")
+@pytest.mark.skipif(not _nanoquic_available, reason="requires qh3")
 def test_basic_sync():
     q = dns.message.make_query("www.example.", "A")
     for address in addresses:
@@ -49,7 +49,7 @@ async def amain(address, port):
     assert r.rcode() == dns.rcode.REFUSED
 
 
-@pytest.mark.skipif(not _nanoquic_available, reason="requires aioquic")
+@pytest.mark.skipif(not _nanoquic_available, reason="requires qh3")
 def test_basic_asyncio():
     dns.asyncbackend.set_default_backend("asyncio")
     for address in addresses:
@@ -60,7 +60,7 @@ def test_basic_asyncio():
 try:
     import trio
 
-    @pytest.mark.skipif(not _nanoquic_available, reason="requires aioquic")
+    @pytest.mark.skipif(not _nanoquic_available, reason="requires qh3")
     def test_basic_trio():
         dns.asyncbackend.set_default_backend("trio")
         for address in addresses:


### PR DESCRIPTION
The `aioquic` repository is almost unmaintained. The last push is 4 months old, while there are 20 PRs waiting for approval. Its fork `qh3` might be a suitable replacement. It is actively maintained and fixes several deficiencies of the `aioquic` library already.
Please consider choosing `qh3` as a backend for QUIC.