### PR TITLE
Add prepend_length to Message.to_wire().

### DIFF
--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -292,14 +292,12 @@ async def send_tcp(
     """
 
     if isinstance(what, dns.message.Message):
-        wire = what.to_wire()
+        tcpmsg = what.to_wire(prepend_length=True)
     else:
-        wire = what
-    l = len(wire)
-    # copying the wire into tcpmsg is inefficient, but lets us
-    # avoid writev() or doing a short write that would get pushed
-    # onto the net
-    tcpmsg = struct.pack("!H", l) + wire
+        # copying the wire into tcpmsg is inefficient, but lets us
+        # avoid writev() or doing a short write that would get pushed
+        # onto the net
+        tcpmsg = len(what).to_bytes(2, 'big') + what
     sent_time = time.time()
     await sock.sendall(tcpmsg, _timeout(expiration, sent_time))
     return (len(tcpmsg), sent_time)

--- a/dns/query.py
+++ b/dns/query.py
@@ -864,14 +864,12 @@ def send_tcp(
     """
 
     if isinstance(what, dns.message.Message):
-        wire = what.to_wire()
+        tcpmsg = what.to_wire(prepend_length=True)
     else:
-        wire = what
-    l = len(wire)
-    # copying the wire into tcpmsg is inefficient, but lets us
-    # avoid writev() or doing a short write that would get pushed
-    # onto the net
-    tcpmsg = struct.pack("!H", l) + wire
+        # copying the wire into tcpmsg is inefficient, but lets us
+        # avoid writev() or doing a short write that would get pushed
+        # onto the net
+        tcpmsg = len(what).to_bytes(2, 'big') + what
     sent_time = time.time()
     _net_write(sock, tcpmsg, expiration)
     return (len(tcpmsg), sent_time)


### PR DESCRIPTION
If a caller passes prepend_length=True, the wire format will include the 2 byte encoded message length before the message itself.  This is useful for callers planning to send the message over TCP, DoT, and DoQ.