### PR TITLE
Canonicalize IPv6 address text form in rdata.

### DIFF
--- a/dns/inet.py
+++ b/dns/inet.py
@@ -178,3 +178,20 @@ def any_for_af(af):
     elif af == socket.AF_INET6:
         return "::"
     raise NotImplementedError(f"unknown address family {af}")
+
+
+def canonicalize(text: str) -> str:
+    """Verify that *address* is a valid text form IPv4 or IPv6 address and return its
+    canonical text form.  IPv6 addresses with scopes are rejected.
+
+    *text*, a ``str``, the address in textual form.
+
+    Raises ``ValueError`` if the text is not valid.
+    """
+    try:
+        return dns.ipv6.canonicalize(text)
+    except Exception:
+        try:
+            return dns.ipv4.canonicalize(text)
+        except Exception:
+            raise ValueError

--- a/dns/ipv4.py
+++ b/dns/ipv4.py
@@ -62,3 +62,16 @@ def inet_aton(text: Union[str, bytes]) -> bytes:
         return struct.pack("BBBB", *b)
     except Exception:
         raise dns.exception.SyntaxError
+
+
+def canonicalize(text: Union[str, bytes]) -> str:
+    """Verify that *address* is a valid text form IPv4 address and return its
+    canonical text form.
+
+    *text*, a ``str`` or ``bytes``, the IPv4 address in textual form.
+
+    Raises ``dns.exception.SyntaxError`` if the text is not valid.
+    """
+    # Note that inet_aton() only accepts canonial form, but we still run through
+    # inet_ntoa() to ensure the output is a str.
+    return dns.ipv4.inet_ntoa(dns.ipv4.inet_aton(text))

--- a/dns/ipv6.py
+++ b/dns/ipv6.py
@@ -104,7 +104,7 @@ _colon_colon_end = re.compile(rb".*::$")
 def inet_aton(text: Union[str, bytes], ignore_scope: bool = False) -> bytes:
     """Convert an IPv6 address in text form to binary form.
 
-    *text*, a ``str``, the IPv6 address in textual form.
+    *text*, a ``str`` or ``bytes``, the IPv6 address in textual form.
 
     *ignore_scope*, a ``bool``.  If ``True``, a scope will be ignored.
     If ``False``, the default, it is an error for a scope to be present.
@@ -206,3 +206,14 @@ def is_mapped(address: bytes) -> bool:
     """
 
     return address.startswith(_mapped_prefix)
+
+
+def canonicalize(text: Union[str, bytes]) -> str:
+    """Verify that *address* is a valid text form IPv6 address and return its
+    canonical text form.  Addresses with scopes are rejected.
+
+    *text*, a ``str`` or ``bytes``, the IPv6 address in textual form.
+
+    Raises ``dns.exception.SyntaxError`` if the text is not valid.
+    """
+    return dns.ipv6.inet_ntoa(dns.ipv6.inet_aton(text))

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -547,9 +547,7 @@ class Rdata:
     @classmethod
     def _as_ipv4_address(cls, value):
         if isinstance(value, str):
-            # call to check validity
-            dns.ipv4.inet_aton(value)
-            return value
+            return dns.ipv4.canonicalize(value)
         elif isinstance(value, bytes):
             return dns.ipv4.inet_ntoa(value)
         else:
@@ -558,9 +556,7 @@ class Rdata:
     @classmethod
     def _as_ipv6_address(cls, value):
         if isinstance(value, str):
-            # call to check validity
-            dns.ipv6.inet_aton(value)
-            return value
+            return dns.ipv6.canonicalize(value)
         elif isinstance(value, bytes):
             return dns.ipv6.inet_ntoa(value)
         else:

--- a/tests/example1.good
+++ b/tests/example1.good
@@ -18,7 +18,7 @@ amtrelay03 3600 IN AMTRELAY 10 0 1 203.0.113.15
 amtrelay04 3600 IN AMTRELAY 10 0 2 2001:db8::15
 amtrelay05 3600 IN AMTRELAY 128 1 3 amtrelays.example.com.
 apl01 3600 IN APL 1:192.168.32.0/21 !1:192.168.38.0/28
-apl02 3600 IN APL 1:224.0.0.0/4 2:FF00:0:0:0:0:0:0:0/8
+apl02 3600 IN APL 1:224.0.0.0/4 2:ff00::/8
 avc01 3600 IN AVC "app-name:WOLFGANG|app-class:OAM|business=yes"
 b 300 IN CNAME foo.net.
 c 300 IN A 73.80.65.49

--- a/tests/example2.good
+++ b/tests/example2.good
@@ -18,7 +18,7 @@ amtrelay03.example. 3600 IN AMTRELAY 10 0 1 203.0.113.15
 amtrelay04.example. 3600 IN AMTRELAY 10 0 2 2001:db8::15
 amtrelay05.example. 3600 IN AMTRELAY 128 1 3 amtrelays.example.com.
 apl01.example. 3600 IN APL 1:192.168.32.0/21 !1:192.168.38.0/28
-apl02.example. 3600 IN APL 1:224.0.0.0/4 2:FF00:0:0:0:0:0:0:0/8
+apl02.example. 3600 IN APL 1:224.0.0.0/4 2:ff00::/8
 avc01.example. 3600 IN AVC "app-name:WOLFGANG|app-class:OAM|business=yes"
 b.example. 300 IN CNAME foo.net.
 c.example. 300 IN A 73.80.65.49

--- a/tests/example3.good
+++ b/tests/example3.good
@@ -18,7 +18,7 @@ amtrelay03 3600 IN AMTRELAY 10 0 1 203.0.113.15
 amtrelay04 3600 IN AMTRELAY 10 0 2 2001:db8::15
 amtrelay05 3600 IN AMTRELAY 128 1 3 amtrelays.example.com.
 apl01 3600 IN APL 1:192.168.32.0/21 !1:192.168.38.0/28
-apl02 3600 IN APL 1:224.0.0.0/4 2:FF00:0:0:0:0:0:0:0/8
+apl02 3600 IN APL 1:224.0.0.0/4 2:ff00::/8
 avc01 3600 IN AVC "app-name:WOLFGANG|app-class:OAM|business=yes"
 b 300 IN CNAME foo.net.
 c 300 IN A 73.80.65.49

--- a/tests/example4.good
+++ b/tests/example4.good
@@ -19,7 +19,7 @@ amtrelay03 3600 IN AMTRELAY 10 0 1 203.0.113.15
 amtrelay04 3600 IN AMTRELAY 10 0 2 2001:db8::15
 amtrelay05 3600 IN AMTRELAY 128 1 3 amtrelays.example.com.
 apl01 3600 IN APL 1:192.168.32.0/21 !1:192.168.38.0/28
-apl02 3600 IN APL 1:224.0.0.0/4 2:FF00:0:0:0:0:0:0:0/8
+apl02 3600 IN APL 1:224.0.0.0/4 2:ff00::/8
 avc01 3600 IN AVC "app-name:WOLFGANG|app-class:OAM|business=yes"
 b 300 IN CNAME foo.net.
 c 300 IN A 73.80.65.49


### PR DESCRIPTION
Dnspython did not canonicalize the textual form of IPv6 address in rdata read from text format, which could possibly cause problems in application software if the address was used as a key.
