### PR TITLE
Allow Zones with different map types.

### DIFF
--- a/dns/immutable.py
+++ b/dns/immutable.py
@@ -1,24 +1,30 @@
 # Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
 
 import collections.abc
-from typing import Any
+from typing import Any, Callable
 
 from dns._immutable_ctx import immutable
 
 
 @immutable
 class Dict(collections.abc.Mapping):  # lgtm[py/missing-equals]
-    def __init__(self, dictionary: Any, no_copy: bool = False):
+    def __init__(
+        self,
+        dictionary: Any,
+        no_copy: bool = False,
+        map_factory: Callable[[], collections.abc.MutableMapping] = dict,
+    ):
         """Make an immutable dictionary from the specified dictionary.
 
         If *no_copy* is `True`, then *dictionary* will be wrapped instead
         of copied.  Only set this if you are sure there will be no external
         references to the dictionary.
         """
-        if no_copy and isinstance(dictionary, dict):
+        if no_copy and isinstance(dictionary, collections.abc.MutableMapping):
             self._odict = dictionary
         else:
-            self._odict = dict(dictionary)
+            self._odict = map_factory()
+            self._odict.update(dictionary)
         self._hash = None
 
     def __getitem__(self, key):

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -21,7 +21,6 @@ import contextlib
 import io
 import os
 import struct
-from collections.abc import MutableMapping
 from typing import (
     Any,
     Callable,
@@ -29,6 +28,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    MutableMapping,
     Optional,
     Set,
     Tuple,

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -477,11 +477,10 @@ class ZoneTestCase(unittest.TestCase):
     def testGenerate(self):
         z = dns.zone.from_text(example_generate, "example.", relativize=True)
         f = StringIO()
-        names = list(z.nodes.keys())
-        for n in names:
-            f.write(z[n].to_text(n))
-            f.write("\n")
-        self.assertEqual(f.getvalue(), example_generate_output)
+        expected = dns.zone.from_text(
+            example_generate_output, "example.", relativize=True
+        )
+        self.assertEqual(z, expected)
 
     def testTorture1(self):
         #


### PR DESCRIPTION
Zones currently insist on using a `dict`, and also the classes WritableVersion and ImmutableVersion.  This fix explores allowing any object implementing `collections.abc.MutableMapping` to be used as the dictionary, and allows the version types to have factories too.  Different storage schemes are created by subclassing Zone and changing the factories in the subclass.

I had to change one test that unwisely relied on the order of keys when iterating.

With these changes, I tried two different alternate storage mechanisms and all the tests still pass.