### PR TITLE
Replace asserts with conditions

### DIFF
--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -76,7 +76,8 @@ class DatagramSocket(dns._asyncbackend.DatagramSocket):
         # ignore size as there's no way I know to tell protocol about it
         done = _get_running_loop().create_future()
         try:
-            assert self.protocol.recvfrom is None
+            if self.protocol.recvfrom is not None:
+                raise AssertionError("recvfrom should be empty at this stage")
             self.protocol.recvfrom = done
             await _maybe_wait_for(done, timeout)
             return done.result()

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -682,7 +682,8 @@ async def inbound_xfr(
                     try:
                         done = inbound.process_message(r)
                     except dns.xfr.UseTCP:
-                        assert is_udp  # should not happen if we used TCP!
+                        if not is_udp:  # should not happen if we used TCP!
+                            raise AssertionError("at this stage udp can't be null")
                         if udp_mode == UDPMode.ONLY:
                             raise
                         done = True

--- a/dns/asyncresolver.py
+++ b/dns/asyncresolver.py
@@ -80,7 +80,8 @@ class Resolver(dns.resolver.BaseResolver):
             if answer is not None:
                 # cache hit!
                 return answer
-            assert request is not None  # needed for type checking
+            if request is None:  # needed for type checking
+                raise AssertionError("request can't be empty")
             done = False
             while not done:
                 (nameserver, tcp, backoff) = resolution.next_nameserver()
@@ -264,7 +265,8 @@ def get_default_resolver() -> Resolver:
     """Get the default asynchronous resolver, initializing it if necessary."""
     if default_resolver is None:
         reset_default_resolver()
-    assert default_resolver is not None
+    if default_resolver is None:
+        raise AssertionError("default resolver can't be empty")
     return default_resolver
 
 
@@ -382,7 +384,8 @@ async def zone_for_name(
             answer = await resolver.resolve(
                 name, dns.rdatatype.SOA, rdclass, tcp, backend=backend
             )
-            assert answer.rrset is not None
+            if answer.rrset is None:
+                raise AssertionError("answer rrset can't be empty")
             if answer.rrset.name == name:
                 return name
             # otherwise we were CNAMEd or DNAMEd and need to look higher

--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -244,7 +244,8 @@ def make_ds(
     if isinstance(name, str):
         name = dns.name.from_text(name, origin)
     wire = name.canonicalize().to_wire()
-    assert wire is not None
+    if wire is None:
+        raise AssertionError("wire can't be empty")
     dshash.update(wire)
     dshash.update(key.to_wire(origin=origin))
     digest = dshash.digest()
@@ -779,7 +780,8 @@ def nsec3_hash(
     if not isinstance(domain, dns.name.Name):
         domain = dns.name.from_text(domain)
     domain_encoded = domain.canonicalize().to_wire()
-    assert domain_encoded is not None
+    if domain_encoded is None:
+        raise AssertionError("encoded domain can't be empty")
 
     digest = hashlib.sha1(domain_encoded + salt_encoded).digest()
     for _ in range(iterations):

--- a/dns/edns.py
+++ b/dns/edns.py
@@ -203,7 +203,8 @@ class ECSOption(Option):  # lgtm[py/missing-equals]
         else:  # pragma: no cover   (this will never happen)
             raise ValueError("Bad address family")
 
-        assert srclen is not None
+        if srclen is None:
+            raise AssertionError("source length can't be empty")
         self.address = address
         self.srclen = srclen
         self.scopelen = scopelen

--- a/dns/exception.py
+++ b/dns/exception.py
@@ -73,15 +73,13 @@ class DNSException(Exception):
 
         For sanity we do not allow to mix old and new behavior."""
         if args or kwargs:
-            assert bool(args) != bool(
-                kwargs
-            ), "keyword arguments are mutually exclusive with positional args"
+            if bool(args) == bool(kwargs):
+                raise AssertionError("keyword arguments are mutually exclusive with positional args")
 
     def _check_kwargs(self, **kwargs):
         if kwargs:
-            assert (
-                set(kwargs.keys()) == self.supp_kwargs
-            ), "following set of keyword args is required: %s" % (self.supp_kwargs)
+            if set(kwargs.keys()) != self.supp_kwargs:
+                raise AssertionError("following set of keyword args is required: %s" % (self.supp_kwargs))
         return kwargs
 
     def _fmt_kwargs(self, **kwargs):

--- a/dns/grange.py
+++ b/dns/grange.py
@@ -61,11 +61,14 @@ def from_text(text: str) -> Tuple[int, int, int]:
     elif state == 1:
         stop = int(cur)
     else:
-        assert state == 2
+        if state != 2:
+            raise AssertionError("state is not equal to 2")
         step = int(cur)
 
-    assert step >= 1
-    assert start >= 0
+    if step < 1:
+        raise AssertionError("step is lower than 1")
+    if start < 0:
+        raise AssertionError("start is lower than 0")
     if start > stop:
         raise dns.exception.SyntaxError("start must be <= stop")
 

--- a/dns/message.py
+++ b/dns/message.py
@@ -1086,7 +1086,8 @@ class _WireReader:
         """Read the next *qcount* records from the wire data and add them to
         the question section.
         """
-        assert self.message is not None
+        if self.message is None:
+            raise AssertionError("message can't be empty")
         section = self.message.sections[section_number]
         for _ in range(qcount):
             qname = self.parser.get_name(self.message.origin)
@@ -1108,7 +1109,8 @@ class _WireReader:
         section_number: the section of the message to which to add records
         count: the number of records to read
         """
-        assert self.message is not None
+        if self.message is None:
+            raise AssertionError("message can't be empty")
         section = self.message.sections[section_number]
         force_unique = self.one_rr_per_rrset
         for i in range(count):
@@ -1669,7 +1671,7 @@ def from_file(
         cm = contextlib.nullcontext(f)
     with cm as f:
         return from_text(f, idna_codec, one_rr_per_rrset)
-    assert False  # for mypy  lgtm[py/unreachable-statement]
+    raise AssertionError("")  # for mypy  lgtm[py/unreachable-statement]
 
 
 def make_query(

--- a/dns/name.py
+++ b/dns/name.py
@@ -638,7 +638,8 @@ class Name:
         """
 
         digest = self.to_wire(origin=origin, canonicalize=True)
-        assert digest is not None
+        if digest is None:
+            raise AssertionError("digest can't be None")
         return digest
 
     def to_wire(

--- a/dns/query.py
+++ b/dns/query.py
@@ -718,9 +718,7 @@ def udp(
         if not q.is_response(r):
             raise BadResponse
         return r
-    assert (
-        False  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
-    )
+    raise AssertionError("")  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
 
 
 def udp_with_fallback(
@@ -996,9 +994,7 @@ def tcp(
         if not q.is_response(r):
             raise BadResponse
         return r
-    assert (
-        False  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
-    )
+    raise AssertionError("")  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
 
 
 def _tls_handshake(s, expiration):
@@ -1112,9 +1108,7 @@ def tls(
         if not q.is_response(r):
             raise BadResponse
         return r
-    assert (
-        False  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
-    )
+    raise AssertionError("")  # help mypy figure out we can't get here  lgtm[py/unreachable-statement]
 
 
 def quic(
@@ -1506,7 +1500,8 @@ def inbound_xfr(
                     try:
                         done = inbound.process_message(r)
                     except dns.xfr.UseTCP:
-                        assert is_udp  # should not happen if we used TCP!
+                        if not is_udp:  # should not happen if we used TCP!
+                            raise AssertionError("udp is turned to false")
                         if udp_mode == UDPMode.ONLY:
                             raise
                         done = True

--- a/dns/quic/_asyncio.py
+++ b/dns/quic/_asyncio.py
@@ -123,7 +123,8 @@ class AsyncioQuicConnection(AsyncQuicConnection):
         while not self._done:
             datagrams = self._connection.datagrams_to_send(time.time())
             for datagram, address in datagrams:
-                assert address == self._peer
+                if address != self._peer:
+                    raise AssertionError("datagram address is different from peer")
                 await self._socket.sendto(datagram, self._peer, None)
             (expiration, interval) = self._get_timer_values()
             try:

--- a/dns/quic/_common.py
+++ b/dns/quic/_common.py
@@ -46,7 +46,8 @@ class Buffer:
         return self._seen_end
 
     def get(self, amount):
-        assert self.have(amount)
+        if not self.have(amount):
+            raise AssertionError("Buffer have no amount")
         data = self._buffer[:amount]
         self._buffer = self._buffer[amount:]
         return data

--- a/dns/rdataset.py
+++ b/dns/rdataset.py
@@ -504,7 +504,8 @@ def from_rdata_list(ttl: int, rdatas: Collection[dns.rdata.Rdata]) -> Rdataset:
             r = Rdataset(rd.rdclass, rd.rdtype)
             r.update_ttl(ttl)
         r.add(rd)
-    assert r is not None
+    if r is None:
+        raise AssertionError("Rdataset can't be empty")
     return r
 
 

--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -59,7 +59,8 @@ class CAA(dns.rdata.Rdata):
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         file.write(struct.pack("!B", self.flags))
         l = len(self.tag)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("tag length can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.tag)
         file.write(self.value)

--- a/dns/rdtypes/ANY/GPOS.py
+++ b/dns/rdtypes/ANY/GPOS.py
@@ -91,15 +91,18 @@ class GPOS(dns.rdata.Rdata):
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         l = len(self.latitude)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("latitude can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.latitude)
         l = len(self.longitude)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("longitude can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.longitude)
         l = len(self.altitude)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("altitude can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.altitude)
 

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -52,11 +52,13 @@ class HINFO(dns.rdata.Rdata):
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         l = len(self.cpu)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("cpu length can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.cpu)
         l = len(self.os)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("os length can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.os)
 

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -59,12 +59,14 @@ class ISDN(dns.rdata.Rdata):
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         l = len(self.address)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("address length can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.address)
         l = len(self.subaddress)
         if l > 0:
-            assert l < 256
+            if l >= 256:
+                raise AssertionError("subaddress length can't be higher than 255")
             file.write(struct.pack("!B", l))
             file.write(self.subaddress)
 

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -48,7 +48,8 @@ class X25(dns.rdata.Rdata):
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         l = len(self.address)
-        assert l < 256
+        if l >= 256:
+            raise AssertionError("address length can't be higher than 255")
         file.write(struct.pack("!B", l))
         file.write(self.address)
 

--- a/dns/rdtypes/IN/APL.py
+++ b/dns/rdtypes/IN/APL.py
@@ -70,7 +70,8 @@ class APLItem:
                 break
         address = address[0:last]
         l = len(address)
-        assert l < 128
+        if l >= 128:
+            raise AssertionError("address length can't be higher than 127")
         if self.negation:
             l |= 0x80
         header = struct.pack("!HBB", self.family, self.prefix, l)

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -26,7 +26,8 @@ import dns.rdtypes.util
 
 def _write_string(file, s):
     l = len(s)
-    assert l < 256
+    if l >= 256:
+        raise AssertionError("length s can't be higher than 255")
     file.write(struct.pack("!B", l))
     file.write(s)
 

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -204,7 +204,8 @@ class Renderer:
         might be, so we we might not get an even multiple of the pad in that case."""
         if pad:
             ttl = opt.ttl
-            assert opt_size >= 11
+            if opt_size < 11:
+                raise AssertionError("opt_size can't be lower than 11")
             opt_rdata = opt[0]
             size_without_padding = self.output.tell() + opt_size + tsig_size
             remainder = size_without_padding % pad

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -272,7 +272,8 @@ def from_rdata_list(
             r = RRset(name, rd.rdclass, rd.rdtype)
             r.update_ttl(ttl)
         r.add(rd)
-    assert r is not None
+    if r is None:
+        raise AssertionError("r can't be None")
     return r
 
 

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -270,7 +270,8 @@ class Tokenizer:
         self.eof = False
         self.delimiters = _DELIMITERS
         self.line_number = 1
-        assert filename is not None
+        if filename is None:
+            raise AssertionError("Filename can't be null")
         self.filename = filename
         if idna_codec is None:
             self.idna_codec: dns.name.IDNACodec = dns.name.IDNA_2003

--- a/dns/versioned.py
+++ b/dns/versioned.py
@@ -98,7 +98,8 @@ class Zone(dns.zone.Zone):  # lgtm[py/missing-equals]
                 if self.relativize:
                     oname = dns.name.empty
                 else:
-                    assert self.origin is not None
+                    if self.origin is None:
+                        raise AssertionError("Origin can't be None")
                     oname = self.origin
                 version = None
                 for v in reversed(self._versions):
@@ -177,7 +178,8 @@ class Zone(dns.zone.Zone):  # lgtm[py/missing-equals]
     # pylint: enable=unused-argument
 
     def _prune_versions_unlocked(self):
-        assert len(self._versions) > 0
+        if len(self._versions) <= 0:
+            raise AssertionError("Versions can't lower than 1")
         # Don't ever prune a version greater than or equal to one that
         # a reader has open.  This pins versions in memory while the
         # reader is open, and importantly lets the reader open a txn on
@@ -238,7 +240,8 @@ class Zone(dns.zone.Zone):  # lgtm[py/missing-equals]
             self._prune_versions_unlocked()
 
     def _end_write_unlocked(self, txn):
-        assert self._write_txn == txn
+        if self._write_txn != txn:
+            raise AssertionError("Writing error with transaction")
         self._write_txn = None
         self._maybe_wakeup_one_waiter_unlocked()
 

--- a/dns/wire.py
+++ b/dns/wire.py
@@ -21,7 +21,8 @@ class Parser:
         return self.end - self.current
 
     def get_bytes(self, size: int) -> bytes:
-        assert size >= 0
+        if size < 0:
+            raise AssertionError("Size can't be lower than 1")
         if size > self.remaining():
             raise dns.exception.FormError
         output = self.wire[self.current : self.current + size]
@@ -66,7 +67,8 @@ class Parser:
 
     @contextlib.contextmanager
     def restrict_to(self, size: int) -> Iterator:
-        assert size >= 0
+        if size < 0:
+            raise AssertionError("Size can't be lower than 1")
         if size > self.remaining():
             raise dns.exception.FormError
         saved_end = self.end

--- a/dns/xfr.py
+++ b/dns/xfr.py
@@ -154,7 +154,8 @@ class Inbound:
             rdataset = rrset
             if self.done:
                 raise dns.exception.FormError("answers after final SOA")
-            assert self.txn is not None  # for mypy
+            if self.txn is None:
+                raise AssertionError("Transaction can't be None")
             if rdataset.rdtype == dns.rdatatype.SOA and name == self.origin:
                 #
                 # Every time we see an origin SOA delete_mode inverts

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -690,7 +690,8 @@ class Zone(dns.transaction.TransactionManager):
                 nl = nl.decode()
 
             if want_origin:
-                assert self.origin is not None
+                if self.origin is None:
+                    raise AssertionError("Origjn can't be None")
                 l = "$ORIGIN " + self.origin.to_text()
                 l_b = l.encode(file_enc)
                 try:
@@ -772,7 +773,8 @@ class Zone(dns.transaction.TransactionManager):
         if self.relativize:
             name = dns.name.empty
         else:
-            assert self.origin is not None
+            if self.origin is None:
+                raise AssertionError("Origjn can't be None")
             name = self.origin
         if self.get_rdataset(name, dns.rdatatype.SOA) is None:
             raise NoSOA
@@ -819,7 +821,8 @@ class Zone(dns.transaction.TransactionManager):
         if self.relativize:
             origin_name = dns.name.empty
         else:
-            assert self.origin is not None
+            if self.origin is None:
+                raise AssertionError("Origjn can't be None")
             origin_name = self.origin
         hasher = hashinfo()
         for name, node in sorted(self.items()):
@@ -857,7 +860,8 @@ class Zone(dns.transaction.TransactionManager):
         if zonemd:
             digests = [zonemd]
         else:
-            assert self.origin is not None
+            if self.origin is None:
+                raise AssertionError("Origjn can't be None")
             rds = self.get_rdataset(self.origin, dns.rdatatype.ZONEMD)
             if rds is None:
                 raise NoDigest
@@ -1113,7 +1117,8 @@ class Transaction(dns.transaction.Transaction):
         return self.manager
 
     def _setup_version(self):
-        assert self.version is None
+        if self.version is not None:
+            raise AssertionError("Version should be None")
         factory = self.manager.writable_version_factory
         if factory is None:
             factory = WritableVersion
@@ -1123,15 +1128,18 @@ class Transaction(dns.transaction.Transaction):
         return self.version.get_rdataset(name, rdtype, covers)
 
     def _put_rdataset(self, name, rdataset):
-        assert not self.read_only
+        if self.read_only:
+            raise AssertionError("Read only is not allowed")
         self.version.put_rdataset(name, rdataset)
 
     def _delete_name(self, name):
-        assert not self.read_only
+        if self.read_only:
+            raise AssertionError("Read only is not allowed")
         self.version.delete_node(name)
 
     def _delete_rdataset(self, name, rdtype, covers):
-        assert not self.read_only
+        if self.read_only:
+            raise AssertionError("Read only is not allowed")
         self.version.delete_rdataset(name, rdtype, covers)
 
     def _name_exists(self, name):
@@ -1383,7 +1391,8 @@ def from_file(
             idna_codec,
             allow_directives,
         )
-    assert False  # make mypy happy  lgtm[py/unreachable-statement]
+    if not False:  # make mypy happy  lgtm[py/unreachable-statement]
+        raise AssertionError("")
 
 
 def from_xfr(

--- a/dns/zonefile.py
+++ b/dns/zonefile.py
@@ -554,7 +554,8 @@ class Reader:
 
 class RRsetsReaderTransaction(dns.transaction.Transaction):
     def __init__(self, manager, replacement, read_only):
-        assert not read_only
+        if read_only:
+            raise AssertionError("Read only is not allowed")
         super().__init__(manager, replacement, read_only)
         self.rdatasets = {}
 
@@ -634,7 +635,8 @@ class RRSetsReaderManager(dns.transaction.TransactionManager):
         raise NotImplementedError
 
     def writer(self, replacement=False):
-        assert replacement is True
+        if replacement is not True:
+            raise AssertionError("replacement is set to False")
         return RRsetsReaderTransaction(self, True, False)
 
     def get_class(self):


### PR DESCRIPTION
Running the python interpreter with the optimization mode turned on (`python -O`, `python -OO`, `set PYTHONOPTIMIZE=1`), will remove all the assert statements from running code [1][2][3].

Dnspython heavily rely on `assert` to check things at runtime. That could be an issue, if the flag is enabled. All the dnspython check would be removed, leading to possible bugs.

This patch propose to replace `assert` statements with condition and by raising an `AssertionError` if the condition is met.

This patch won't change the logic and the behaviour of the checks previously made by using `assert`, however, these changes will remain actives at runtime, even if python optimization is enabled.

This patch do not replace `assert` in unit tests because they are not an issue.

[1] https://docs.python.org/3/using/cmdline.html?highlight=pythonoptimize#cmdoption-O
[2] https://docs.python.org/3/using/cmdline.html?highlight=pythonoptimize#cmdoption-OO
[3] https://docs.python.org/3/using/cmdline.html?highlight=pythonoptimize#envvar-PYTHONOPTIMIZE