### PR TITLE
Uniform TLS verify argument support.

### DIFF
--- a/dns/nameserver.py
+++ b/dns/nameserver.py
@@ -284,6 +284,7 @@ class DoTNameserver(AddressAndPortNameserver):
             one_rr_per_rrset=one_rr_per_rrset,
             ignore_trailing=ignore_trailing,
             server_hostname=self.hostname,
+            verify=self.verify,
         )
 
 

--- a/dns/nameserver.py
+++ b/dns/nameserver.py
@@ -158,10 +158,16 @@ class Do53Nameserver(AddressAndPortNameserver):
 
 
 class DoHNameserver(Nameserver):
-    def __init__(self, url: str, bootstrap_address: Optional[str] = None):
+    def __init__(
+        self,
+        url: str,
+        bootstrap_address: Optional[str] = None,
+        verify: Union[bool, str] = True,
+    ):
         super().__init__()
         self.url = url
         self.bootstrap_address = bootstrap_address
+        self.verify = verify
 
     def kind(self):
         return "DoH"
@@ -198,6 +204,7 @@ class DoHNameserver(Nameserver):
             bootstrap_address=self.bootstrap_address,
             one_rr_per_rrset=one_rr_per_rrset,
             ignore_trailing=ignore_trailing,
+            verify=self.verify,
         )
 
     async def async_query(
@@ -218,13 +225,21 @@ class DoHNameserver(Nameserver):
             bootstrap_address=self.bootstrap_address,
             one_rr_per_rrset=one_rr_per_rrset,
             ignore_trailing=ignore_trailing,
+            verify=self.verify,
         )
 
 
 class DoTNameserver(AddressAndPortNameserver):
-    def __init__(self, address: str, port: int = 853, hostname: Optional[str] = None):
+    def __init__(
+        self,
+        address: str,
+        port: int = 853,
+        hostname: Optional[str] = None,
+        verify: Union[bool, str] = True,
+    ):
         super().__init__(address, port)
         self.hostname = hostname
+        self.verify = verify
 
     def kind(self):
         return "DoT"
@@ -247,6 +262,7 @@ class DoTNameserver(AddressAndPortNameserver):
             one_rr_per_rrset=one_rr_per_rrset,
             ignore_trailing=ignore_trailing,
             server_hostname=self.hostname,
+            verify=self.verify,
         )
 
     async def async_query(

--- a/dns/query.py
+++ b/dns/query.py
@@ -1015,6 +1015,28 @@ def _tls_handshake(s, expiration):
             _wait_for_writable(s, expiration)
 
 
+def _make_dot_ssl_context(
+    server_hostname: Optional[str], verify: Union[bool, str]
+) -> ssl.SSLContext:
+    cafile: Optional[str] = None
+    capath: Optional[str] = None
+    if isinstance(verify, str):
+        if os.path.isfile(verify):
+            cafile = verify
+        elif os.path.isdir(verify):
+            capath = verify
+        else:
+            raise ValueError("invalid verify string")
+    ssl_context = ssl.create_default_context(cafile=cafile, capath=capath)
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    if server_hostname is None:
+        ssl_context.check_hostname = False
+    ssl_context.set_alpn_protocols(["dot"])
+    if verify is False:
+        ssl_context.verify_mode = ssl.CERT_NONE
+    return ssl_context
+
+
 def tls(
     q: dns.message.Message,
     where: str,
@@ -1098,20 +1120,7 @@ def tls(
         where, port, source, source_port
     )
     if ssl_context is None and not sock:
-        cafile: Optional[str] = None
-        capath: Optional[str] = None
-        if isinstance(verify, str):
-            if os.path.isfile(verify):
-                cafile = verify
-            elif os.path.isdir(verify):
-                capath = verify
-        ssl_context = ssl.create_default_context(cafile=cafile, capath=capath)
-        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-        if server_hostname is None:
-            ssl_context.check_hostname = False
-        ssl_context.set_alpn_protocols(["dot"])
-        if verify is False:
-            ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context = _make_dot_ssl_context(server_hostname, verify)
 
     with _make_socket(
         af,


### PR DESCRIPTION
We supported the fairly standard TLS "verify" bool or str parameter for only the DoQNameserver.  We now support it
for all TLS-aware Nameserver subclasses.  This required adding support for the verify parameter to dns.query.tls().
