### PR TITLE
FIX: Add license specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "dnspython"
 description = "DNS toolkit"
+license = "ISC License (ISCL)"
 authors = [{ name = "Bob Halley", email = "halley@dnspython.org" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
When dnspython moved to hatchling, it didn't add the license specification. As a result, `pip show` now outputs the following:

![image](https://github.com/rthalley/dnspython/assets/17561586/0a734f5b-3288-4902-b939-b2d4b2417dba)

While in the past it outputted the following:

![image](https://github.com/rthalley/dnspython/assets/17561586/00e7f8d6-2c84-4772-901e-8beb954bed14)

This means that any license-aware company is not going to be able to use dnspython==2.5.0 because lack of license is considered to be dangerous (as far as I know, at least. I'm not a licensing expert :))   This fix should resolve the issue.