### PR TITLE
Include the text description of an EDE.

### DIFF
--- a/dns/edns.py
+++ b/dns/edns.py
@@ -345,6 +345,8 @@ class EDECode(dns.enum.IntEnum):
 class EDEOption(Option):  # lgtm[py/missing-equals]
     """Extended DNS Error (EDE, RFC8914)"""
 
+    _preserve_case = {"DNSKEY", "DS", "DNSSEC", "RRSIGs", "NSEC", "NXDOMAIN"}
+
     def __init__(self, code: Union[EDECode, str], text: Optional[str] = None):
         """*code*, a ``dns.edns.EDECode`` or ``str``, the info code of the
         extended error.
@@ -362,6 +364,13 @@ class EDEOption(Option):  # lgtm[py/missing-equals]
 
     def to_text(self) -> str:
         output = f"EDE {self.code}"
+        if self.code in EDECode:
+            desc = EDECode.to_text(self.code)
+            desc = " ".join(
+                word if word in self._preserve_case else word.title()
+                for word in desc.split("_")
+            )
+            output += f" ({desc})"
         if self.text is not None:
             output += f": {self.text}"
         return output

--- a/tests/test_edns.py
+++ b/tests/test_edns.py
@@ -141,7 +141,7 @@ class OptionTestCase(unittest.TestCase):
         opt.to_wire(io)
         data = io.getvalue()
         self.assertEqual(data, b"\x00\x03")
-        self.assertEqual(str(opt), "EDE 3")
+        self.assertEqual(str(opt), "EDE 3 (Stale Answer)")
         # with text
         opt = dns.edns.EDEOption(16, "test")
         io = BytesIO()


### PR DESCRIPTION
For known EDEs, add the description of the code in the output.