### PR TITLE
Remove customizable selectors.

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -217,7 +217,7 @@ def _wait_for(fd, readable, writable, _, expiration):
 
     if readable and isinstance(fd, ssl.SSLSocket) and fd.pending() > 0:
         return True
-    sel = _selector_class()
+    sel = selectors.DefaultSelector()
     events = 0
     if readable:
         events |= selectors.EVENT_READ
@@ -233,26 +233,6 @@ def _wait_for(fd, readable, writable, _, expiration):
             raise dns.exception.Timeout
     if not sel.select(timeout):
         raise dns.exception.Timeout
-
-
-def _set_selector_class(selector_class):
-    # Internal API. Do not use.
-
-    global _selector_class
-
-    _selector_class = selector_class
-
-
-if hasattr(selectors, "PollSelector"):
-    # Prefer poll() on platforms that support it because it has no
-    # limits on the maximum value of a file descriptor (plus it will
-    # be more efficient for high values).
-    #
-    # We ignore typing here as we can't say _selector_class is Any
-    # on python < 3.8 due to a bug.
-    _selector_class = selectors.PollSelector  # type: ignore
-else:
-    _selector_class = selectors.SelectSelector  # type: ignore
 
 
 def _wait_for_readable(s, expiration):

--- a/dns/quic/_sync.py
+++ b/dns/quic/_sync.py
@@ -21,12 +21,6 @@ from dns.quic._common import (
     UnexpectedEOF,
 )
 
-# Avoid circularity with dns.query
-if hasattr(selectors, "PollSelector"):
-    _selector_class = selectors.PollSelector  # type: ignore
-else:
-    _selector_class = selectors.SelectSelector  # type: ignore
-
 
 class SyncQuicStream(BaseQuicStream):
     def __init__(self, connection, stream_id):
@@ -118,7 +112,7 @@ class SyncQuicConnection(BaseQuicConnection):
 
     def _worker(self):
         try:
-            sel = _selector_class()
+            sel = selectors.DefaultSelector()
             sel.register(self._socket, selectors.EVENT_READ, self._read)
             sel.register(self._receive_wakeup, selectors.EVENT_READ, self._drain_wakeup)
             while not self._done:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -817,35 +817,6 @@ class LiveResolverTests(unittest.TestCase):
                 res.nameservers = [ns]
 
 
-class PollingMonkeyPatchMixin(object):
-    def setUp(self):
-        self.__native_selector_class = dns.query._selector_class
-        dns.query._set_selector_class(self.selector_class())
-
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        dns.query._set_selector_class(self.__native_selector_class)
-
-        unittest.TestCase.tearDown(self)
-
-
-class SelectResolverTestCase(
-    PollingMonkeyPatchMixin, LiveResolverTests, unittest.TestCase
-):
-    def selector_class(self):
-        return selectors.SelectSelector
-
-
-if hasattr(selectors, "PollSelector"):
-
-    class PollResolverTestCase(
-        PollingMonkeyPatchMixin, LiveResolverTests, unittest.TestCase
-    ):
-        def selector_class(self):
-            return selectors.PollSelector
-
-
 class NXDOMAINExceptionTestCase(unittest.TestCase):
     # pylint: disable=broad-except
 


### PR DESCRIPTION
The customization predates the selectors now, and presumably was present to work around something broken long ago.  Any such logic should be in the selectors module, and if there is some platform for which selectors.DefaultSelector doesn't work, that can be overridden.