### PR TITLE
Replace h3 parameter with http_version.

### DIFF
--- a/dns/nameserver.py
+++ b/dns/nameserver.py
@@ -168,14 +168,14 @@ class DoHNameserver(Nameserver):
         bootstrap_address: Optional[str] = None,
         verify: Union[bool, str] = True,
         want_get: bool = False,
-        h3: bool = False,
+        http_version: dns.query.HTTPVersion = dns.query.HTTPVersion.DEFAULT,
     ):
         super().__init__()
         self.url = url
         self.bootstrap_address = bootstrap_address
         self.verify = verify
         self.want_get = want_get
-        self.h3 = h3
+        self.http_version = http_version
 
     def kind(self):
         return "DoH"
@@ -216,7 +216,7 @@ class DoHNameserver(Nameserver):
             ignore_trailing=ignore_trailing,
             verify=self.verify,
             post=(not self.want_get),
-            h3=self.h3,
+            http_version=self.http_version,
         )
 
     async def async_query(
@@ -241,7 +241,7 @@ class DoHNameserver(Nameserver):
             ignore_trailing=ignore_trailing,
             verify=self.verify,
             post=(not self.want_get),
-            h3=self.h3,
+            http_version=self.http_version,
         )
 
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -570,7 +570,7 @@ class AsyncTests(unittest.TestCase):
                 post=False,
                 timeout=4,
                 family=family,
-                h3=True,
+                http_version=dns.asyncquery.HTTPVersion.H3,
             )
             self.assertTrue(q.is_response(r))
 
@@ -587,7 +587,7 @@ class AsyncTests(unittest.TestCase):
                 post=True,
                 timeout=4,
                 family=family,
-                h3=True,
+                http_version=dns.asyncquery.HTTPVersion.H3,
             )
             self.assertTrue(q.is_response(r))
 
@@ -603,7 +603,7 @@ class AsyncTests(unittest.TestCase):
                 nameserver_ip,
                 post=False,
                 timeout=4,
-                h3=True,
+                http_version=dns.asyncquery.HTTPVersion.H3,
             )
             self.assertTrue(q.is_response(r))
 

--- a/tests/test_doh.py
+++ b/tests/test_doh.py
@@ -203,7 +203,7 @@ class DNSOverHTTP3TestCase(unittest.TestCase):
             post=False,
             timeout=4,
             family=family,
-            h3=True,
+            http_version=dns.query.HTTPVersion.H3,
         )
         self.assertTrue(q.is_response(r))
 
@@ -216,7 +216,7 @@ class DNSOverHTTP3TestCase(unittest.TestCase):
             post=True,
             timeout=4,
             family=family,
-            h3=True,
+            http_version=dns.query.HTTPVersion.H3,
         )
         self.assertTrue(q.is_response(r))
 
@@ -233,7 +233,7 @@ class DNSOverHTTP3TestCase(unittest.TestCase):
                 nameserver_ip,
                 post=False,
                 timeout=4,
-                h3=True,
+                http_version=dns.query.HTTPVersion.H3,
             )
             self.assertTrue(q.is_response(r))
         if resolver_v6_addresses:
@@ -244,7 +244,7 @@ class DNSOverHTTP3TestCase(unittest.TestCase):
                 nameserver_ip,
                 post=False,
                 timeout=4,
-                h3=True,
+                http_version=dns.query.HTTPVersion.H3,
             )
             self.assertTrue(q.is_response(r))
 


### PR DESCRIPTION
This allows more flexibility; clients can specify which http version they want, or use the default.

