### PR TITLE
Update resolver.py

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1182,6 +1182,7 @@ class BaseResolver:
     ) -> List[dns.nameserver.Nameserver]:
         enriched_nameservers = []
         if isinstance(nameservers, list):
+            nameservers = [ns for ns in nameservers if ns]
             for nameserver in nameservers:
                 enriched_nameserver: dns.nameserver.Nameserver
                 if isinstance(nameserver, dns.nameserver.Nameserver):


### PR DESCRIPTION
Avoid dns error if a empty dns server name is included in dns server  list.  This is a problem since 2.1.0.  Just upgrade from 2.1.0 to 2.6.1 and found this issue.  Thank you.

