### PR TITLE
Add dns.rdata.load_all_types().

### DIFF
--- a/doc/rdata-make.rst
+++ b/doc/rdata-make.rst
@@ -6,3 +6,9 @@ Making DNS Rdata
 .. autofunction:: dns.rdata.from_text
 .. autofunction:: dns.rdata.from_wire_parser
 .. autofunction:: dns.rdata.from_wire
+
+Miscellaneous Rdata Functions
+-----------------------------
+
+.. autofunction:: dns.rdata.register_type
+.. autofunction:: dns.rdata.load_all_types


### PR DESCRIPTION
This PR provides `dns.rdata.load_all_types()`, which loads all rdata implementations instead of dynamically loading them on use.  This is useful in some cases, as in issue [#1083] or if using `chroot()`.
