### PR TITLE
Fix to make_response so that update messages have all sections copied

### DIFF
--- a/dns/update.py
+++ b/dns/update.py
@@ -372,6 +372,15 @@ class UpdateMessage(dns.message.Message):  # lgtm[py/missing-equals]
                 )
         return (rdclass, rdtype, deleting, empty)
 
+    def _copy_sections_for_response(self, update):
+        """Copy the sections required to make a response message - update messages
+        require all sections to be copied.
+        """
+        self.zone = list(update.zone)
+        self.prerequisite = list(update.prerequisite)
+        self.update = list(update.update)
+        self.additional = list(update.additional)
+
 
 # backwards compatibility
 Update = UpdateMessage


### PR DESCRIPTION
According to the [RFC](https://datatracker.ietf.org/doc/html/rfc2136), DNS update message responses should take the form:

```
   3.8 - Response

   At the end of UPDATE processing, a response code will be known.  A
   response message is generated by copying the ID and Opcode fields
   from the request, and either copying the ZOCOUNT, PRCOUNT, UPCOUNT,
   and ADCOUNT fields and associated sections, or placing zeros (0) in
   the these "count" fields and not including any part of the original
   update.  The QR bit is set to one (1), and the response is sent back
   to the requestor.  If the requestor used UDP, then the response will
   be sent to the requestor's source UDP port.  If the requestor used
   TCP, then the response will be sent back on the requestor's open TCP
   connection.
```

Currently, `make_response` doesn't do either of these, and just copies the ZONE (QUERY) section.  We spotted this troubleshooting updates on Windows, which tends to be pretty fussy about standards compliance.

I'm not sure if this raises concerns for backwards compatibility, as previously `is_response` just made the assumption that everything was good and always returned true for `UPDATE` opcode messages - e.g. it might be better to just fix `make_response` and continue to make `is_response` always true, but up for discussion.