### PR TITLE
Ensure we have a zone origin

### DIFF
--- a/dns/dnssec.py
+++ b/dns/dnssec.py
@@ -1056,6 +1056,9 @@ def sign_zone(
     else:
         cm = zone.writer()
 
+    if zone.origin is None:
+        raise ValueError("no zone origin")
+
     with cm as _txn:
         if add_dnskey:
             if dnskey_ttl is None:


### PR DESCRIPTION
The zone signer must have a zone origin or it cannot determine the signer's name.