### PR TITLE
Deal with windows registry delimiters more comprehensively.

### DIFF
--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -82,32 +82,21 @@ if sys.platform == "win32":
         def __init__(self):
             self.info = DnsInfo()
 
-        def _determine_split_char(self, entry):
-            #
-            # The windows registry irritatingly changes the list element
-            # delimiter in between ' ' and ',' (and vice-versa) in various
-            # versions of windows.
-            #
-            if entry.find(" ") >= 0:
-                split_char = " "
-            elif entry.find(",") >= 0:
-                split_char = ","
-            else:
-                # probably a singleton; treat as a space-separated list.
-                split_char = " "
-            return split_char
+        def _split(self, text):
+            # The windows registry has used both " " and "," as a delimiter, and while
+            # it is currently using "," in Windows 10 and later, updates can seemingly
+            # leave a space in too, e.g. "a, b".  So we just convert all commas to
+            # spaces, and use split() in its default configuration, which splits on
+            # all whitespace and ignores empty strings.
+            return text.replace(",", " ").split()
 
         def _config_nameservers(self, nameservers):
-            split_char = self._determine_split_char(nameservers)
-            ns_list = nameservers.split(split_char)
-            for ns in ns_list:
+            for ns in self._split(nameservers):
                 if ns not in self.info.nameservers:
                     self.info.nameservers.append(ns)
 
         def _config_search(self, search):
-            split_char = self._determine_split_char(search)
-            search_list = search.split(split_char)
-            for s in search_list:
+            for s in self._split(search):
                 s = _config_domain(s)
                 if s not in self.info.search:
                     self.info.search.append(s)


### PR DESCRIPTION
Windows has used both " " and "," as a list item delimiter, and issues [#1010] and [#1112] have also show that both can happen, possibly due to updates, e.g. "a, b".  We now just convert "," to " " and split().

