### PR TITLE
Do not allow an empty list in TXT record wire format

### DIFF
--- a/dns/rdtypes/txtbase.py
+++ b/dns/rdtypes/txtbase.py
@@ -50,6 +50,8 @@ class TXTBase(dns.rdata.Rdata):
         self.strings: Tuple[bytes] = self._as_tuple(
             strings, lambda x: self._as_bytes(x, True, 255)
         )
+        if len(self.strings) == 0:
+            raise ValueError("the list of strings must not be empty")
 
     def to_text(
         self,

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -672,6 +672,10 @@ class RdataTestCase(unittest.TestCase):
         with self.assertRaises(dns.exception.SyntaxError):
             dns.rdata.from_text("in", "txt", "")
 
+    def test_empty_TXT_wire(self):
+        with self.assertRaises(dns.exception.FormError):
+            dns.rdata.from_wire(dns.rdataclass.IN, dns.rdatatype.TXT, b"", 0, 0)
+
     def test_too_long_TXT(self):
         # hit too long
         with self.assertRaises(dns.exception.SyntaxError):


### PR DESCRIPTION
Do not allow an empty list in TXT record wire format or when invoking the constructor.  [#1117]

