### PR TITLE
Avoid instantiating Resolver when it is not necessary for DoH

### DIFF
--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -197,7 +197,7 @@ if dns._features.have("doh"):
             family=socket.AF_UNSPEC,
             **kwargs,
         ):
-            if resolver is None:
+            if resolver is None and bootstrap_address is None:
                 # pylint: disable=import-outside-toplevel,redefined-outer-name
                 import dns.asyncresolver
 

--- a/dns/_trio_backend.py
+++ b/dns/_trio_backend.py
@@ -171,7 +171,7 @@ if dns._features.have("doh"):
             family=socket.AF_UNSPEC,
             **kwargs,
         ):
-            if resolver is None:
+            if resolver is None and bootstrap_address is None:
                 # pylint: disable=import-outside-toplevel,redefined-outer-name
                 import dns.asyncresolver
 

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -560,21 +560,23 @@ async def https(
     else:
         url = where
 
+    if bootstrap_address is None:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.hostname is None:
+            raise ValueError("no hostname in URL")
+        if dns.inet.is_address(parsed.hostname):
+            bootstrap_address = parsed.hostname
+        if parsed.port is not None:
+            port = parsed.port
+
     if http_version == HTTPVersion.H3 or (
         http_version == HTTPVersion.DEFAULT and not have_doh
     ):
         if bootstrap_address is None:
-            parsed = urllib.parse.urlparse(url)
             resolver = _maybe_get_resolver(resolver)
-            if parsed.hostname is None:
-                raise ValueError("no hostname in URL")
-            if dns.inet.is_address(parsed.hostname):
-                bootstrap_address = parsed.hostname
-            else:
-                answers = await resolver.resolve_name(parsed.hostname, family)
-                bootstrap_address = random.choice(list(answers.addresses()))
-            if parsed.port is not None:
-                port = parsed.port
+            assert parsed.hostname is not None  # for mypy
+            answers = await resolver.resolve_name(parsed.hostname, family)
+            bootstrap_address = random.choice(list(answers.addresses()))
         return await _http3(
             q,
             bootstrap_address,

--- a/dns/query.py
+++ b/dns/query.py
@@ -131,7 +131,7 @@ if _have_httpx:
             family=socket.AF_UNSPEC,
             **kwargs,
         ):
-            if resolver is None:
+            if resolver is None and bootstrap_address is None:
                 # pylint: disable=import-outside-toplevel,redefined-outer-name
                 import dns.resolver
 

--- a/dns/query.py
+++ b/dns/query.py
@@ -449,21 +449,23 @@ def https(
     else:
         url = where
 
+    if bootstrap_address is None:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.hostname is None:
+            raise ValueError("no hostname in URL")
+        if dns.inet.is_address(parsed.hostname):
+            bootstrap_address = parsed.hostname
+        if parsed.port is not None:
+            port = parsed.port
+
     if http_version == HTTPVersion.H3 or (
         http_version == HTTPVersion.DEFAULT and not have_doh
     ):
         if bootstrap_address is None:
-            parsed = urllib.parse.urlparse(url)
             resolver = _maybe_get_resolver(resolver)
-            if parsed.hostname is None:
-                raise ValueError("no hostname in URL")
-            if dns.inet.is_address(parsed.hostname):
-                bootstrap_address = parsed.hostname
-            else:
-                answers = resolver.resolve_name(parsed.hostname, family)
-                bootstrap_address = random.choice(list(answers.addresses()))
-            if parsed.port is not None:
-                port = parsed.port
+            assert parsed.hostname is not None  # for mypy
+            answers = resolver.resolve_name(parsed.hostname, family)
+            bootstrap_address = random.choice(list(answers.addresses()))
         return _http3(
             q,
             bootstrap_address,


### PR DESCRIPTION
Currently, a Resolver with default settings is always instantiated when instantiating a DoH backend. e.g. :
https://github.com/rthalley/dnspython/blob/3fbb41abf77ae09f0792cfa2c724c60611c39b0e/dns/_asyncio_backend.py#L190-L204

The Resolver is used to resolve the IP address for the hostname of the DoH server address.

However, this is not always necessary.
For example, when bootstrap_address is present or hostname is already a IP address:
https://github.com/rthalley/dnspython/blob/3fbb41abf77ae09f0792cfa2c724c60611c39b0e/dns/_asyncio_backend.py#L154-L166

And it may potentially cause problems as the Resolver is instantiated with default settings.
For example, `/etc/resolv.conf` is not accessible in Termux (https://github.com/URenko/Accesser/issues/187).

This pr partially mitigated this issue by avoiding instantiating the Resolver when bootstrap_address is present.
Further fixes are required to fully resolve this issue.