### PR TITLE
Create EOFError exceptions with text EOF.

### DIFF
--- a/dns/_asyncio_backend.py
+++ b/dns/_asyncio_backend.py
@@ -42,7 +42,7 @@ class _DatagramProtocol:
             if exc is None:
                 # EOF we triggered.  Is there a better way to do this?
                 try:
-                    raise EOFError
+                    raise EOFError('EOF')
                 except EOFError as e:
                     self.recvfrom.set_exception(e)
             else:

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -342,7 +342,7 @@ async def _read_exactly(sock, count, expiration):
     while count > 0:
         n = await sock.recv(count, _timeout(expiration))
         if n == b"":
-            raise EOFError
+            raise EOFError('EOF')
         count = count - len(n)
         s = s + n
     return s

--- a/dns/query.py
+++ b/dns/query.py
@@ -976,7 +976,7 @@ def _net_read(sock, count, expiration):
         try:
             n = sock.recv(count)
             if n == b"":
-                raise EOFError
+                raise EOFError('EOF')
             count -= len(n)
             s += n
         except (BlockingIOError, ssl.SSLWantReadError):


### PR DESCRIPTION
Create EOFError exceptions with text EOF.
    
Previously, EOFErrors were being created with no text, leading to bad
looking error messages.
