### PR TITLE
Add a copy mode to dns.message.make_response().

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1826,7 +1826,7 @@ def make_query(
     return m
 
 
-class CopyMode:
+class CopyMode(enum.Enum):
     """
     How should sections be copied when making an update response?
     """

--- a/dns/message.py
+++ b/dns/message.py
@@ -1843,7 +1843,7 @@ def make_response(
     fudge: int = 300,
     tsig_error: int = 0,
     pad: Optional[int] = None,
-    copy_mode: CopyMode = CopyMode.QUESTION,
+    copy_mode: Optional[CopyMode] = None,
 ) -> Message:
     """Make a message which is a response for the specified query.
     The message returned is really a response skeleton; it has all of the infrastructure
@@ -1868,8 +1868,10 @@ def make_response(
     message.  If ``None``, add padding following RFC 8467, namely if the request is
     padded, pad the response to 468 otherwise do not pad.
 
-    *copy_mode*, a ``dns.message.CopyMode``, determines how sections are copied.  The
-    default, ``dns.message.CopyMode.QUESTION`` copies only the question section.
+    *copy_mode*, a ``dns.message.CopyMode`` or ``None``, determines how sections are
+    copied.  The default, ``None`` copies sections according to the default for the
+    message's opcode, which is currently ``dns.message.CopyMode.QUESTION`` for all
+    opcodes.   ``dns.message.CopyMode.QUESTION`` copies only the question section.
     ``dns.message.CopyMode.EVERYTHING`` copies all sections other than OPT or TSIG
     records, which are created appropriately if needed. ``dns.message.CopyMode.NOTHING``
     copies no sections; note that this mode is for server testing purposes and is
@@ -1891,6 +1893,8 @@ def make_response(
     if recursion_available:
         response.flags |= dns.flags.RA
     response.set_opcode(opcode)
+    if copy_mode is None:
+        copy_mode = CopyMode.QUESTION
     if copy_mode != CopyMode.NOTHING:
         response.question = list(query.question)
     if copy_mode == CopyMode.EVERYTHING:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -3,14 +3,13 @@
 import unittest
 
 import dns.dnssec
-import dns.rdtypes.dnskeybase
-import dns.flags
-import dns.rcode
-import dns.opcode
-import dns.message
-import dns.update
 import dns.edns
-
+import dns.flags
+import dns.message
+import dns.opcode
+import dns.rcode
+import dns.rdtypes.dnskeybase
+import dns.update
 import tests.util
 
 
@@ -27,7 +26,9 @@ class ConstantsTestCase(unittest.TestCase):
         tests.util.check_enum_exports(dns.opcode, self.assertEqual)
 
     def test_message_constants(self):
-        tests.util.check_enum_exports(dns.message, self.assertEqual)
+        tests.util.check_enum_exports(
+            dns.message, self.assertEqual, only={dns.message.MessageSection}
+        )
         tests.util.check_enum_exports(dns.update, self.assertEqual)
 
     def test_rdata_constants(self):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -233,6 +233,34 @@ class MessageTestCase(unittest.TestCase):
         self.assertTrue(r.flags & dns.flags.RA != 0)
         self.assertEqual(r.edns, 0)
 
+    def test_MakeResponseCopyNothing(self):
+        q = dns.message.make_query("foo", "A")
+        r = dns.message.make_response(q, copy_mode=dns.message.CopyMode.NOTHING)
+        self.assertEqual(len(r.question), 0)
+        self.assertEqual(len(r.answer), 0)
+        self.assertEqual(len(r.authority), 0)
+        self.assertEqual(len(r.additional), 0)
+
+    def test_MakeResponseCopyQuestion(self):
+        q = dns.message.make_query("foo", "A")
+        r = dns.message.make_response(q, copy_mode=dns.message.CopyMode.QUESTION)
+        self.assertTrue(len(r.question) == 1 and q.question[0] == r.question[0])
+        self.assertEqual(len(r.answer), 0)
+        self.assertEqual(len(r.authority), 0)
+        self.assertEqual(len(r.additional), 0)
+
+    def test_MakeResponseCopyEverything(self):
+        q = dns.message.make_query("foo", "A")
+        q.answer.append(dns.rrset.from_text("foo", 300, "IN", "A", "10.0.0.1"))
+        # These are nonsensical, but all we care about is they get copied.
+        q.authority.append(dns.rrset.from_text("foo2", 300, "IN", "A", "10.0.0.2"))
+        q.additional.append(dns.rrset.from_text("foo3", 300, "IN", "A", "10.0.0.3"))
+        r = dns.message.make_response(q, copy_mode=dns.message.CopyMode.EVERYTHING)
+        self.assertTrue(len(r.question) == 1 and q.question == r.question)
+        self.assertTrue(len(r.answer) == 1 and q.answer == r.answer)
+        self.assertTrue(len(r.authority) == 1 and q.authority == r.authority)
+        self.assertTrue(len(r.additional) == 1 and q.additional == r.additional)
+
     def test_ExtendedRcodeSetting(self):
         m = dns.message.make_query("foo", "A")
         m.set_rcode(4095)


### PR DESCRIPTION
If the mode is dns.message.CopyMode.QUESTION, the default, then only the question section is copied.

If the mode is dns.message.CopyMode.EVERYTHING, then all sections are copied other than OPT or TSIG records which are created appropriately if needed instead of being copied.

If the mode is dns.message.CopyMode.NOTHING then no sections are copied.

