### PR TITLE
fix(answer): add typing to range

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -36,6 +36,7 @@ import dns.ipv4
 import dns.ipv6
 import dns.message
 import dns.name
+import dns.rdata
 import dns.nameserver
 import dns.query
 import dns.rcode
@@ -297,7 +298,7 @@ class Answer:
     def __len__(self) -> int:
         return self.rrset and len(self.rrset) or 0
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[dns.rdata.Rdata]:
         return self.rrset and iter(self.rrset) or iter(tuple())
 
     def __getitem__(self, i):


### PR DESCRIPTION
this will make so the code:

```
import dns.resolver

domain = "test.com"
mx_resolved_responses = dns.resolver.resolve(domain, "MX")
for mx_resolved_response in mx_resolved_responses:
  pass
```

won't get a linter error on: 
```
"Answer" is not iterable
  "__next__" method not defined on type
  ```