### PR TITLE
Ensure thread does not die due to uncaught exception

### DIFF
--- a/dns/quic/_sync.py
+++ b/dns/quic/_sync.py
@@ -119,7 +119,7 @@ class SyncQuicConnection(BaseQuicConnection):
             count += 1
             try:
                 datagram = self._socket.recv(QUIC_MAX_DATAGRAM)
-            except BlockingIOError:
+            except (BlockingIOError, ConnectionRefusedError):
                 return
             with self._lock:
                 self._connection.receive_datagram(datagram, self._peer, time.time())


### PR DESCRIPTION
The caller should be able to catch and handle this exception, which is caused when a quic connection fails.

