### PR TITLE
Update resolver._Resolution to check other nameservers on NXDOMAIN while on vpn

### DIFF
--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -65,6 +65,7 @@ class RdataTestCase(unittest.TestCase):
 
     def test_class_registration(self):
         CTXT = 64003
+
         class CTXTImp(dns.rdtypes.txtbase.TXTBase):
             """Test TXT-like record"""
 


### PR DESCRIPTION
## Details

- Adds a new flag `vpn_nameservers` to the BaseResolver that when set to true causes `resolver._Resolution` to report `done` as False when an NXDOMAIN is received and there are still other nameservers that have not yet been checked.

## Motivation

We ran into a situation where while on a vpn connection, the list of nameservers looked like `['public nameserver 1', 'public nameserver 2', ..., 'vpn nameserver 1']`. 

This resulted in our calls to resolve to fail with NXDOMAIN because the first public nameserver did not have an answer for the query which only existed on the vpn. 

Once we discovered the issue we were able to work around it by using the cmd prompt / command line to find all the nameservers the computer was aware of, and then manually setting `nameservers = ['vpn nameserver 1', 'vpn nameserver 2']`

In light of this I'm proposing this change for a couple of reasons:

1. It was not intuitive what the issue was since it did not reproduce on all machines on the vpn.
2. Folks who are not familiar with this space and would have difficulty working around it without other guidance.
3. The vpn nameservers could change arbitrarily and I don't think there is an easy way to generically distinguish nameservers.

## Testing

- Added new test cases in [tests/test_resolution.py](https://github.com/rthalley/dnspython/compare/main...marcospedreiro:dnspython:retry-nxdomain?expand=1#diff-58e45f30924e3bfc9bbf548cea334a9bbf9b083c4577a36d7b7b2774d1ba24d1)
- Updated two existing test cases in [tests/test_resolution.py](https://github.com/rthalley/dnspython/compare/main...marcospedreiro:dnspython:retry-nxdomain?expand=1#diff-58e45f30924e3bfc9bbf548cea334a9bbf9b083c4577a36d7b7b2774d1ba24d1), `test_query_result_nxdomain`, and `test_query_result_nxdomain_cached`, the change I'm proposing means that they need to query twice because there are two nameservers.

## Other

Ran the following locally and the output came back green:

```
make pyright
make lint
make flake
make ruff
make black
make test
make cov
```

Output of `make cov` filtered to `resol`: 

![Screenshot 2025-01-16 at 11 49 19 PM](https://github.com/user-attachments/assets/25e44e6b-7086-4722-8d57-4d29e1494143)
![Screenshot 2025-01-16 at 11 49 33 PM](https://github.com/user-attachments/assets/1faf9a03-6d37-49f9-b06f-ff25fef65901)

