### PR TITLE
QUIC code should process verify correctly when given a directory path. [#1174]

### DIFF
--- a/dns/_tls_util.py
+++ b/dns/_tls_util.py
@@ -1,0 +1,19 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+import os
+from typing import Optional, Tuple, Union
+
+
+def convert_verify_to_cafile_and_capath(
+    verify: Union[bool, str],
+) -> Tuple[Optional[str], Optional[str]]:
+    cafile: Optional[str] = None
+    capath: Optional[str] = None
+    if isinstance(verify, str):
+        if os.path.isfile(verify):
+            cafile = verify
+        elif os.path.isdir(verify):
+            capath = verify
+        else:
+            raise ValueError("invalid verify string")
+    return cafile, capath

--- a/dns/query.py
+++ b/dns/query.py
@@ -32,6 +32,7 @@ import urllib.parse
 from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import dns._features
+import dns._tls_util
 import dns.exception
 import dns.inet
 import dns.message
@@ -1213,15 +1214,7 @@ def _tls_handshake(s, expiration):
 def _make_dot_ssl_context(
     server_hostname: Optional[str], verify: Union[bool, str]
 ) -> ssl.SSLContext:
-    cafile: Optional[str] = None
-    capath: Optional[str] = None
-    if isinstance(verify, str):
-        if os.path.isfile(verify):
-            cafile = verify
-        elif os.path.isdir(verify):
-            capath = verify
-        else:
-            raise ValueError("invalid verify string")
+    cafile, capath = dns._tls_util.convert_verify_to_cafile_and_capath(verify)
     ssl_context = ssl.create_default_context(cafile=cafile, capath=capath)
     ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
     if server_hostname is None:

--- a/dns/quic/_common.py
+++ b/dns/quic/_common.py
@@ -14,6 +14,7 @@ import aioquic.h3.events  # type: ignore
 import aioquic.quic.configuration  # type: ignore
 import aioquic.quic.connection  # type: ignore
 
+import dns._tls_util
 import dns.inet
 
 QUIC_MAX_DATAGRAM = 2048
@@ -245,7 +246,10 @@ class BaseQuicManager:
                 server_name=server_name,
             )
             if verify_path is not None:
-                conf.load_verify_locations(verify_path)
+                cafile, capath = dns._tls_util.convert_verify_to_cafile_and_capath(
+                    verify_path
+                )
+                conf.load_verify_locations(cafile=cafile, capath=capath)
         self._conf = conf
 
     def _connect(


### PR DESCRIPTION

We refactor the code to avoid duplicating the code in query.py.
