### PR TITLE
Only update hostname if not supplied through parameter

### DIFF
--- a/dns/query.py
+++ b/dns/query.py
@@ -634,7 +634,7 @@ def _http3(
         raise NoDOH("DNS-over-HTTP3 is not available.")  # pragma: no cover
 
     url_parts = urllib.parse.urlparse(url)
-    if hostname is not None:
+    if hostname is None:
         hostname = url_parts.hostname
     if url_parts.port is not None:
         port = url_parts.port

--- a/dns/query.py
+++ b/dns/query.py
@@ -634,7 +634,8 @@ def _http3(
         raise NoDOH("DNS-over-HTTP3 is not available.")  # pragma: no cover
 
     url_parts = urllib.parse.urlparse(url)
-    hostname = url_parts.hostname
+    if hostname is not None:
+        hostname = url_parts.hostname
     if url_parts.port is not None:
         port = url_parts.port
 


### PR DESCRIPTION
I wanted to specifically set a hostname in the _http3 method. I saw that it allows to supply a hostname as a parameter, however, it is directly overwritten at the beginning of the function based on the parsed URL from urllib. Currently, the supplied hostname does not have any impact at all.