### PR TITLE
Allow built-in `IPv{4,6}Address` objects when constructing A/AAAA rdata

### DIFF
--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -22,6 +22,7 @@ import binascii
 import inspect
 import io
 import itertools
+import ipaddress
 import random
 from importlib import import_module
 from typing import Any, Dict, Optional, Tuple, Union
@@ -551,6 +552,8 @@ class Rdata:
             return dns.ipv4.canonicalize(value)
         elif isinstance(value, bytes):
             return dns.ipv4.inet_ntoa(value)
+        elif isinstance(value, ipaddress.IPv4Address):
+            return dns.ipv4.inet_ntoa(value.packed)
         else:
             raise ValueError("not an IPv4 address")
 
@@ -560,6 +563,8 @@ class Rdata:
             return dns.ipv6.canonicalize(value)
         elif isinstance(value, bytes):
             return dns.ipv6.inet_ntoa(value)
+        elif isinstance(value, ipaddress.IPv6Address):
+            return dns.ipv6.inet_ntoa(value.packed)
         else:
             raise ValueError("not an IPv6 address")
 

--- a/dns/rdata.py
+++ b/dns/rdata.py
@@ -757,6 +757,8 @@ def from_text(
     """
     if isinstance(tok, str):
         tok = dns.tokenizer.Tokenizer(tok, idna_codec=idna_codec)
+    if not isinstance(tok, dns.tokenizer.Tokenizer):
+        raise ValueError("tok must be a string or a Tokenizer")
     rdclass = dns.rdataclass.RdataClass.make(rdclass)
     rdtype = dns.rdatatype.RdataType.make(rdtype)
     cls = get_rdata_class(rdclass, rdtype)

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -17,6 +17,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import io
+import ipaddress
 import operator
 import pickle
 import struct
@@ -29,6 +30,8 @@ import dns.rdataclass
 import dns.rdataset
 import dns.rdatatype
 import dns.rdtypes.ANY.RRSIG
+import dns.rdtypes.IN.A
+import dns.rdtypes.IN.AAAA
 import dns.rdtypes.IN.APL
 import dns.rdtypes.util
 import dns.tokenizer
@@ -895,6 +898,28 @@ class RdataTestCase(unittest.TestCase):
         expected_abs = dns.name.from_text("ck0q2d6ni4i7eqh8na30ns61o48ul8g5.com.")
         self.assertEqual(rdata.next_name(), expected_rel)
         self.assertEqual(rdata.next_name(origin), expected_abs)
+
+    def test_a_rdata_made_multiple_ways(self):
+        r1 = dns.rdtypes.IN.A.A(dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
+        r2 = dns.rdtypes.IN.A.A(dns.rdataclass.IN, dns.rdatatype.A, b"\x01\x02\x03\x04")
+        r3 = dns.rdtypes.IN.A.A(
+            dns.rdataclass.IN, dns.rdatatype.A, ipaddress.ip_address("1.2.3.4")
+        )
+        self.assertEqual(r1, r2)
+        self.assertEqual(r1, r3)
+
+    def test_aaaa_rdata_made_multiple_ways(self):
+        r1 = dns.rdtypes.IN.AAAA.AAAA(dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+        r2 = dns.rdtypes.IN.AAAA.AAAA(
+            dns.rdataclass.IN,
+            dns.rdatatype.AAAA,
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+        )
+        r3 = dns.rdtypes.IN.AAAA.AAAA(
+            dns.rdataclass.IN, dns.rdatatype.AAAA, ipaddress.ip_address("::1")
+        )
+        self.assertEqual(r1, r2)
+        self.assertEqual(r1, r3)
 
 
 class UtilTestCase(unittest.TestCase):


### PR DESCRIPTION
This pull request adds support of Python's built-in `ipaddress.IPv{4,6}Address` types for constructing `Rdata` of type `A` and `AAAA`. This also adds support in other places `dns.rdata.Rdata._as_ipv{4,6}_address` class method is used.

In testing this I also encountered a cryptic error message from `dns.rdata.from_text` which I improved to be more specific.