### PR TITLE
docs: update zone transfer example to use inbound_xfr()

### DIFF
--- a/examples/xfr.py
+++ b/examples/xfr.py
@@ -7,6 +7,7 @@ import dns.zone
 soa_answer = dns.resolver.resolve("dnspython.org", "SOA")
 master_answer = dns.resolver.resolve(soa_answer[0].mname, "A")
 
-z = dns.zone.from_xfr(dns.query.xfr(master_answer[0].address, "dnspython.org"))
+z = dns.zone.Zone("dnspython.org")
+dns.query.inbound_xfr(master_answer[0].address, z)
 for n in sorted(z.nodes.keys()):
     print(z[n].to_text(n))


### PR DESCRIPTION
The docs mention that `dns.query.xfr()` is deprecated and that `dns.query.inbound_xfr()` should be used instead.

This PR updates the example in `xfr.py` to use the newer method.

Closes #1180 