### PR TITLE
Update wmi extra to only install on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ doh = ["httpcore>=1.0.0", "httpx>=0.26.0", "h2>=4.1.0"]
 doq = ["aioquic>=1.0.0"]
 idna = ["idna>=3.7"]
 trio = ["trio>=0.23"]
-wmi = ["wmi>=1.5.1"]
+wmi = ["wmi>=1.5.1; platform_system=='Windows'"]
 
 [project.urls]
 homepage = "https://www.dnspython.org"


### PR DESCRIPTION
Since installing `dnspython[wmi]` is the recommended way to avoid querying dns servers on inactive interfaces (#1191), but WMI is only meaningful on Windows, perhaps the extra should only be installed on Windows.

