### PR TITLE
Use Windows API to get dns nameservers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,9 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+
+    - name: Test with wmi
+      if: ${{ startsWith(matrix.os, 'windows') }}
+      run: |
+        python -m pip install ".[wmi]"
+        pytest

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -327,10 +327,7 @@ if sys.platform == "win32":
             
             current_adapter = adapter_addresses  
             while current_adapter:  
-
-                friendly_name = ctypes.wstring_at(current_adapter.contents.FriendlyName)  
                 oper_status = current_adapter.contents.OperStatus  
-                oper_status_str = "Operational" if oper_status == 1 else "Non-Operational"  
 
                 # Exclude loopback adapters.
                 if current_adapter.contents.IfType == IF_TYPE_SOFTWARE_LOOPBACK: 

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -412,7 +412,6 @@ if sys.platform == "win32":
             registry_getter = _RegistryGetter()
             info = registry_getter.get()
             self.info.search = info.search
-            raise ValueError("Making sure we hit this point")
             return self.info
 
     def set_config_method(method: ConfigMethod) -> None:

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -412,6 +412,7 @@ if sys.platform == "win32":
             registry_getter = _RegistryGetter()
             info = registry_getter.get()
             self.info.search = info.search
+            raise ValueError("Making sure we hit this point")
             return self.info
 
     def set_config_method(method: ConfigMethod) -> None:

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -241,8 +241,6 @@ if sys.platform == "win32":
         def _config_nameservers(self, nameservers):
             """Override the nameservers retrieved from the registry.
             """
-            nameservers = []
-
             # Load the IP Helper library  
             # # https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
             IPHLPAPI = ctypes.WinDLL('Iphlpapi.dll')  
@@ -349,12 +347,12 @@ if sys.platform == "win32":
                         ip = format_ipv6(sockaddr.contents)  
                         
                     if ip:  
-                        nameservers.append(ip)
+                        if ip not in self.info.nameservers:
+                            self.info.nameservers.append(ip)
                         
                     current_dns_server = current_dns_server.contents.Next  
         
                 current_adapter = current_adapter.contents.Next  
-            return nameservers
 
     _getter_class: Any
     if _prefer_ctypes:

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -16,6 +16,7 @@ if sys.platform == "win32":
     import winreg  # pylint: disable=import-error
     import ctypes  
     import ctypes.wintypes as wintypes  
+    import ipaddress
 
     # Keep pylint quiet on non-windows.
     try:
@@ -304,8 +305,7 @@ if sys.platform == "win32":
                 return ".".join(map(str, sockaddr_in.sa_data[2:6]))  
             
             def format_ipv6(sockaddr_in6):  
-                parts = [sockaddr_in6.sa_data[i] << 8 | sockaddr_in6.sa_data[i+1] for i in range(0, 14, 2)]  
-                return ":".join(f"{part:04x}" for part in parts)  
+                return str(ipaddress.IPv6Address(sockaddr_in6.sa_data))
             
             buffer_size = ctypes.c_ulong(15000)  
             while True:  

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -413,8 +413,8 @@ if sys.platform == "win32":
             self.info.search = info.search
             return self.info
 
-    def set_config_method(method: ConfigMethod):
-        nonlocal _config_method
+    def set_config_method(method: ConfigMethod) -> None:
+        global _config_method
         _config_method = method
 
     def get_dns_info():

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -417,7 +417,7 @@ if sys.platform == "win32":
         global _config_method
         _config_method = method
 
-    def get_dns_info():
+    def get_dns_info() -> DnsInfo:
         """Extract resolver configuration."""
         if _config_method == ConfigMethod.Win32:
             getter = _Win32Getter()

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -354,6 +354,7 @@ if sys.platform == "win32":
                     current_dns_server = current_dns_server.contents.Next  
         
                 current_adapter = current_adapter.contents.Next  
+            return nameservers
 
     _getter_class: Any
     if _prefer_ctypes:

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -358,7 +358,7 @@ if sys.platform == "win32":
     _getter_class: Any
     if _prefer_ctypes:
         _getter_class = _CtypesGetter
-    if _have_wmi and _prefer_wmi:
+    elif _have_wmi and _prefer_wmi:
         _getter_class = _WMIGetter
     else:
         _getter_class = _RegistryGetter

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -324,9 +324,6 @@ if sys.platform == "win32":
                         
             class IP_ADAPTER_ADDRESSES(ctypes.Structure):  
                 pass  # Forward declaration  
-
-            class IP_ADAPTER_ADDRESSES(ctypes.Structure):  
-                pass  # Forward declaration  
             
             IP_ADAPTER_ADDRESSES._fields_ = [  
                 ("Length", wintypes.ULONG),  
@@ -374,7 +371,6 @@ if sys.platform == "win32":
             
             current_adapter = adapter_addresses  
             while current_adapter:  
-                addapter = current_adapter.contents
 
                 # Skip non-operational adapters.
                 oper_status = current_adapter.contents.OperStatus  

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -9,7 +9,7 @@ if sys.platform == "win32":
     import dns.name
 
     _prefer_wmi = True
-    # TODO: How to configure this?
+    # TODO: How to configure
     _prefer_ctypes = os.environ.get('DNSPYTHON_PREFER_CTYPES') is not None
     _prefer_ctypes = True
 
@@ -327,7 +327,10 @@ if sys.platform == "win32":
             
             current_adapter = adapter_addresses  
             while current_adapter:  
+                # Skip non-operational adapters.
                 oper_status = current_adapter.contents.OperStatus  
+                if oper_status != 1:
+                    continue  
 
                 # Exclude loopback adapters.
                 if current_adapter.contents.IfType == IF_TYPE_SOFTWARE_LOOPBACK: 

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -367,6 +367,3 @@ if sys.platform == "win32":
         """Extract resolver configuration."""
         getter = _getter_class()
         return getter.get()
-
-    info = get_dns_info()
-    print(info.nameservers)

--- a/dns/win32util.py
+++ b/dns/win32util.py
@@ -72,19 +72,20 @@ if sys.platform == "win32":
                 self.start()
                 self.join()
                 return self.info
-
-        def _config_domain(domain):
-            # Sometimes DHCP servers add a '.' prefix to the default domain, and
-            # Windows just stores such values in the registry (see #687).
-            # Check for this and fix it.
-            if domain.startswith("."):
-                domain = domain[1:]
-            return dns.name.from_text(domain)
     
     else:
         class _WMIGetter:  # type: ignore
             pass
 
+
+    def _config_domain(domain):
+        # Sometimes DHCP servers add a '.' prefix to the default domain, and
+        # Windows just stores such values in the registry (see #687).
+        # Check for this and fix it.
+        if domain.startswith("."):
+            domain = domain[1:]
+        return dns.name.from_text(domain)
+        
     class _RegistryGetter:
         def __init__(self):
             self.info = DnsInfo()

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,7 +6,9 @@ What's New in dnspython
 2.8.0 (in development)
 ----------------------
 
-* TBD
+* dns/win32util.py now supports explicitly setting the configuration method used to get 
+  system dns info, using the set_config_method() function.   There is a new configuration
+  method that uses the Win32 API, which can be set using set_config_method(ConfigMethod.Win32).
 
 2.7.0
 -----

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -999,9 +999,9 @@ class ResolverMiscTestCase(unittest.TestCase):
 
         def test_set_config_method(self):
             from dns.win32util import set_config_method, ConfigMethod
-            self.assertNotEqual(dns.win32util.__config_method, dns.win32util.ConfigMethod.Win32)
+            self.assertNotEqual(dns.win32util._config_method, dns.win32util.ConfigMethod.Win32)
             dns.win32util.set_config_method(dns.win32util.ConfigMethod.Win32)
-            self.assertEqual(dns.win32util.__config_method, dns.win32util.ConfigMethod.Win32)
+            self.assertEqual(dns.win32util._config_method, dns.win32util.ConfigMethod.Win32)
 
 class ResolverNameserverValidTypeTestCase(unittest.TestCase):
     def test_set_nameservers_to_list(self):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -23,6 +23,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
+import dns.win32util
 import pytest
 
 import dns.e164
@@ -996,6 +997,11 @@ class ResolverMiscTestCase(unittest.TestCase):
             self.assertEqual(n, dns.win32util._config_domain("home"))
             self.assertEqual(n, dns.win32util._config_domain(".home"))
 
+        def test_set_config_method(self):
+            from dns.win32util import set_config_method, ConfigMethod
+            self.assertNotEqual(dns.win32util.__config_method, dns.win32util.ConfigMethod.Win32)
+            dns.win32util.set_config_method(dns.win32util.ConfigMethod.Win32)
+            self.assertEqual(dns.win32util.__config_method, dns.win32util.ConfigMethod.Win32)
 
 class ResolverNameserverValidTypeTestCase(unittest.TestCase):
     def test_set_nameservers_to_list(self):


### PR DESCRIPTION
Fixes #1191 

As far as I can tell the only two ways of getting the search list are using COM or the registry, so I subclassed the registry getter.

Testing with a PR against my fork so I can run actions: https://github.com/blink1073/dnspython/pull/1

- [x] Get it to pass in GitHub Actions
- [x] Get it to pass in PyMongo CI
- [x] Establish how to configure the usage of this getter