### PR TITLE
TSIG fix for make_response()

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1925,7 +1925,7 @@ def make_response(
                 if option.otype == dns.edns.OptionType.PADDING:
                     pad = 468
         response.use_edns(0, 0, our_payload, query.payload, pad=pad)
-    if query.had_tsig:
+    if query.had_tsig and query.keyring:
         assert query.mac is not None
         assert query.keyalgorithm is not None
         response.use_tsig(

--- a/tests/test_tsig.py
+++ b/tests/test_tsig.py
@@ -366,3 +366,15 @@ example. 300 IN SOA . . 1 2 3 4 5
 
     def test_multi_with_pad(self):
         self._test_multi(468)
+
+    def test_make_response_to_unverified(self):
+        # Ensure that we can make a response to an unverified query that
+        # contained a TSIG.
+        q1 = dns.message.make_query("example", "a")
+        q1.use_tsig(keyring, keyname)
+        wire = q1.to_wire()
+
+        q2 = dns.message.from_wire(wire, keyring=False)
+        m = dns.message.make_response(q2)
+
+        self.assertIsNone(m.tsig)


### PR DESCRIPTION
If a query contained a TSIG record that was unverified, attempting to make a response to that query would throw an exception.

This should fix https://github.com/rthalley/dnspython/issues/1205.

