### PR TITLE
Fix: Allow tuple in nameservers type check

### DIFF
--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1190,7 +1190,7 @@ class BaseResolver:
         default_port: int,
     ) -> List[dns.nameserver.Nameserver]:
         enriched_nameservers = []
-        if isinstance(nameservers, list):
+        if isinstance(nameservers, (list,tuple)):
             for nameserver in nameservers:
                 enriched_nameserver: dns.nameserver.Nameserver
                 if isinstance(nameserver, dns.nameserver.Nameserver):


### PR DESCRIPTION
Closes #1234

Assigning a tuple to the resolver.nameservers property causes a ValueError due to a tuple option omitted in the type check. This simple patch solves it