### PR TITLE
docs: Add :py:func:`...` annotations

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -1780,8 +1780,8 @@ def make_query(
     default is ``None``.  If ``None``, EDNS will be enabled only if other
     parameters (*ednsflags*, *payload*, *request_payload*, or *options*) are
     set.
-    See the description of dns.message.Message.use_edns() for the possible
-    values for use_edns and their meanings.
+    See the description of :py:func:`dns.message.Message.use_edns()` for the
+    possible values for use_edns and their meanings.
 
     *want_dnssec*, a ``bool``.  If ``True``, DNSSEC data is desired.
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1360,8 +1360,8 @@ class Resolver(BaseResolver):
 
         This method calls resolve() with ``search=True``, and is
         provided for backwards compatibility with prior versions of
-        dnspython.  See the documentation for the resolve() method for
-        further details.
+        dnspython.  See the documentation for the
+        :py:func:`dns.resolver.Resolver.resolve()` method for further details.
         """
         warnings.warn(
             "please use dns.resolver.Resolver.resolve() instead",
@@ -1596,8 +1596,8 @@ def query(
 
     This method calls resolve() with ``search=True``, and is
     provided for backwards compatibility with prior versions of
-    dnspython.  See the documentation for the resolve() method for
-    further details.
+    dnspython.  See the documentation for the
+    :py:func:`dns.resolver.resolve()` method for further details.
     """
     warnings.warn(
         "please use dns.resolver.resolve() instead", DeprecationWarning, stacklevel=2


### PR DESCRIPTION
I'm not certain this markup is correct, but I tried to model it after other instances.