### PR TITLE
Map exception to rcode

### DIFF
--- a/dns/rcode.py
+++ b/dns/rcode.py
@@ -139,6 +139,29 @@ def to_text(value: Rcode, tsig: bool = False) -> str:
     return Rcode.to_text(value)
 
 
+def from_exception(e: Exception) -> Rcode:
+    """Get rcode for exception"""
+    if isinstance(e, dns.exception.FormError):
+        return Rcode.FORMERR
+    elif isinstance(e, dns.exception.SyntaxError):
+        return Rcode.SERVFAIL
+    elif isinstance(e, dns.exception.UnexpectedEnd):
+        return Rcode.BADTRUNC
+    elif isinstance(e, dns.exception.TooBig):
+        return Rcode.BADTRUNC
+    elif isinstance(e, dns.exception.Timeout):
+        return Rcode.SERVFAIL
+    elif isinstance(e, dns.exception.UnsupportedAlgorithm):
+        return Rcode.BADALG
+    elif isinstance(e, dns.exception.AlgorithmKeyMismatch):
+        return Rcode.BADALG
+    elif isinstance(e, dns.exception.ValidationFailure):
+        return Rcode.SERVFAIL
+    elif isinstance(e, dns.exception.DeniedByPolicy):
+        return Rcode.REFUSED
+    return Rcode.SERVFAIL
+
+
 ### BEGIN generated Rcode constants
 
 NOERROR = Rcode.NOERROR


### PR DESCRIPTION
This makes error handling a lot easier.

I am not sure if it would be better to add a field to each Exception class with the preferred rcode, but this would require all exception modules to import rcode as well.