### PR TITLE
Require the idna module and default to IDNA 2008 Practical

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ If you want to use DNS-over-HTTPS, run
 If you want to use DNSSEC functionality, run
 `pip install dnspython[dnssec]`.
 
-If you want to use internationalized domain names (IDNA)
-functionality, you must run
-`pip install dnspython[idna]`
-
 If you want to use the Trio asynchronous I/O package, run
 `pip install dnspython[trio]`.
 

--- a/dns/rrset.py
+++ b/dns/rrset.py
@@ -199,8 +199,7 @@ def from_text_list(
     the specified list of rdatas in text format.
 
     *idna_codec*, a ``dns.name.IDNACodec``, specifies the IDNA
-    encoder/decoder to use; if ``None``, the default IDNA 2003
-    encoder/decoder is used.
+    encoder/decoder to use; if ``None``, the default encoder/decoder is used.
 
     *origin*, a ``dns.name.Name`` (or ``None``), the
     origin to use for relative names.
@@ -255,8 +254,7 @@ def from_rdata_list(
     the specified list of rdata objects.
 
     *idna_codec*, a ``dns.name.IDNACodec``, specifies the IDNA
-    encoder/decoder to use; if ``None``, the default IDNA 2003
-    encoder/decoder is used.
+    encoder/decoder to use; if ``None``, the default IDNA encoder/decoder is used.
 
     Returns a ``dns.rrset.RRset`` object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "idna>=3.11",
+]
 version = "2.9.0dev0"
 
 [project.optional-dependencies]
@@ -46,7 +48,6 @@ dev = [
 dnssec = ["cryptography>=46"]
 doh = ["httpcore>=1.0.0", "httpx>=0.28.0", "h2>=4.3.0"]
 doq = ["aioquic>=1.3.0"]
-idna = ["idna>=3.11"]
 trio = ["trio>=0.30"]
 wmi = ["wmi>=1.5.1; platform_system=='Windows'"]
 

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -804,14 +804,11 @@ class NameTestCase(unittest.TestCase):
         e = dns.name.from_unicode(t, idna_codec=dns.name.IDNA_2003)
         self.assertEqual(str(e), "xn--knigsgsschen-lcb0w.")
 
-    def testFromUnicodeIDNA2003Default(self):
+    def testFromUnicodeIDNA2008Default(self):
         t = "Königsgäßchen"
         e = dns.name.from_unicode(t)
-        self.assertEqual(str(e), "xn--knigsgsschen-lcb0w.")
+        self.assertEqual(str(e), "xn--knigsgchen-b4a3dun.")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testFromUnicodeIDNA2008(self):
         t = "Königsgäßchen"
 
@@ -826,9 +823,6 @@ class NameTestCase(unittest.TestCase):
         e2 = dns.name.from_unicode(t, idna_codec=c2)
         self.assertEqual(str(e2), "xn--knigsgsschen-lcb0w.")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testFromUnicodeIDNA2008Mixed(self):
         # the IDN rules for names are very restrictive, disallowing
         # practical names like '_sip._tcp.Königsgäßchen'.  Dnspython
@@ -875,18 +869,12 @@ class NameTestCase(unittest.TestCase):
         s = n.to_unicode()
         self.assertEqual(s, "foo.bar.")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testToUnicode4(self):
         n = dns.name.from_text("ドメイン.テスト", idna_codec=dns.name.IDNA_2008)
         s = n.to_unicode()
         self.assertEqual(str(n), "xn--eckwd4c7c.xn--zckzah.")
         self.assertEqual(s, "ドメイン.テスト.")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testToUnicode5(self):
         # Exercise UTS 46 remapping in decode.  This doesn't normally happen
         # as you can see from us having to instantiate the codec as
@@ -895,9 +883,6 @@ class NameTestCase(unittest.TestCase):
         n = dns.name.from_text("xn--gro-7ka.com")
         self.assertEqual(n.to_unicode(idna_codec=codec), "gross.com.")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testToUnicode6(self):
         # Test strict 2008 decoding without UTS 46
         n = dns.name.from_text("xn--gro-7ka.com")
@@ -938,9 +923,6 @@ class NameTestCase(unittest.TestCase):
             dns.name.LabelTooLong, lambda: dns.name.IDNA_2003.encode("x" * 64)
         )
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testIDNA2008Misc(self):
         self.assertEqual(dns.name.IDNA_2008.encode(""), b"")
         self.assertRaises(
@@ -1086,29 +1068,10 @@ class NameTestCase(unittest.TestCase):
         c = dns.name.IDNA_2003_Strict
         self.assertEqual(c.decode(b""), "")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testRootLabel2008StrictDecode(self):
         c = dns.name.IDNA_2008_Strict
         self.assertEqual(c.decode(b""), "")
 
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
-    def testCodecNotFoundRaises(self):
-        dns.name.have_idna_2008 = False
-        with self.assertRaises(dns.name.NoIDNA2008):
-            c = dns.name.IDNA2008Codec()
-            c.encode("Königsgäßchen")
-        with self.assertRaises(dns.name.NoIDNA2008):
-            c = dns.name.IDNA2008Codec(strict_decode=True)
-            c.decode(b"xn--eckwd4c7c.xn--zckzah.")
-        dns.name.have_idna_2008 = True
-
-    @unittest.skipUnless(
-        dns.name.have_idna_2008, "Python idna cannot be imported; no IDNA2008"
-    )
     def testBadPunycodeStrict2008(self):
         c = dns.name.IDNA2008Codec(strict_decode=True)
         with self.assertRaises(dns.name.IDNAException):
@@ -1145,9 +1108,11 @@ class NameTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             del n.labels
 
-    def testUnicodeEscapify(self):
-        n = dns.name.from_unicode("Königsgäßchen;\ttext")
-        self.assertEqual(n.to_unicode(), "königsgässchen\\;\\009text.")
+    def testUnicodeEscapify2003(self):
+        n = dns.name.from_unicode("Königsgäßchen;\ttext", idna_codec=dns.name.IDNA_2003)
+        self.assertEqual(
+            n.to_unicode(idna_codec=dns.name.IDNA_2003), "königsgässchen\\;\\009text."
+        )
 
     def test_pickle(self):
         n1 = dns.name.from_text("foo.example")

--- a/tests/test_rrset.py
+++ b/tests/test_rrset.py
@@ -57,10 +57,20 @@ class RRsetTestCase(unittest.TestCase):
 
     def testCodec2003(self):
         r1 = dns.rrset.from_text_list(
-            "Königsgäßchen", 30, "in", "ns", ["Königsgäßchen"]
+            "Königsgäßchen",
+            30,
+            "in",
+            "ns",
+            ["Königsgäßchen"],
+            idna_codec=dns.name.IDNA_2003,
         )
         r2 = dns.rrset.from_text_list(
-            "xn--knigsgsschen-lcb0w", 30, "in", "ns", ["xn--knigsgsschen-lcb0w"]
+            "xn--knigsgsschen-lcb0w",
+            30,
+            "in",
+            "ns",
+            ["xn--knigsgsschen-lcb0w"],
+            idna_codec=dns.name.IDNA_2003,
         )
         self.assertEqual(r1, r2)
 

--- a/util/uv-dev-setup
+++ b/util/uv-dev-setup
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-uv sync  --extra dnssec --extra doh --extra doq --extra idna --extra trio --extra dev $*
+uv sync  --extra dnssec --extra doh --extra doq --extra trio --extra dev $*


### PR DESCRIPTION
We've lingered on an IDNA 2003 default while supporting 2008 for a long time, but this is no longer appropriate.  The major browsers are all using IDNA 2008, and not in "transitional" (i.e. backwards support for 2003 in some cases) mode.  The proper default would thus seem to be IDNA 2008, but this requires the idna module for the mapping data, so dnspython will have to have a dependency after a long time not having any.

This PR keeps us in "practical" mode, so we won't reject names with capital letters or some all-ASCII labels, e.g. "_sip" as strict mode would require.
