### PR TITLE
fix: limit $GENERATE range to 65535 records

### DIFF
--- a/dns/grange.py
+++ b/dns/grange.py
@@ -66,5 +66,6 @@ def from_text(text: str) -> tuple[int, int, int]:
     assert start >= 0
     if start > stop:
         raise dns.exception.SyntaxError("start must be <= stop")
-
+    if (stop - start) // step > 65535:
+        raise dns.exception.SyntaxError("$GENERATE range too large (max 65535 records)")
     return (start, stop, step)


### PR DESCRIPTION
Previously there was no limit on the $GENERATE range, which could cause excessive CPU and memory usage when parsing zone text from untrusted sources.

Raise SyntaxError when (stop - start) // step > 65535.