### PR TITLE
Render unnamed flag bits in flags.to_text() instead of dropping them

### DIFF
--- a/dns/flags.py
+++ b/dns/flags.py
@@ -54,15 +54,32 @@ def _from_text(text: str, enum_class: Any) -> int:
     flags = 0
     tokens = text.split()
     for t in tokens:
-        flags |= enum_class[t.upper()]
+        token = t.upper()
+        if token.startswith("FLAG") and token[4:].isdigit():
+            # An unnamed flag, rendered by _to_text() as FLAGn (see below).
+            flags |= 1 << int(token[4:])
+        else:
+            flags |= enum_class[token]
     return flags
 
 
 def _to_text(flags: int, enum_class: Any) -> str:
     text_flags = []
+    known = 0
     for k, v in enum_class.__members__.items():
+        known |= int(v)
         if flags & v != 0:
             text_flags.append(k)
+    # Render any set bits that do not have a named flag as FLAGn, where n is
+    # the bit position, so that they are not silently dropped. These tokens
+    # round-trip through _from_text().
+    unknown = flags & ~known
+    bit = 0
+    while unknown:
+        if unknown & 1:
+            text_flags.append(f"FLAG{bit}")
+        unknown >>= 1
+        bit += 1
     return " ".join(text_flags)
 
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,6 +14,11 @@ TBD
   only Python 3" update, also quite some time ago.  It is now renamed to "type"
   (again) so it matches the Python 3 code it is overriding.
 
+* dns.flags.to_text() and dns.flags.edns_to_text() no longer silently drop set
+  bits that have no named flag.  Such bits are now rendered as ``FLAGn``, where n
+  is the bit position, and dns.flags.from_text() / edns_from_text() parse that form
+  back, so the conversions round-trip.  See issue #1264.
+
 2.8.0
 -----
 

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -57,6 +57,23 @@ class FlagsTestCase(unittest.TestCase):
         flags = dns.flags.QR | dns.flags.AA | dns.flags.RD | dns.flags.RA
         self.assertEqual(dns.flags.to_text(flags), "QR AA RD RA")
 
+    def test_to_text_unknown_flag(self):
+        # An unknown flag bit must not be silently dropped (issue #1264).
+        self.assertEqual(dns.flags.to_text(0x8000 | 0x0001), "QR FLAG0")
+
+    def test_edns_to_text_unknown_flag(self):
+        # EDNS flags behave the same: the unnamed 0x2000 bit is rendered.
+        self.assertEqual(dns.flags.edns_to_text(0x2000), "FLAG13")
+        self.assertEqual(dns.flags.edns_to_text(0x8000 | 0x2000), "DO FLAG13")
+
+    def test_unknown_flag_roundtrip(self):
+        for value in [0x0001, 0x8000 | 0x0001, 0x0400 | 0x0008]:
+            self.assertEqual(dns.flags.from_text(dns.flags.to_text(value)), value)
+        for value in [0x2000, 0x8000 | 0x2000, 0x4000 | 0x2000]:
+            self.assertEqual(
+                dns.flags.edns_from_text(dns.flags.edns_to_text(value)), value
+            )
+
     def test_rcode_badvers(self):
         rcode = dns.rcode.BADVERS
         self.assertEqual(rcode.value, 16)


### PR DESCRIPTION
Closes #1264.

`dns.flags.to_text()` and `dns.flags.edns_to_text()` only iterated the named enum members, so any set bit without a named flag was silently dropped. For example, `edns_to_text(0x2000)` returned `''` and `edns_to_text(DO | 0x2000)` returned `'DO'`, hiding the unknown bit.

Unnamed bits are now rendered as `FLAGn`, where n is the bit position, and `from_text()` / `edns_from_text()` parse that form back, so the conversions round-trip:

```python
>>> dns.flags.edns_to_text(0x2000)
'FLAG13'
>>> dns.flags.edns_to_text(dns.flags.DO | 0x2000)
'DO FLAG13'
>>> dns.flags.edns_from_text('DO FLAG13') == (dns.flags.DO | 0x2000)
True
```

This mirrors how dnspython already renders other unknown protocol values (e.g. `TYPEnnnn` for unknown RR types). Tests are added in `tests/test_flags.py` and a `whatsnew` entry is included.

A small design note: I went with `FLAGn` (bit position) for the token. Happy to switch to another representation if you would prefer one, since you mentioned wanting to ponder the format.
