### PR TITLE
Make dns.serial.Serial hashable

### DIFF
--- a/dns/serial.py
+++ b/dns/serial.py
@@ -18,6 +18,12 @@ class Serial:
             return NotImplemented
         return self.value == other.value
 
+    def __hash__(self):
+        # hash(self.value) satisfies the contract that a == b implies
+        # hash(a) == hash(b): Serial(v, bits) compares equal to the int v
+        # (after modular reduction), so its hash must equal hash(v).
+        return hash(self.value)
+
     def __ne__(self, other):
         if isinstance(other, int):
             other = Serial(other, self.bits)

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -126,3 +126,23 @@ class SerialTestCase(unittest.TestCase):
     def test_not_equal(self):
         self.assertNotEqual(S8(0), S8(1))
         self.assertNotEqual(S8(0), S2(0))
+
+    def test_hashable(self):
+        # Serial must be hashable so it can be used in sets and as dict keys.
+        s = S8(42)
+        self.assertEqual(hash(s), hash(42))
+
+        # Equal values hash the same.
+        self.assertEqual(hash(S8(1)), hash(S8(1)))
+
+        # Can be stored in a set.
+        seen = {S8(0), S8(1), S8(2)}
+        self.assertIn(S8(1), seen)
+
+        # Can be used as a dict key.
+        d = {S8(100): "zone-a"}
+        self.assertEqual(d[S8(100)], "zone-a")
+
+        # hash(Serial(v)) == hash(v) (int), satisfying the equality contract.
+        self.assertEqual(hash(S8(0)), hash(0))
+        self.assertEqual(hash(S8(255)), hash(255))


### PR DESCRIPTION
## Problem

`dns.serial.Serial` defines `__eq__` but not `__hash__`.  In Python, when `__eq__` is overridden without providing `__hash__`, Python sets `__hash__ = None`, making instances unhashable:

```python
>>> s = dns.serial.Serial(100)
>>> hash(s)
TypeError: unhashable type: 'Serial'
>>> {s}
TypeError: unhashable type: 'Serial'
>>> {s: "zone-a"}
TypeError: unhashable type: 'Serial'
```

Storing zone serial numbers in a set or using them as dict keys is a natural pattern for callers that track which serials have been seen (e.g. duplicate-detection, caching, or history).  The class is otherwise well-designed for that purpose (RFC 1982 arithmetic, comparison operators), but the missing hash makes it impossible.

## Fix

Add `__hash__` returning `hash(self.value)`.

This satisfies Python's equality contract: `Serial(v, bits)` compares equal to the plain integer `v` (after modular reduction), so `hash(Serial(v, bits))` must equal `hash(v)`.  Two `Serial` objects with the same value but different bit widths will share the same hash (they both equal the same integer), which is permitted — hash collisions are fine.

## After

```python
>>> s = dns.serial.Serial(100)
>>> hash(s)
100
>>> {dns.serial.Serial(0), dns.serial.Serial(1)}
{dns.serial.Serial(0, 32), dns.serial.Serial(1, 32)}
>>> d = {dns.serial.Serial(2024010101): "zone-a"}
>>> d[dns.serial.Serial(2024010101)]
'zone-a'
```

A `test_hashable` test case is added to `tests/test_serial.py`.

---

This pull request was prepared with the assistance of AI, under my direction and review.