### PR TITLE
Raise BadTTL for non-decimal Unicode digits in dns.ttl.from_text()

### DIFF
--- a/dns/ttl.py
+++ b/dns/ttl.py
@@ -42,7 +42,7 @@ def from_text(text: str) -> int:
     :rtype: int
     """
 
-    if text.isdigit():
+    if text.isdecimal():
         total = int(text)
     elif len(text) == 0:
         raise BadTTL
@@ -51,7 +51,7 @@ def from_text(text: str) -> int:
         current = 0
         need_digit = True
         for c in text:
-            if c.isdigit():
+            if c.isdecimal():
                 current *= 10
                 current += int(c)
                 need_digit = False

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -19,6 +19,12 @@ TBD
   is the bit position, and dns.flags.from_text() / edns_from_text() parse that form
   back, so the conversions round-trip.  See issue #1264.
 
+* dns.ttl.from_text() now raises dns.ttl.BadTTL, rather than leaking a bare
+  ValueError, when the text contains a non-decimal Unicode "digit" (e.g. the
+  superscript ``\u00b2``).  Such characters are accepted by ``str.isdigit()`` but
+  rejected by ``int()``, so they previously escaped the parser's validation.  This
+  also makes zone files with such a TTL fail with a clean dns.exception.SyntaxError.
+
 2.8.0
 -----
 

--- a/tests/test_ttl.py
+++ b/tests/test_ttl.py
@@ -42,3 +42,12 @@ class TTLTestCase(unittest.TestCase):
     def test_empty(self):
         with self.assertRaises(dns.ttl.BadTTL):
             dns.ttl.from_text("")
+
+    def test_non_decimal_unicode_digits(self):
+        # str.isdigit() is True for Unicode "digit" characters (e.g. the
+        # superscript "\u00b2" or the Ethiopic "\u1369") that int() cannot
+        # convert, so these must be rejected as a BadTTL rather than leaking a
+        # bare ValueError.
+        for text in ("\u00b2", "1\u00b2", "\u00b2w", "1\u00b2s", "\u1369"):
+            with self.assertRaises(dns.ttl.BadTTL):
+                dns.ttl.from_text(text)


### PR DESCRIPTION
## What

`dns.ttl.from_text()` raises a bare `ValueError` instead of the documented `dns.ttl.BadTTL` when the text contains a non-decimal Unicode "digit". This also leaks out of the public zone-file parser as a raw `ValueError` rather than a clean `dns.exception.SyntaxError`.

## Root cause

`from_text()` gates its integer parsing on `str.isdigit()` and then calls `int()`:

```python
if text.isdigit():
    total = int(text)
...
    for c in text:
        if c.isdigit():
            current *= 10
            current += int(c)
```

`str.isdigit()` returns `True` for Unicode characters in category **No** (e.g. the superscript `²` U+00B2, or the Ethiopic digit `፩` U+1369), but `int()` only accepts decimal digits. So such input passes the `isdigit()` gate and then blows up inside `int()` with a bare `ValueError`, escaping the parser's own validation.

The function's docstring explicitly promises `:raises dns.ttl.BadTTL:`, so this is a contract violation.

### Before (on `main`)

```pycon
>>> import dns.ttl, dns.zone
>>> dns.ttl.from_text("\u00b2")
ValueError: invalid literal for int() with base 10: '²'
>>> dns.zone.from_text("@ 3\u00b2 IN A 1.2.3.4\n", origin="example.")
ValueError: invalid literal for int() with base 10: '3²'
>>> dns.zone.from_text("$TTL 1\u00b2\n@ IN A 1.2.3.4\n", origin="example.")
ValueError: invalid literal for int() with base 10: '1²'
```

### After

```pycon
>>> dns.ttl.from_text("\u00b2")
dns.ttl.BadTTL
>>> dns.zone.from_text("@ 3\u00b2 IN A 1.2.3.4\n", origin="example.")
dns.exception.SyntaxError: ...
```

## Fix

Switch both `isdigit()` checks to `isdecimal()`.

This is exactly behaviour-preserving for every valid TTL. For a single character, `int()`-acceptance is *identical* to `str.isdecimal()`, and `isdecimal()` is a strict subset of `isdigit()`:

```pycon
# int()-acceptance != isdecimal(): 0 chars over the whole Unicode range
# isdecimal-but-not-isdigit chars: 0
```

So no previously valid TTL is rejected; only the non-decimal "digits" that already crashed are now cleanly reported as `BadTTL`.

## Tests

Added `test_non_decimal_unicode_digits`, covering both the all-digit fast path and the BIND-style units path (`"\u00b2"`, `"1\u00b2"`, `"\u00b2w"`, `"1\u00b2s"`, `"\u1369"`).

Proven to guard the bug (stash only the source fix, keep the test):

```
# without the fix:
FAILED tests/test_ttl.py::TTLTestCase::test_non_decimal_unicode_digits
  ValueError: invalid literal for int() with base 10: '²'  (dns/ttl.py:46)
# with the fix:
1 passed
```

## Verification

- `tests/test_ttl.py`: 10 passed
- `tests/test_zone.py tests/test_tokenizer.py`: 169 passed
- Full suite: 1281 passed, 118 skipped (the single `test_basic_getaddrinfo` failure is a pre-existing environment artifact — the local system resolver returns IPv4-mapped IPv6 for `dns.google` — present on `main` before this change, unrelated to it).
- `ruff check`, `ruff format --check`, `black --check` clean on the changed files.

Diff is `+17 / −2` across `dns/ttl.py`, `tests/test_ttl.py`, and a `doc/whatsnew.rst` bullet.
