### PR TITLE
Don't compress or downcase the FQDN in LP rdata

### DIFF
--- a/dns/rdtypes/ANY/LP.py
+++ b/dns/rdtypes/ANY/LP.py
@@ -33,7 +33,10 @@ class LP(dns.rdata.Rdata):
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         file.write(struct.pack("!H", self.preference))
-        self.fqdn.to_wire(file, compress, origin, canonicalize)
+        # LP is not an RFC 1035 type, so per RFC 3597 section 4 its FQDN is
+        # never compressed, and per RFC 4034 section 6.2 (as amended by RFC
+        # 6840 section 5.1) it is not downcased for the canonical form.
+        self.fqdn.to_wire(file, None, origin, False)
 
     @classmethod
     def from_wire_parser(cls, rdclass, rdtype, parser, origin=None):

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -34,6 +34,7 @@ import dns.rdtypes.IN.A
 import dns.rdtypes.IN.AAAA
 import dns.rdtypes.IN.APL
 import dns.rdtypes.util
+import dns.rrset
 import dns.tokenizer
 import dns.ttl
 import dns.wire
@@ -1015,6 +1016,21 @@ class UtilTestCase(unittest.TestCase):
     def test_compressed_in_generic_is_bad(self):
         with self.assertRaises(dns.exception.SyntaxError):
             dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.MX, r"\# 4 000aC000")
+
+    def test_LP_name_not_compressed(self):
+        # RFC 3597 section 4 requires that domain names in the RDATA of RR
+        # types not defined in RFC 1035 MUST NOT be compressed.  LP (RFC 6742)
+        # is such a type, so its FQDN must be emitted uncompressed.  The
+        # owner and FQDN differ only in case (name compression is
+        # case-insensitive) so a full label proves both that the name was
+        # not compressed and that its case was preserved.
+        rrs = dns.rrset.from_text("elsewhere.", 300, "in", "lp", "10 elseWhere.")
+        output = io.BytesIO()
+        compress = {}
+        rrs.to_wire(output, compress)
+        wire = output.getvalue()
+        self.assertFalse(wire.endswith(b"\xc0\x00"))
+        self.assertTrue(wire.endswith(b"\x09elseWhere\x00"))
 
     def test_rdataset_ttl_conversion(self):
         rds1 = dns.rdataset.from_text("in", "a", 300, "10.0.0.1")


### PR DESCRIPTION
`LP._to_wire` (`dns/rdtypes/ANY/LP.py`) forwards the message compression table and the canonicalize flag to its embedded FQDN:

```python
self.fqdn.to_wire(file, compress, origin, canonicalize)
```

So an LP record's name gets **name-compressed** on the wire and **downcased** in the DNSSEC canonical form. Both are wrong for LP (RFC 6742), which is not an RFC 1035 type:

- **RFC 3597 §4**: names embedded in the RDATA of non-RFC-1035 types MUST NOT be compressed; new RR types MUST NOT allow name compression.
- **RFC 4034 §6.2**, as amended by **RFC 6840 §5.1** (the downcasing list only ever shrinks): LP is not on the list, so its name is not downcased in the canonical form.

Every other modern name-bearing type in dnspython (`DSYNC`, `SVCB`/`HTTPS`, `HIP`, `IPSECKEY`, `NSEC`) already uses `to_wire(file, None, origin, False)`. LP is the lone outlier — it was written from the `MX` template, where compression is grandfathered.

```
# owner "elsewhere." + LP "10 elseWhere." (case-insensitive compression):
before: 000a c000              # preference + a compression pointer
after:  000a 09elseWhere00     # full, uncompressed, case preserved

# to_digestable() of "LP 10 L64.EXAMPLE.":
before: ...l64...   (downcased)
after:  ...L64...   (preserved, like the sibling DSYNC)
```

**Fix**: use the same idiom as the sibling types — `to_wire(file, None, origin, False)`.

**Verification** (re-runnable from the diff): added `test_LP_name_not_compressed` in `tests/test_rdata.py`, modeled on the existing `test_svcb.py::test_alias_not_compressed`; it fails on the current tree and passes with the fix. `tests/test_rdata.py` + `tests/test_wire.py` → 108 passed; the wider suite is green apart from an unrelated offline live-network test.

*(Left out of this PR: `DNAME`/`UncompressedNS` does not downcase even though DNAME is on the RFC 4034 list — but that's arguably intentional (RFC 6672) and debated, so I scoped this to the clear-cut LP case.)*

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
