### PR TITLE
Apply character-string escapes as bytes in URI, HINFO, X25, ISDN, NAPTR, and CAA

### DIFF
--- a/dns/rdtypes/ANY/CAA.py
+++ b/dns/rdtypes/ANY/CAA.py
@@ -47,8 +47,8 @@ class CAA(dns.rdata.Rdata):
         cls, rdclass, rdtype, tok, origin=None, relativize=True, relativize_to=None
     ) -> "CAA":
         flags = tok.get_uint8()
-        tag = tok.get_string().encode()
-        value = tok.get_string().encode()
+        tag = tok.get_bytes(max_length=255)
+        value = tok.get_bytes()
         return cls(rdclass, rdtype, flags, tag, value)
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):

--- a/dns/rdtypes/ANY/HINFO.py
+++ b/dns/rdtypes/ANY/HINFO.py
@@ -43,8 +43,8 @@ class HINFO(dns.rdata.Rdata):
     def from_text(
         cls, rdclass, rdtype, tok, origin=None, relativize=True, relativize_to=None
     ):
-        cpu = tok.get_string(max_length=255)
-        os = tok.get_string(max_length=255)
+        cpu = tok.get_bytes(max_length=255)
+        os = tok.get_bytes(max_length=255)
         return cls(rdclass, rdtype, cpu, os)
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):

--- a/dns/rdtypes/ANY/ISDN.py
+++ b/dns/rdtypes/ANY/ISDN.py
@@ -49,12 +49,12 @@ class ISDN(dns.rdata.Rdata):
     def from_text(
         cls, rdclass, rdtype, tok, origin=None, relativize=True, relativize_to=None
     ):
-        address = tok.get_string()
+        address = tok.get_bytes(max_length=255)
         tokens = tok.get_remaining(max_tokens=1)
         if len(tokens) >= 1:
-            subaddress = tokens[0].unescape().value
+            subaddress = tokens[0].unescape_to_bytes().value
         else:
-            subaddress = ""
+            subaddress = b""
         return cls(rdclass, rdtype, address, subaddress)
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):

--- a/dns/rdtypes/ANY/URI.py
+++ b/dns/rdtypes/ANY/URI.py
@@ -42,7 +42,7 @@ class URI(dns.rdata.Rdata):
             raise dns.exception.SyntaxError("URI target cannot be empty")
 
     def to_styled_text(self, style: dns.rdata.RdataStyle) -> str:
-        return f'{self.priority} {self.weight} "{self.target.decode()}"'
+        return f'{self.priority} {self.weight} "{dns.rdata._escapify(self.target)}"'
 
     @classmethod
     def from_text(
@@ -50,10 +50,8 @@ class URI(dns.rdata.Rdata):
     ):
         priority = tok.get_uint16()
         weight = tok.get_uint16()
-        target = tok.get().unescape()
-        if not (target.is_quoted_string() or target.is_identifier()):
-            raise dns.exception.SyntaxError("URI target must be a string")
-        return cls(rdclass, rdtype, priority, weight, target.value)
+        target = tok.get_bytes()
+        return cls(rdclass, rdtype, priority, weight, target)
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):
         two_ints = struct.pack("!HH", self.priority, self.weight)

--- a/dns/rdtypes/ANY/X25.py
+++ b/dns/rdtypes/ANY/X25.py
@@ -42,7 +42,7 @@ class X25(dns.rdata.Rdata):
     def from_text(
         cls, rdclass, rdtype, tok, origin=None, relativize=True, relativize_to=None
     ):
-        address = tok.get_string()
+        address = tok.get_bytes(max_length=255)
         return cls(rdclass, rdtype, address)
 
     def _to_wire(self, file, compress=None, origin=None, canonicalize=False):

--- a/dns/rdtypes/IN/NAPTR.py
+++ b/dns/rdtypes/IN/NAPTR.py
@@ -66,9 +66,9 @@ class NAPTR(dns.rdata.Rdata):
     ):
         order = tok.get_uint16()
         preference = tok.get_uint16()
-        flags = tok.get_string()
-        service = tok.get_string()
-        regexp = tok.get_string()
+        flags = tok.get_bytes(max_length=255)
+        service = tok.get_bytes(max_length=255)
+        regexp = tok.get_bytes(max_length=255)
         replacement = tok.get_name(origin, relativize, relativize_to)
         return cls(
             rdclass, rdtype, order, preference, flags, service, regexp, replacement

--- a/dns/tokenizer.py
+++ b/dns/tokenizer.py
@@ -549,6 +549,19 @@ class Tokenizer:
 
         return self.as_string(self.get().unescape(), max_length)
 
+    def get_bytes(self, max_length: int | None = None) -> bytes:
+        """Read the next token and interpret it as a byte string,
+        applying any DNS escapes directly to bytes.
+
+        Raises dns.exception.SyntaxError if not a string.
+        Raises dns.exception.SyntaxError if the byte length
+        exceeds max_length (if specified).
+
+        Returns bytes.
+        """
+
+        return self.as_bytes(self.get().unescape_to_bytes(), max_length)
+
     def get_identifier(self) -> str:
         """Read the next token, which should be an identifier.
 
@@ -717,6 +730,25 @@ class Tokenizer:
         if max_length and len(token.value) > max_length:
             raise dns.exception.SyntaxError("string too long")
         return token.value
+
+    def as_bytes(self, token: Token, max_length: int | None = None) -> bytes:
+        """Try to interpret the token as a byte string.
+
+        Raises dns.exception.SyntaxError if not a string.
+        Raises dns.exception.SyntaxError if the byte length
+        exceeds max_length (if specified).
+
+        Returns bytes.
+        """
+
+        if not (token.is_identifier() or token.is_quoted_string()):
+            raise dns.exception.SyntaxError("expecting a string")
+        value = token.value
+        if isinstance(value, str):
+            value = value.encode()
+        if max_length and len(value) > max_length:
+            raise dns.exception.SyntaxError("string too long")
+        return value
 
     def as_identifier(self, token: Token) -> str:
         """Try to interpret the token as an identifier.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,15 @@ TBD
   so the output did not parse back to the original value.  Such bytes are now
   escaped once, at the character-string level.
 
+* Rdata types with free-form string fields (URI, HINFO, X25, ISDN, NAPTR, and
+  CAA) processed ``\ddd`` escapes as Unicode code points and then UTF-8 encoded
+  them, so escapes greater than ``\127`` became two octets instead of one.  URI
+  also emitted its target unescaped in to_text(), raising UnicodeDecodeError
+  for wire-legal non-UTF-8 targets and corrupting backslashes and quotes on a
+  round trip.  These fields now apply escapes directly to bytes, like TXT-like
+  records, using the new Tokenizer.get_bytes(), and URI escapes its target on
+  output, so from_text(to_text()) is the identity for all octet values.
+
 2.8.0
 -----
 

--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -181,6 +181,58 @@ class RdataTestCase(unittest.TestCase):
         )
         self.assertEqual(str(rdata), '"foo\\226\\128\\139{bar"')
 
+    def test_uri_to_text_escapes_target(self):
+        # A URI target from the wire may contain arbitrary octets, so
+        # to_text() must escape them rather than raise UnicodeDecodeError.
+        wire = bytes.fromhex("000a000168747470ff")
+        rdata = dns.rdata.from_wire("in", "uri", wire, 0, len(wire))
+        self.assertEqual(rdata.target, b"http\xff")
+        self.assertEqual(rdata.to_text(), '10 1 "http\\255"')
+
+    def test_uri_escape_roundtrip(self):
+        # from_text() unescapes the target, so to_text() must escape it,
+        # or backslashes and quotes are corrupted on a round trip.
+        text = '10 1 "http://example/a\\\\b\\"c\\255"'
+        rdata = dns.rdata.from_text("in", "uri", text)
+        self.assertEqual(rdata.target, b'http://example/a\\b"c\xff')
+        self.assertEqual(rdata.to_text(), text)
+
+    def test_uri_escape_not_double_encoded(self):
+        # \255 is the single octet 0xff on the wire, not UTF-8 0xc3 0xbf.
+        rdata = dns.rdata.from_text("in", "uri", '10 1 "http://x/\\255"')
+        self.assertEqual(rdata.to_wire()[4:], b"http://x/\xff")
+
+    def test_character_string_escape_roundtrip_all_octets(self):
+        # For rdtypes with free-form string fields, \DDD parses to octet
+        # DDD (RFC 1035 5.1) and from_text(to_text()) is the identity.
+        cases = [
+            ("uri", '10 1 "x{}"', lambda r: r.target),
+            ("hinfo", '"x{}" "os"', lambda r: r.cpu),
+            ("x25", '"x{}"', lambda r: r.address),
+            ("isdn", '"x{}" "004"', lambda r: r.address),
+            ("naptr", '10 10 "x{}" "s" "r" .', lambda r: r.flags),
+            ("caa", '0 issue "x{}"', lambda r: r.value),
+            ("txt", '"x{}"', lambda r: r.strings[0]),
+        ]
+        for value in range(256):
+            expected = b"x" + bytes([value])
+            for rdtype, template, field in cases:
+                text = template.format(f"\\{value:03d}")
+                rdata = dns.rdata.from_text("in", rdtype, text)
+                self.assertEqual(field(rdata), expected)
+                again = dns.rdata.from_text("in", rdtype, rdata.to_text())
+                self.assertEqual(again, rdata)
+
+    def test_isdn_subaddress_escape(self):
+        rdata = dns.rdata.from_text("in", "isdn", '"150862028003217" "\\255"')
+        self.assertEqual(rdata.subaddress, b"\xff")
+        self.assertEqual(rdata, dns.rdata.from_text("in", "isdn", rdata.to_text()))
+
+    def test_bad_HINFO_text(self):
+        # string too long
+        with self.assertRaises(dns.exception.SyntaxError):
+            dns.rdata.from_text("in", "hinfo", '"' + "a" * 256 + '" "os"')
+
     def test_unicode_idna2003_in_rdata(self):
         rdata = dns.rdata.from_text(
             dns.rdataclass.IN,

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -259,6 +259,30 @@ class TokenizerTestCase(unittest.TestCase):
         with self.assertRaises(dns.exception.SyntaxError):
             tok.get_string()
 
+    def testGetBytes(self):
+        tok = dns.tokenizer.Tokenizer("foo")
+        v = tok.get_bytes()
+        self.assertEqual(v, b"foo")
+        tok = dns.tokenizer.Tokenizer('"foo\\255"')
+        v = tok.get_bytes()
+        self.assertEqual(v, b"foo\xff")
+        tok = dns.tokenizer.Tokenizer('"foo\u200bbar"')
+        v = tok.get_bytes()
+        self.assertEqual(v, b"foo\xe2\x80\x8bbar")
+        tok = dns.tokenizer.Tokenizer("abcdefghij")
+        v = tok.get_bytes(max_length=10)
+        self.assertEqual(v, b"abcdefghij")
+        with self.assertRaises(dns.exception.SyntaxError):
+            tok = dns.tokenizer.Tokenizer("abcdefghij")
+            tok.get_bytes(max_length=9)
+        with self.assertRaises(dns.exception.SyntaxError):
+            # the limit is on the byte length, not the character length
+            tok = dns.tokenizer.Tokenizer('"\u200b"')
+            tok.get_bytes(max_length=2)
+        tok = dns.tokenizer.Tokenizer("")
+        with self.assertRaises(dns.exception.SyntaxError):
+            tok.get_bytes()
+
     def testMultiLineWithComment(self):
         tok = dns.tokenizer.Tokenizer("( ; abc\n)")
         tok.get_eol()


### PR DESCRIPTION
URI records crash on printing when the wire target is not valid UTF-8, and silently corrupt backslashes and quotes on a text round trip, because `to_text()` emits the raw target with a bare `.decode()` while `from_text()` unescapes:

```
>>> dns.rdata.from_wire("in", "uri", bytes.fromhex("0001000168747470ff"), 0, 9).to_text()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 4
```

Auditing the other free-form string fields: HINFO, X25, ISDN, NAPTR, and CAA escape correctly on output but still parse `\ddd` through the str-based `unescape()`, so `\255` becomes the two octets `c3 bf` instead of `ff` — the same double-encoding #321 fixed for TXT-like records with `unescape_to_bytes()`, which never reached these types. BIND round-trips `\255` in these fields as a single octet.

This adds `Tokenizer.get_bytes()`/`as_bytes()` (bytes counterpart of `get_string()`, built on `unescape_to_bytes()`, with the length limit measured in bytes) and uses it for these fields, and `URI.to_styled_text()` now escapes the target with `_escapify` like its siblings. Tests cover the URI crash and round-trip repros, plus `\ddd` -> octet and `from_text(to_text())` identity over all 256 octet values for all six types and TXT. Full pytest suite passes locally; ruff and pyright clean.
