### PR TITLE
Bring async zone_for_name in line with the sync one

### DIFF
--- a/dns/asyncresolver.py
+++ b/dns/asyncresolver.py
@@ -368,6 +368,7 @@ async def zone_for_name(
     tcp: bool = False,
     resolver: Resolver | None = None,
     backend: dns.asyncbackend.Backend | None = None,
+    lifetime: float | None = None,
 ) -> dns.name.Name:
     """Find the name of the zone which contains the specified name.
 
@@ -381,17 +382,52 @@ async def zone_for_name(
         resolver = get_default_resolver()
     if not name.is_absolute():
         raise NotAbsolute(name)
+    start = time.time()
+    expiration: float | None
+    if lifetime is not None:
+        expiration = start + lifetime
+    else:
+        expiration = None
     while True:
         try:
+            rlifetime: float | None
+            if expiration is not None:
+                rlifetime = expiration - time.time()
+                if rlifetime <= 0:
+                    rlifetime = 0
+            else:
+                rlifetime = None
             answer = await resolver.resolve(
-                name, dns.rdatatype.SOA, rdclass, tcp, backend=backend
+                name,
+                dns.rdatatype.SOA,
+                rdclass,
+                tcp,
+                lifetime=rlifetime,
+                backend=backend,
             )
             assert answer.rrset is not None
             if answer.rrset.name == name:
                 return name
             # otherwise we were CNAMEd or DNAMEd and need to look higher
-        except (NXDOMAIN, NoAnswer):
-            pass
+        except (NXDOMAIN, NoAnswer) as e:
+            if isinstance(e, NXDOMAIN):
+                response = e.responses().get(name)
+            else:
+                response = e.response()  # pylint: disable=no-value-for-parameter
+            if response:
+                for rrs in response.authority:
+                    if rrs.rdtype == dns.rdatatype.SOA and rrs.rdclass == rdclass:
+                        nr, _, _ = rrs.name.fullcompare(name)
+                        if nr == dns.name.NAMERELN_SUPERDOMAIN:
+                            # We're doing a proper superdomain check as
+                            # if the name were equal we ought to have gotten
+                            # it in the answer section!  We are ignoring the
+                            # possibility that the authority is insane and
+                            # is including multiple SOA RRs for different
+                            # authorities.
+                            return rrs.name
+            # we couldn't extract anything useful from the response (e.g. it's
+            # a type 3 NXDOMAIN)
         try:
             name = name.parent()
         except dns.name.NoParent:  # pragma: no cover

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -15,6 +15,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import asyncio
 import selectors
 import socket
 import sys
@@ -26,6 +27,7 @@ from unittest.mock import patch
 import dns.win32util
 import pytest
 
+import dns.asyncresolver
 import dns.e164
 import dns.message
 import dns.name
@@ -1249,3 +1251,41 @@ def testZoneForNameLifetimeTimeout():
             dns.resolver.zone_for_name(
                 "1.2.3.4.5.6.7.8.9.10.example.", resolver=res, lifetime=1.0
             )
+
+
+@pytest.mark.skipif(
+    not (tests.util.is_internet_reachable() and _nanonameserver_available),
+    reason="Internet and NanoAuth required",
+)
+def testAsyncZoneForNameLifetimeTimeout():
+    with SlowAlwaysType3NXDOMAINNanoNameserver() as na:
+        res = dns.asyncresolver.Resolver(configure=False)
+        res.port = na.udp_address[1]
+        res.nameservers = [na.udp_address[0]]
+
+        async def run():
+            return await dns.asyncresolver.zone_for_name(
+                "1.2.3.4.5.6.7.8.9.10.example.", resolver=res, lifetime=1.0
+            )
+
+        with pytest.raises(dns.resolver.LifetimeTimeout):
+            asyncio.run(run())
+
+
+@pytest.mark.skipif(
+    not (tests.util.is_internet_reachable() and _nanonameserver_available),
+    reason="Internet and NanoAuth required",
+)
+def testAsyncHelpfulNXDOMAIN():
+    # the SOA in the authority section should short-circuit the walk up the tree
+    with AlwaysNXDOMAINNanoNameserver() as na:
+        res = dns.asyncresolver.Resolver(configure=False)
+        res.port = na.udp_address[1]
+        res.nameservers = [na.udp_address[0]]
+
+        async def run():
+            return await dns.asyncresolver.zone_for_name(
+                "1.2.3.4.5.6.7.8.9.10.example.", resolver=res
+            )
+
+        assert asyncio.run(run()) == dns.name.from_text("example.")


### PR DESCRIPTION
#673 gave `dns.resolver.zone_for_name` a `lifetime` parameter and taught it to use an SOA in the authority section of a negative response. It only touched `resolver.py`, so `dns.asyncresolver.zone_for_name` still has neither, and its docstring points readers at the sync one "for more information on the parameters".

The authority-section part changes the answer. Against a server that returns type 3 NXDOMAIN, the sync version reads the SOA and returns `example.`, while the async one walks to the root and raises `NoRootSOA`. Same query, same server. Different answer.

The missing `lifetime` means an async caller has no way to bound the total walk. Each query still has its own timeout, but a deep name (an IPv6 reverse name, say) can issue a lot of them. `asyncresolver` threads `lifetime` everywhere else, including its own module-level `resolve`, so `zone_for_name` is the only place it stopped.

This ports both halves, keeping the sync code's structure so the two read the same. They are separable if you would rather take only the `lifetime` half.

Two tests next to the sync ones, both using the existing nano nameservers. `testAsyncHelpfulNXDOMAIN` fails with `NoRootSOA` without the change, and `testAsyncZoneForNameLifetimeTimeout` fails with a `TypeError` on the missing keyword, so each covers its own half.

Suite goes 1343 to 1345. The 3 failures are the same before and after (`test_name.py::testToUnicode5`, two in `test_resolver_override.py`). `black` is clean, and `ruff` reports the same 40 findings either way, none in the lines I touched.
