### PR TITLE
Support Path in addition to str when dealing with file paths

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Nicki Křížek <nicki@isc.org> <tomas.krizek@mailbox.org>
+Nicki Křížek <nicki@isc.org> <tomas.krizek@nic.cz>

--- a/dns/_file_util.py
+++ b/dns/_file_util.py
@@ -1,12 +1,13 @@
 # Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
 
 import contextlib
+import os
 from typing import Any
 
 
 def as_filename(f: Any) -> str | None:
-    if isinstance(f, str):
-        return f
+    if isinstance(f, (str, os.PathLike)):
+        return os.fsdecode(f)
     return None
 
 

--- a/dns/_file_util.py
+++ b/dns/_file_util.py
@@ -2,19 +2,20 @@
 
 import contextlib
 import os
-from typing import Any
+from typing import IO, Any, cast
 
 
-def as_filename(f: Any) -> str | None:
+def as_filename(f: object) -> str | None:
     if isinstance(f, (str, os.PathLike)):
         return os.fsdecode(f)
     return None
 
 
 def maybe_open(
-    f: Any, mode: str = "r", encoding: str | None = None
-) -> contextlib.AbstractContextManager:
+    f: str | os.PathLike | IO[Any], mode: str = "r", encoding: str | None = None
+) -> contextlib.AbstractContextManager[IO[Any]]:
     filename = as_filename(f)
     if filename is not None:
         return open(filename, mode, encoding=encoding)
-    return contextlib.nullcontext(f)
+    # as_filename() is not a type guard, so narrow f by hand
+    return contextlib.nullcontext(cast(IO[Any], f))

--- a/dns/_file_util.py
+++ b/dns/_file_util.py
@@ -1,0 +1,19 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+import contextlib
+from typing import Any
+
+
+def as_filename(f: Any) -> str | None:
+    if isinstance(f, str):
+        return f
+    return None
+
+
+def maybe_open(
+    f: Any, mode: str = "r", encoding: str | None = None
+) -> contextlib.AbstractContextManager:
+    filename = as_filename(f)
+    if filename is not None:
+        return open(filename, mode, encoding=encoding)
+    return contextlib.nullcontext(f)

--- a/dns/_tls_util.py
+++ b/dns/_tls_util.py
@@ -2,17 +2,20 @@
 
 import os
 
+import dns._file_util
+
 
 def convert_verify_to_cafile_and_capath(
-    verify: bool | str,
+    verify: bool | str | os.PathLike,
 ) -> tuple[str | None, str | None]:
     cafile: str | None = None
     capath: str | None = None
-    if isinstance(verify, str):
-        if os.path.isfile(verify):
-            cafile = verify
-        elif os.path.isdir(verify):
-            capath = verify
+    filename = dns._file_util.as_filename(verify)
+    if filename is not None:
+        if os.path.isfile(filename):
+            cafile = filename
+        elif os.path.isdir(filename):
+            capath = filename
         else:
             raise ValueError("invalid verify string")
     return cafile, capath

--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -19,6 +19,7 @@
 
 import base64
 import contextlib
+import os
 import random
 import socket
 import struct
@@ -26,6 +27,7 @@ import time
 import urllib.parse
 from typing import Any, cast
 
+import dns._file_util
 import dns.asyncbackend
 import dns.exception
 import dns.inet
@@ -461,7 +463,7 @@ async def tls(
     backend: dns.asyncbackend.Backend | None = None,
     ssl_context: ssl.SSLContext | None = None,
     server_hostname: str | None = None,
-    verify: bool | str = True,
+    verify: bool | str | os.PathLike = True,
 ) -> dns.message.Message:
     """Return the response obtained after sending a query via TLS.
 
@@ -543,7 +545,7 @@ async def https(
     client: "httpx2.AsyncClient|dns.quic.AsyncQuicConnection | None" = None,
     path: str = "/dns-query",
     post: bool = True,
-    verify: bool | str | ssl.SSLContext = True,
+    verify: bool | str | os.PathLike | ssl.SSLContext = True,
     bootstrap_address: str | None = None,
     resolver: "dns.asyncresolver.Resolver | None" = None,  # pyright: ignore
     family: int = socket.AF_UNSPEC,
@@ -560,6 +562,9 @@ async def https(
     parameters, exceptions, and return type of this method.
     """
 
+    verify_filename = dns._file_util.as_filename(verify)
+    if verify_filename is not None:
+        verify = verify_filename
     try:
         af = dns.inet.af_for_address(where)
     except ValueError:
@@ -716,7 +721,7 @@ async def _http3(
     source_port: int = 0,
     one_rr_per_rrset: bool = False,
     ignore_trailing: bool = False,
-    verify: bool | str | ssl.SSLContext = True,
+    verify: bool | str | os.PathLike | ssl.SSLContext = True,
     backend: dns.asyncbackend.Backend | None = None,
     post: bool = True,
     connection: dns.quic.AsyncQuicConnection | None = None,
@@ -780,7 +785,7 @@ async def quic(
     one_rr_per_rrset: bool = False,
     ignore_trailing: bool = False,
     connection: dns.quic.AsyncQuicConnection | None = None,
-    verify: bool | str = True,
+    verify: bool | str | os.PathLike = True,
     backend: dns.asyncbackend.Backend | None = None,
     hostname: str | None = None,
     server_hostname: str | None = None,

--- a/dns/message.py
+++ b/dns/message.py
@@ -1665,7 +1665,8 @@ def from_file(
 
     Message blocks are separated by a single blank line.
 
-    :param f: A file object or a pathname string.
+    :param f: A file object, or the name of a file to open, as a ``str``
+        or an ``os.PathLike``.
     :param idna_codec: The IDNA encoder/decoder. Defaults to IDNA 2003.
     :type idna_codec: :py:class:`dns.name.IDNACodec` or ``None``
     :param one_rr_per_rrset: If ``True``, put each RR into its own RRset.

--- a/dns/message.py
+++ b/dns/message.py
@@ -20,8 +20,9 @@
 import dataclasses
 import enum
 import io
+import os
 import time
-from typing import Any, cast
+from typing import Any, TextIO, cast
 
 import dns._file_util
 import dns.edns
@@ -1657,7 +1658,7 @@ def from_text(
 
 
 def from_file(
-    f: Any,
+    f: str | os.PathLike | TextIO,
     idna_codec: dns.name.IDNACodec | None = None,
     one_rr_per_rrset: bool = False,
 ) -> Message:
@@ -1676,8 +1677,8 @@ def from_file(
     :rtype: :py:class:`dns.message.Message`
     """
 
-    with dns._file_util.maybe_open(f, encoding="utf-8") as f:
-        reader = _TextReader(f, idna_codec, one_rr_per_rrset)
+    with dns._file_util.maybe_open(f, encoding="utf-8") as fp:
+        reader = _TextReader(fp, idna_codec, one_rr_per_rrset)
         return reader.read()
     assert False  # for mypy  lgtm[py/unreachable-statement]
 

--- a/dns/message.py
+++ b/dns/message.py
@@ -17,13 +17,13 @@
 
 """DNS Messages"""
 
-import contextlib
 import dataclasses
 import enum
 import io
 import time
 from typing import Any, cast
 
+import dns._file_util
 import dns.edns
 import dns.entropy
 import dns.enum
@@ -1675,11 +1675,7 @@ def from_file(
     :rtype: :py:class:`dns.message.Message`
     """
 
-    if isinstance(f, str):
-        cm: contextlib.AbstractContextManager = open(f, encoding="utf-8")
-    else:
-        cm = contextlib.nullcontext(f)
-    with cm as f:
+    with dns._file_util.maybe_open(f, encoding="utf-8") as f:
         reader = _TextReader(f, idna_codec, one_rr_per_rrset)
         return reader.read()
     assert False  # for mypy  lgtm[py/unreachable-statement]

--- a/dns/nameserver.py
+++ b/dns/nameserver.py
@@ -1,3 +1,4 @@
+import os
 from urllib.parse import urlparse
 
 import dns.asyncbackend
@@ -164,7 +165,7 @@ class DoHNameserver(Nameserver):
         self,
         url: str,
         bootstrap_address: str | None = None,
-        verify: bool | str = True,
+        verify: bool | str | os.PathLike = True,
         want_get: bool = False,
         http_version: dns.query.HTTPVersion = dns.query.HTTPVersion.DEFAULT,
     ):
@@ -249,7 +250,7 @@ class DoTNameserver(AddressAndPortNameserver):
         address: str,
         port: int = 853,
         hostname: str | None = None,
-        verify: bool | str = True,
+        verify: bool | str | os.PathLike = True,
     ):
         super().__init__(address, port)
         self.hostname = hostname
@@ -307,7 +308,7 @@ class DoQNameserver(AddressAndPortNameserver):
         self,
         address: str,
         port: int = 853,
-        verify: bool | str = True,
+        verify: bool | str | os.PathLike = True,
         server_hostname: str | None = None,
     ):
         super().__init__(address, port)

--- a/dns/query.py
+++ b/dns/query.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import dns._features
+import dns._file_util
 import dns._tls_util
 import dns.exception
 import dns.inet
@@ -440,7 +441,7 @@ def https(
     path: str = "/dns-query",
     post: bool = True,
     bootstrap_address: str | None = None,
-    verify: bool | str | ssl.SSLContext = True,
+    verify: bool | str | os.PathLike | ssl.SSLContext = True,
     resolver: "dns.resolver.Resolver | None" = None,  # pyright: ignore
     family: int = socket.AF_UNSPEC,
     http_version: HTTPVersion = HTTPVersion.DEFAULT,
@@ -480,9 +481,9 @@ def https(
     :param bootstrap_address: The IP address to use to bypass resolution.
     :type bootstrap_address: str or ``None``
     :param verify: If ``True``, verify the TLS certificate using default CA
-        roots; if ``False``, disable verification; if a ``str``, path to a
-        certificate file or directory.
-    :type verify: bool or str
+        roots; if ``False``, disable verification; if a ``str`` or an
+        ``os.PathLike``, path to a certificate file or directory.
+    :type verify: bool, str, or os.PathLike
     :param resolver: Resolver to use for hostname resolution in URLs.  If
         ``None``, a new resolver with default configuration is used (not the
         default resolver, to avoid a DoH chicken-and-egg problem).  Only
@@ -496,6 +497,9 @@ def https(
     :rtype: :py:class:`dns.message.Message`
     """
 
+    verify_filename = dns._file_util.as_filename(verify)
+    if verify_filename is not None:
+        verify = verify_filename
     af, _, the_source = _destination_and_source(where, port, source, source_port, False)
     # we bind url and then override as pyright can't figure out all paths bind.
     url = where
@@ -664,7 +668,7 @@ def _http3(
     source_port: int = 0,
     one_rr_per_rrset: bool = False,
     ignore_trailing: bool = False,
-    verify: bool | str | ssl.SSLContext = True,
+    verify: bool | str | os.PathLike | ssl.SSLContext = True,
     post: bool = True,
     connection: dns.quic.SyncQuicConnection | None = None,
 ) -> dns.message.Message:
@@ -1242,7 +1246,7 @@ def _tls_handshake(s, expiration):
 
 
 def make_ssl_context(
-    verify: bool | str = True,
+    verify: bool | str | os.PathLike = True,
     check_hostname: bool = True,
     alpns: list[str] | None = None,
 ) -> ssl.SSLContext:
@@ -1250,9 +1254,10 @@ def make_ssl_context(
 
     If *verify* is ``True``, the default, then certificate verification will occur using
     the standard CA roots.  If *verify* is ``False``, then certificate verification will
-    be disabled.  If *verify* is a string which is a valid pathname, then if the
-    pathname is a regular file, the CA roots will be taken from the file, otherwise if
-    the pathname is a directory roots will be taken from the directory.
+    be disabled.  If *verify* is a ``str`` or an ``os.PathLike`` which is a valid
+    pathname, then if the pathname is a regular file, the CA roots will be taken from
+    the file, otherwise if the pathname is a directory roots will be taken from the
+    directory.
 
     If *check_hostname* is ``True``, the default, then the hostname of the server must
     be specified when connecting and the server's certificate must authorize the
@@ -1276,7 +1281,7 @@ def make_ssl_context(
 
 # for backwards compatibility
 def _make_dot_ssl_context(
-    server_hostname: str | None, verify: bool | str
+    server_hostname: str | None, verify: bool | str | os.PathLike
 ) -> ssl.SSLContext:
     return make_ssl_context(verify, server_hostname is not None, ["dot"])
 
@@ -1293,7 +1298,7 @@ def tls(
     sock: ssl.SSLSocket | None = None,
     ssl_context: ssl.SSLContext | None = None,
     server_hostname: str | None = None,
-    verify: bool | str = True,
+    verify: bool | str | os.PathLike = True,
 ) -> dns.message.Message:
     """Return the response obtained after sending a query via TLS.
 
@@ -1330,9 +1335,9 @@ def tls(
         and an SSL context is created, hostname checking is disabled.
     :type server_hostname: str or ``None``
     :param verify: If ``True``, verify the TLS certificate using default CA
-        roots; if ``False``, disable verification; if a ``str``, path to a
-        certificate file or directory.
-    :type verify: bool or str
+        roots; if ``False``, disable verification; if a ``str`` or an
+        ``os.PathLike``, path to a certificate file or directory.
+    :type verify: bool, str, or os.PathLike
     :rtype: :py:class:`dns.message.Message`
     """
 
@@ -1393,7 +1398,7 @@ def quic(
     one_rr_per_rrset: bool = False,
     ignore_trailing: bool = False,
     connection: dns.quic.SyncQuicConnection | None = None,
-    verify: bool | str = True,
+    verify: bool | str | os.PathLike = True,
     hostname: str | None = None,
     server_hostname: str | None = None,
 ) -> dns.message.Message:
@@ -1422,9 +1427,9 @@ def quic(
     :param connection: If provided, the QUIC connection to use.
     :type connection: :py:class:`dns.quic.SyncQuicConnection` or ``None``
     :param verify: If ``True``, verify the TLS certificate using default CA
-        roots; if ``False``, disable verification; if a ``str``, path to a
-        certificate file or directory.
-    :type verify: bool or str
+        roots; if ``False``, disable verification; if a ``str`` or an
+        ``os.PathLike``, path to a certificate file or directory.
+    :type verify: bool, str, or os.PathLike
     :param hostname: The server's hostname, or ``None``.  If ``None`` and an
         SSL context is created, hostname checking is disabled.
     :type hostname: str or ``None``

--- a/dns/quic/_common.py
+++ b/dns/quic/_common.py
@@ -13,6 +13,7 @@ import aioquic.h3.connection  # pyright: ignore
 import aioquic.quic.configuration  # pyright: ignore
 import aioquic.quic.connection  # pyright: ignore
 
+import dns._file_util
 import dns._tls_util
 import dns.inet
 
@@ -231,9 +232,8 @@ class BaseQuicManager:
         self._tokens = {}
         self._h3 = h3
         if conf is None:
-            verify_path = None
-            if isinstance(verify_mode, str):
-                verify_path = verify_mode
+            verify_path = dns._file_util.as_filename(verify_mode)
+            if verify_path is not None:
                 verify_mode = True
             if h3:
                 alpn_protocols = ["h3"]

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -25,7 +25,7 @@ import threading
 import time
 import warnings
 from collections.abc import Iterator, Sequence
-from typing import Any, cast
+from typing import Any, TextIO, cast
 from urllib.parse import urlparse
 
 import dns._ddr
@@ -936,7 +936,9 @@ class BaseResolver:
     _nameservers: Sequence[str | dns.nameserver.Nameserver]
 
     def __init__(
-        self, filename: str | os.PathLike = "/etc/resolv.conf", configure: bool = True
+        self,
+        filename: str | os.PathLike | TextIO = "/etc/resolv.conf",
+        configure: bool = True,
     ) -> None:
         """Initialize a resolver.
 
@@ -984,7 +986,7 @@ class BaseResolver:
         self.rotate = False
         self.ndots = None
 
-    def read_resolv_conf(self, f: Any) -> None:
+    def read_resolv_conf(self, f: str | os.PathLike | TextIO) -> None:
         """Process *f* as a file in the /etc/resolv.conf format.  If *f* is
         a ``str`` or an ``os.PathLike``, it is used as the name of the file
         to open; otherwise it is treated as the file itself.
@@ -1007,9 +1009,8 @@ class BaseResolver:
         except OSError:
             # /etc/resolv.conf doesn't exist, can't be read, etc.
             raise NoResolverConfiguration(f"cannot open {f}")
-        with cm as f:
-            assert f is not None
-            for l in f:
+        with cm as fp:
+            for l in fp:
                 if len(l) == 0 or l[0] == "#" or l[0] == ";":
                     continue
                 tokens = l.split()

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -17,6 +17,7 @@
 
 """DNS stub resolver."""
 
+import os
 import random
 import socket
 import sys
@@ -935,14 +936,15 @@ class BaseResolver:
     _nameservers: Sequence[str | dns.nameserver.Nameserver]
 
     def __init__(
-        self, filename: str = "/etc/resolv.conf", configure: bool = True
+        self, filename: str | os.PathLike = "/etc/resolv.conf", configure: bool = True
     ) -> None:
         """Initialize a resolver.
 
-        :param filename: A ``str`` or file object specifying a file in
-            standard ``/etc/resolv.conf`` format.  Meaningful only when
-            *configure* is ``True`` and the platform is POSIX.
-        :type filename: str or file
+        :param filename: A ``str``, ``os.PathLike``, or file object
+            specifying a file in standard ``/etc/resolv.conf`` format.
+            Meaningful only when *configure* is ``True`` and the platform
+            is POSIX.
+        :type filename: str, os.PathLike, or file
         :param configure: If ``True`` (the default), configure the resolver
             for the operating system (reads ``/etc/resolv.conf`` on POSIX,
             registry on Windows).
@@ -983,9 +985,9 @@ class BaseResolver:
         self.ndots = None
 
     def read_resolv_conf(self, f: Any) -> None:
-        """Process *f* as a file in the /etc/resolv.conf format.  If f is
-        a ``str``, it is used as the name of the file to open; otherwise it
-        is treated as the file itself.
+        """Process *f* as a file in the /etc/resolv.conf format.  If *f* is
+        a ``str`` or an ``os.PathLike``, it is used as the name of the file
+        to open; otherwise it is treated as the file itself.
 
         Interprets the following items:
 

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -17,7 +17,6 @@
 
 """DNS stub resolver."""
 
-import contextlib
 import random
 import socket
 import sys
@@ -29,6 +28,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 import dns._ddr
+import dns._file_util
 import dns.edns
 import dns.exception
 import dns.flags
@@ -1000,14 +1000,11 @@ class BaseResolver:
         """
 
         nameservers = []
-        if isinstance(f, str):
-            try:
-                cm: contextlib.AbstractContextManager = open(f, encoding="utf-8")
-            except OSError:
-                # /etc/resolv.conf doesn't exist, can't be read, etc.
-                raise NoResolverConfiguration(f"cannot open {f}")
-        else:
-            cm = contextlib.nullcontext(f)
+        try:
+            cm = dns._file_util.maybe_open(f, encoding="utf-8")
+        except OSError:
+            # /etc/resolv.conf doesn't exist, can't be read, etc.
+            raise NoResolverConfiguration(f"cannot open {f}")
         with cm as f:
             assert f is not None
             for l in f:

--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -18,6 +18,7 @@
 """A place to store TSIG keys."""
 
 import base64
+import os
 import re
 from typing import Any
 from pathlib import Path
@@ -40,7 +41,7 @@ TSIG_KEY_FILE_RE = re.compile(
 )
 
 
-def from_file(key_file: str) -> dict[dns.name.Name, Any]:
+def from_file(key_file: str | os.PathLike) -> dict[dns.name.Name, Any]:
     """Open a tsig key file generate by tsig-keygen
     and parse to retrieve key, algo and secret
     @rtype: dict"""

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -17,7 +17,6 @@
 
 """DNS Zones."""
 
-import contextlib
 import dataclasses
 import io
 import os
@@ -25,6 +24,7 @@ import struct
 from collections.abc import Callable, Iterable, Iterator, MutableMapping
 from typing import Any, BinaryIO, TextIO, cast
 
+import dns._file_util
 import dns.exception
 import dns.immutable
 import dns.name
@@ -687,11 +687,7 @@ class Zone(dns.transaction.TransactionManager):
             else:
                 txt_is_utf8 = style.txt_is_utf8
             style = style.replace(idna_codec=idna_codec, txt_is_utf8=txt_is_utf8)
-        if isinstance(f, str):
-            cm: contextlib.AbstractContextManager = open(f, "wb")
-        else:
-            cm = contextlib.nullcontext(f)
-        with cm as output:
+        with dns._file_util.maybe_open(f, "wb") as output:
             # must be in this way, f.encoding may contain None, or even
             # attribute may not be there
             file_enc = getattr(f, "encoding", None)
@@ -1423,13 +1419,9 @@ def from_file(
     :returns: A subclass of :py:class:`dns.zone.Zone`.
     """
 
-    if isinstance(f, str):
-        if filename is None:
-            filename = f
-        cm: contextlib.AbstractContextManager = open(f, encoding="utf-8")
-    else:
-        cm = contextlib.nullcontext(f)
-    with cm as f:
+    if filename is None:
+        filename = dns._file_util.as_filename(f)
+    with dns._file_util.maybe_open(f, encoding="utf-8") as f:
         return _from_text(
             f,
             origin,

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -609,7 +609,7 @@ class Zone(dns.transaction.TransactionManager):
 
     def to_file(
         self,
-        f: Any,
+        f: str | os.PathLike | BinaryIO | TextIO,
         sorted: bool = True,
         relativize: bool = True,
         nl: str | bytes | None = None,
@@ -666,7 +666,7 @@ class Zone(dns.transaction.TransactionManager):
     def to_styled_file(
         self,
         style: ZoneStyle,
-        f: Any,
+        f: str | os.PathLike | BinaryIO | TextIO,
     ) -> None:
         """Write a zone to a styled file.
 
@@ -1367,7 +1367,7 @@ def from_text(
 
 
 def from_file(
-    f: Any,
+    f: str | os.PathLike | TextIO,
     origin: dns.name.Name | str | None = None,
     rdclass: dns.rdataclass.RdataClass = dns.rdataclass.IN,
     relativize: bool = True,
@@ -1423,9 +1423,9 @@ def from_file(
 
     if filename is None:
         filename = dns._file_util.as_filename(f)
-    with dns._file_util.maybe_open(f, encoding="utf-8") as f:
+    with dns._file_util.maybe_open(f, encoding="utf-8") as fp:
         return _from_text(
-            f,
+            fp,
             origin,
             rdclass,
             relativize,

--- a/dns/zone.py
+++ b/dns/zone.py
@@ -619,8 +619,9 @@ class Zone(dns.transaction.TransactionManager):
     ) -> None:
         """Write a zone to a file.
 
-        :param f: A file object or a ``str`` filename.  If a string, it is
-            treated as the name of a file to open.
+        :param f: A file object, a ``str`` filename, or an ``os.PathLike``.
+            If not a file object, it is treated as the name of a file to
+            open.
         :param bool sorted: If ``True`` (the default), the file will be
             written with the names sorted in DNSSEC order from least to
             greatest.  Otherwise the names will be written in whatever order
@@ -671,8 +672,9 @@ class Zone(dns.transaction.TransactionManager):
 
         :param style: The style to apply.
         :type style: :py:class:`dns.zone.ZoneStyle`
-        :param f: A file object or a ``str`` filename.  If a string, it is
-            treated as the name of a file to open.
+        :param f: A file object, a ``str`` filename, or an ``os.PathLike``.
+            If not a file object, it is treated as the name of a file to
+            open.
         """
 
         # Apply style items we learned from $UNICODE when we loaded the zone (if any).
@@ -1379,8 +1381,8 @@ def from_file(
 ) -> Zone:
     """Read a zone file and build a zone object.
 
-    :param f: A file object or a ``str`` filename.  If a string, it is
-        treated as the name of a file to open.
+    :param f: A file object, a ``str`` filename, or an ``os.PathLike``.  If
+        not a file object, it is treated as the name of a file to open.
     :param origin: The origin of the zone.  If not specified, the first
         ``$ORIGIN`` statement in the zone file will determine the origin.
     :type origin: :py:class:`dns.name.Name`, str, or ``None``

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -70,6 +70,10 @@ TBD
   now also accept any ``os.PathLike``, e.g. a ``pathlib.Path``.  Previously a path
   object was mistaken for an open file.
 
+* The *verify* parameter of the DoH/DoT/DoQ query functions and nameserver classes
+  now also accepts an ``os.PathLike`` naming the CA file or directory.  Previously a
+  path object was silently ignored and the default CA roots were used.
+
 2.8.0
 -----
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -64,6 +64,12 @@ TBD
 
 * The HHIT and BRID rdata types are now supported, and the NXNAME metatype is defined.
 
+* APIs which accept the name of a file to open — dns.zone.from_file(),
+  dns.zone.Zone.to_file(), dns.message.from_file(), dns.tsigkeyring.from_file(),
+  Resolver.read_resolv_conf(), and the resolver constructor's *filename* parameter —
+  now also accept any ``os.PathLike``, e.g. a ``pathlib.Path``.  Previously a path
+  object was mistaken for an open file.
+
 2.8.0
 -----
 

--- a/tests/resolv.conf
+++ b/tests/resolv.conf
@@ -1,0 +1,7 @@
+
+    /t/t
+# comment 1
+; comment 2
+domain foo
+nameserver 10.0.0.1
+nameserver 10.0.0.2

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -17,6 +17,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import binascii
+import pathlib
 import unittest
 
 import dns.edns
@@ -435,6 +436,11 @@ class MessageTestCase(unittest.TestCase):
 
     def test_from_file(self):
         m = dns.message.from_file(here("query"))
+        expected = dns.message.from_text(query_text)
+        self.assertEqual(m, expected)
+
+    def test_from_file_with_path(self):
+        m = dns.message.from_file(pathlib.Path(here("query")))
         expected = dns.message.from_text(query_text)
         self.assertEqual(m, expected)
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -16,6 +16,7 @@
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import asyncio
+import pathlib
 import selectors
 import socket
 import sys
@@ -70,15 +71,6 @@ except Exception:
 # it should say no error no data.
 _is_docker = tests.util.is_docker()
 
-
-resolv_conf = """
-    /t/t
-# comment 1
-; comment 2
-domain foo
-nameserver 10.0.0.1
-nameserver 10.0.0.2
-"""
 
 resolv_conf_options1 = """
 nameserver 10.0.0.1
@@ -228,11 +220,19 @@ class FakeTime:
 
 class BaseResolverTests(unittest.TestCase):
     def testRead(self):
-        f = StringIO(resolv_conf)
         r = dns.resolver.Resolver(configure=False)
-        r.read_resolv_conf(f)
+        with open(tests.util.here("resolv.conf")) as f:
+            r.read_resolv_conf(f)
         self.assertEqual(r.nameservers, ["10.0.0.1", "10.0.0.2"])
         self.assertEqual(r.domain, dns.name.from_text("foo"))
+
+    def testReadPath(self):
+        r = dns.resolver.Resolver(configure=False)
+        r.read_resolv_conf(pathlib.Path(tests.util.here("resolv.conf")))
+        self.assertEqual(r.nameservers, ["10.0.0.1", "10.0.0.2"])
+        self.assertEqual(r.domain, dns.name.from_text("foo"))
+        with self.assertRaises(dns.resolver.NoResolverConfiguration):
+            r.read_resolv_conf(pathlib.Path(tests.util.here("nonexistent.conf")))
 
     def testReadOptions(self):
         f = StringIO(resolv_conf_options1)

--- a/tests/test_tls_util.py
+++ b/tests/test_tls_util.py
@@ -1,0 +1,46 @@
+# Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+import pathlib
+import ssl
+
+import pytest
+
+import dns._tls_util
+import dns.query
+from tests.util import here
+
+
+def test_convert_verify_bool():
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(True) == (None, None)
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(False) == (None, None)
+
+
+def test_convert_verify_str():
+    cafile = here("tls/ca.crt")
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(cafile) == (cafile, None)
+    capath = here("tls")
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(capath) == (None, capath)
+
+
+def test_convert_verify_pathlike():
+    cafile = pathlib.Path(here("tls/ca.crt"))
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(cafile) == (
+        str(cafile),
+        None,
+    )
+    capath = pathlib.Path(here("tls"))
+    assert dns._tls_util.convert_verify_to_cafile_and_capath(capath) == (
+        None,
+        str(capath),
+    )
+
+
+def test_convert_verify_invalid():
+    for bad in [here("tls/nonexistent"), pathlib.Path(here("tls/nonexistent"))]:
+        with pytest.raises(ValueError):
+            dns._tls_util.convert_verify_to_cafile_and_capath(bad)
+
+
+def test_make_ssl_context_with_pathlike_verify():
+    ctx = dns.query.make_ssl_context(verify=pathlib.Path(here("tls/ca.crt")))
+    assert isinstance(ctx, ssl.SSLContext)

--- a/tests/test_tsigkeyring.py
+++ b/tests/test_tsigkeyring.py
@@ -1,6 +1,7 @@
 # Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
 
 import base64
+import pathlib
 import unittest
 import os
 import dns.tsig
@@ -94,6 +95,13 @@ class TSIGKeyRingTestCase(unittest.TestCase):
     def test_from_file_1(self):
         """test to parse key file 1.key"""
         keyring = dns.tsigkeyring.from_file(os.path.join(TEST_DIR, "./tsigkeys/1.key"))
+        self.assertEqual(keyring, keyring_file_1)
+
+    def test_from_file_with_path(self):
+        """test to parse key file 1.key named by a pathlib.Path"""
+        keyring = dns.tsigkeyring.from_file(
+            pathlib.Path(TEST_DIR) / "tsigkeys" / "1.key"
+        )
         self.assertEqual(keyring, keyring_file_1)
 
     def test_from_file_2(self):

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -18,6 +18,7 @@
 
 import difflib
 import os
+import pathlib
 import sys
 import unittest
 from io import BytesIO, StringIO
@@ -418,6 +419,24 @@ class ZoneTestCase(unittest.TestCase):
         finally:
             if not _keep_output:
                 os.unlink(here("example2.out"))
+        self.assertTrue(ok)
+
+    def testFromFileWithPath(self):
+        z = dns.zone.from_file(pathlib.Path(here("example")), "example")
+        z2 = dns.zone.from_file(here("example"), "example")
+        self.assertEqual(z, z2)
+
+    def testToFileWithPath(self):
+        z = dns.zone.from_file(here("example"), "example")
+        ok = False
+        try:
+            z.to_file(pathlib.Path(here("example-path.out")), nl=b"\x0a")
+            ok = compare_files(
+                "testToFileWithPath", here("example-path.out"), here("example1.good")
+            )
+        finally:
+            if not _keep_output:
+                os.unlink(here("example-path.out"))
         self.assertTrue(ok)
 
     def testToFileTextualStream(self):


### PR DESCRIPTION
Make the API compatible with `pathlib.Path` wherever a filepath is expected, in addition to passing the filepath as a `str`, e.g. `dns.zone.from_file(pathlib.Path("/tmp/zone"))`.

Stricter type checking for the file-like objects was also implemented.

I'm not sure what is the policy for LLM-assisted contributions - I'm following the [guidelines used by BIND9](https://gitlab.isc.org/isc-projects/bind9/-/blob/main/CONTRIBUTING.md?ref_type=heads#guidelines-for-tool-generated-content). TL;DR is I'm responsible for the output and I indicated the used model in the commit message.

I also sneaked in a `.mailmap` update - if that would be more appropriate to do in a separate MR, please let me know.