### PR TITLE
Bring async receive_udp ignore_errors in line with the sync one

### DIFF
--- a/dns/asyncquery.py
+++ b/dns/asyncquery.py
@@ -158,7 +158,6 @@ async def receive_udp(
                 one_rr_per_rrset=one_rr_per_rrset,
                 ignore_trailing=ignore_trailing,
                 raise_on_truncation=raise_on_truncation,
-                continue_on_error=ignore_errors,
             )
         except dns.message.Truncated as e:
             # See the comment in query.py for details.
@@ -361,7 +360,6 @@ async def receive_tcp(
     keyring: dict[dns.name.Name, dns.tsig.Key] | None = None,
     request_mac: bytes | None = b"",
     ignore_trailing: bool = False,
-    ignore_errors: bool = False,
 ) -> tuple[dns.message.Message, float]:
     """Read a DNS message from a TCP socket.
 
@@ -382,7 +380,6 @@ async def receive_tcp(
         request_mac=request_mac,
         one_rr_per_rrset=one_rr_per_rrset,
         ignore_trailing=ignore_trailing,
-        continue_on_error=ignore_errors,
     )
     return (r, received_time)
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -60,6 +60,13 @@ TBD
 
 * The async `zone_from_name()` function now behaves the same as the sync version.
 
+* `dns.asyncquery.receive_udp()` with ``ignore_errors`` set again discards a datagram
+  that fails to parse and keeps listening for a valid response, matching
+  `dns.query.receive_udp()`.  It had been returning the unparsable datagram with its
+  errors recorded on the message.  The unused ``ignore_errors`` parameter added to
+  `dns.asyncquery.receive_tcp()` at the same time has been removed, as the sync
+  version has no such parameter.
+
 * Documentation has been augmented and modernized.
 
 * The HHIT and BRID rdata types are now supported, and the NXNAME metatype is defined.

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -972,6 +972,31 @@ class IgnoreErrors(unittest.TestCase):
 
         self.async_run(run)
 
+    def test_unparsable_wire_is_skipped_not_salvaged(self):
+        # ignore_errors means "keep listening for a valid response", so a
+        # datagram that fails to parse must be discarded rather than returned
+        # with its parse errors recorded.  The first datagram below has a
+        # valid header and a different rcode, so returning it instead of the
+        # second one is detectable.
+        async def run():
+            bad_r = dns.message.make_response(self.q)
+            bad_r.set_rcode(dns.rcode.SERVFAIL)
+            bad_r_wire = bad_r.to_wire() + b"abcd"
+            s = MockSock(
+                bad_r_wire, ("127.0.0.1", 53), self.good_r_wire, ("127.0.0.1", 53)
+            )
+            r, _, _ = await dns.asyncquery.receive_udp(
+                s,
+                ("127.0.0.1", 53),
+                time.time() + 2,
+                ignore_errors=True,
+                query=self.q,
+            )
+            self.assertEqual(r, self.good_r)
+            self.assertEqual(r.errors, [])
+
+        self.async_run(run)
+
     def test_trailing_wire_not_ignored(self):
         wire = self.good_r_wire + b"abcd"
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -864,6 +864,30 @@ class IgnoreErrors(unittest.TestCase):
         wire = self.good_r_wire + b"abcd"
         self.mock_receive(wire, ("127.0.0.1", 53), self.good_r_wire, ("127.0.0.1", 53))
 
+    def test_unparsable_wire_is_skipped_not_salvaged(self):
+        # The twin of the dns.asyncquery test of the same name.  The first
+        # datagram has a valid header and a different rcode, so returning it
+        # instead of the second one is detectable.
+        bad_r = dns.message.make_response(self.q)
+        bad_r.set_rcode(dns.rcode.SERVFAIL)
+        bad_r_wire = bad_r.to_wire() + b"abcd"
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            with mock_udp_recv(
+                bad_r_wire, ("127.0.0.1", 53), self.good_r_wire, ("127.0.0.1", 53)
+            ):
+                r, _ = dns.query.receive_udp(
+                    s,
+                    ("127.0.0.1", 53),
+                    time.time() + 2,
+                    ignore_errors=True,
+                    query=self.q,
+                )
+                self.assertEqual(r, self.good_r)
+                self.assertEqual(r.errors, [])
+        finally:
+            s.close()
+
     def test_trailing_wire_not_ignored(self):
         wire = self.good_r_wire + b"abcd"
 


### PR DESCRIPTION
Differential fuzz of `dns.query` against `dns.asyncquery` over 400 response datagrams: 120 diverged, every one with `ignore_errors=True`. A control restricted to well-formed wire gave 0/400 before and after.

Two datagrams into each twin: a valid header plus trailing junk, then a clean NXDOMAIN response.

```
sync  dns.query.receive_udp      -> rcode=NXDOMAIN errors=0 datagrams_read=2
async dns.asyncquery.receive_udp -> rcode=SERVFAIL errors=1 datagrams_read=1
```

The sync twin discards the unparsable datagram and keeps listening, as its docstring promises ("ignore format errors or response mismatches and keep listening for a valid response"), which the async docstring defers to. The async twin returns it with the parse errors recorded.

Blame puts both bodies at f66e25b5 (2024-02-09). `dns/asyncquery.py:161` is 864308a3 (#1248), which added `continue_on_error=ignore_errors` to the async twin only; `dns/query.py` was not touched.

`Do53Nameserver.query` and `.async_query` both pass `ignore_errors=True` for UDP, so `dns.resolver` and `dns.asyncresolver` disagree on a damaged or injected response. Nothing in dnspython reads `Message.errors`, so a salvaged message reaches the resolver looking clean.

After the change the same fuzz gives 0 across four seeds.

The `receive_tcp` hunk is separable: #1248 also gave the async `receive_tcp` an `ignore_errors` parameter the sync one lacks and no caller passes. Neither has shipped in a release.

`test_unparsable_wire_is_skipped_not_salvaged` is added to both suites. The async one fails without the source change; the sync one passes either way and pins the authoritative behaviour.
