### PR TITLE
Require an unquoted identifier for zone file directives

### DIFF
--- a/dns/zonefile.py
+++ b/dns/zonefile.py
@@ -489,7 +489,11 @@ class Reader:
                 elif token.is_comment():
                     self.tok.get_eol()
                     continue
-                elif token.value[0] == "$" and len(self.allowed_directives) > 0:
+                elif (
+                    token.is_identifier()
+                    and token.value[0] == "$"
+                    and len(self.allowed_directives) > 0
+                ):
                     # Note that we only run directive processing code if at least
                     # one directive is allowed in order to be backwards compatible
                     c = token.value.upper()

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -37,6 +37,13 @@ TBD
   rejected by ``int()``, so they previously escaped the parser's validation.  This
   also makes zone files with such a TTL fail with a clean dns.exception.SyntaxError.
 
+* The zone file reader no longer treats a quoted string as a directive.  A line
+  starting with ``"$TTL"`` was processed as if it were ``$TTL``, because only the
+  token's value was tested and not its type; a directive must now be an unquoted
+  identifier.  This also fixes a crash: a line beginning with an empty token
+  (e.g. an empty quoted string) made the reader raise a bare IndexError, rather
+  than the dns.exception.SyntaxError any other malformed zone file gets.
+
 * The to_text() of string-list SVCB parameters (alpn and docpath) escaped
   non-printable bytes twice, rendering them as ``\\ddd`` instead of ``\ddd``,
   so the output did not parse back to the original value.  Such bytes are now

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1162,6 +1162,26 @@ class ZoneTestCase(unittest.TestCase):
 
         self.assertRaises(dns.exception.SyntaxError, bad)
 
+    def testEmptyTokenAtStartOfLine(self):
+        # An empty token at the start of a line is not a directive, and used
+        # to escape as an IndexError instead of a SyntaxError.
+        def bad():
+            dns.zone.from_text('""\n', origin="example.", check_origin=False)
+
+        self.assertRaises(dns.exception.SyntaxError, bad)
+
+    def testQuotedDirectiveIsNotADirective(self):
+        # A quoted string is data, not a directive, so "$TTL" must not be
+        # processed as $TTL.
+        def bad():
+            dns.zone.from_text(
+                '"$TTL" 60\nfoo 60 IN A 10.0.0.1\n',
+                origin="example.",
+                check_origin=False,
+            )
+
+        self.assertRaises(dns.exception.SyntaxError, bad)
+
     def testFirstRRStartsWithWhitespace(self):
         # no name is specified, so default to the initial origin
         z = dns.zone.from_text(


### PR DESCRIPTION
`Reader.read()` decided whether a line starts a directive by looking only at the token's value:

```python
elif token.value[0] == "$" and len(self.allowed_directives) > 0:
```

I ran into this because it crashes: An empty quoted string at the start of a line gives a token whose value is `""`, and the branches above only handle EOF, EOL and comments:

```python
dns.zone.from_text('""\n', origin=dns.name.from_text("example.com"),
                   check_origin=False)
# IndexError: string index out of range
```

No `$` needs to appear anywhere in the file. All other malformed input raises `SyntaxError`.

The missing bounds check isn't really the bug: the token's *type* is never checked either, so a quoted first token is honoured as a directive:

```python
dns.zone.from_text('"$TTL" 60\nfoo 60 IN A 1.2.3.4\n', ...)  # parses fine
```

`"$TTL"` acts as `$TTL`. In master file format a quoted string is data, never syntax, and everywhere else the parser checks `is_identifier()` before treating a token as a keyword, except here. So the fix here requires an unquoted identifier:

```python
elif (
    token.is_identifier()
    and token.value[0] == "$"
    and len(self.allowed_directives) > 0
):
```

This happens to also fix the `""` input problem. I've added tests for both failure modes.

Zone files that relied on a quoted directive will now fail to parse. I think that's correct, but if that change in undesirable, I'll be happy to fix the IndexError only.