### PR TITLE
Add an opt-in `rfc2308_ttl` mode for TTL inheritance

### DIFF
--- a/dns/zone.py
+++ b/dns/zone.py
@@ -1264,6 +1264,7 @@ def _from_text(
     idna_codec: dns.name.IDNACodec | None = None,
     allow_directives: bool | Iterable[str] = True,
     transaction_setup: Callable[[dns.transaction.Transaction], None] | None = None,
+    rfc2308_ttl: bool = False,
 ) -> Zone:
     # See the comments for the public APIs from_text() and from_file() for
     # details.
@@ -1285,6 +1286,7 @@ def _from_text(
             txn,
             allow_include=allow_include,
             allow_directives=allow_directives,
+            rfc2308_ttl=rfc2308_ttl,
         )
         try:
             reader.read()
@@ -1310,6 +1312,7 @@ def from_text(
     idna_codec: dns.name.IDNACodec | None = None,
     allow_directives: bool | Iterable[str] = True,
     transaction_setup: Callable[[dns.transaction.Transaction], None] | None = None,
+    rfc2308_ttl: bool = False,
 ) -> Zone:
     """Build a zone object from a zone file format string.
 
@@ -1346,6 +1349,13 @@ def from_text(
         transaction.  This lets the caller alter the transaction's configuration
         before it is used, for example adding checking policies.
     :type transaction_setup: ``None`` or ``Callable[[dns.transaction.Transaction], None]``.
+    :param bool rfc2308_ttl: If ``False``, the default, then a master file with
+        no ``$TTL`` directive gets its default TTL from the SOA MINIMUM field,
+        which is the pre-RFC 2308 behavior.  If ``True``, then RFC 2308 section 4
+        is followed and MINIMUM is not treated as a source of the default TTL; a
+        record with no TTL instead inherits the most recently stated TTL, per RFC
+        1035 section 5.1.  The SOA MINIMUM is still used as a last resort if no
+        TTL has been stated at all.
     :raises dns.zone.NoSOA: if there is no SOA RRset.
     :raises dns.zone.NoNS: if there is no NS RRset.
     :raises KeyError: if there is no origin node.
@@ -1363,6 +1373,7 @@ def from_text(
         idna_codec,
         allow_directives,
         transaction_setup,
+        rfc2308_ttl,
     )
 
 
@@ -1378,6 +1389,7 @@ def from_file(
     idna_codec: dns.name.IDNACodec | None = None,
     allow_directives: bool | Iterable[str] = True,
     transaction_setup: Callable[[dns.transaction.Transaction], None] | None = None,
+    rfc2308_ttl: bool = False,
 ) -> Zone:
     """Read a zone file and build a zone object.
 
@@ -1415,6 +1427,13 @@ def from_file(
         transaction.  This lets the caller alter the transaction's configuration
         before it is used, for example adding checking policies.
     :type transaction_setup: ``None`` or ``Callable[[dns.transaction.Transaction], None]``.
+    :param bool rfc2308_ttl: If ``False``, the default, then a master file with
+        no ``$TTL`` directive gets its default TTL from the SOA MINIMUM field,
+        which is the pre-RFC 2308 behavior.  If ``True``, then RFC 2308 section 4
+        is followed and MINIMUM is not treated as a source of the default TTL; a
+        record with no TTL instead inherits the most recently stated TTL, per RFC
+        1035 section 5.1.  The SOA MINIMUM is still used as a last resort if no
+        TTL has been stated at all.
     :raises dns.zone.NoSOA: if there is no SOA RRset.
     :raises dns.zone.NoNS: if there is no NS RRset.
     :raises KeyError: if there is no origin node.
@@ -1436,6 +1455,7 @@ def from_file(
             idna_codec,
             allow_directives,
             transaction_setup,
+            rfc2308_ttl,
         )
     assert False  # make mypy happy  lgtm[py/unreachable-statement]
 

--- a/dns/zonefile.py
+++ b/dns/zonefile.py
@@ -75,8 +75,9 @@ SavedStateType = tuple[
     int,  # last_ttl
     bool,  # last_ttl_known
     int,  # default_ttl
-    bool,
-]  # default_ttl_known
+    bool,  # default_ttl_known
+    bool,  # default_ttl_from_soa
+]
 
 
 def _upper_dollarize(s):
@@ -101,12 +102,15 @@ class Reader:
         force_rdclass: dns.rdataclass.RdataClass | None = None,
         force_rdtype: dns.rdatatype.RdataType | None = None,
         default_ttl: int | None = None,
+        rfc2308_ttl: bool = False,
     ):
         self.tok = tok
         self.zone_origin, self.relativize, _ = txn.manager.origin_information()
         self.current_origin = self.zone_origin
         self.last_ttl = 0
         self.last_ttl_known = False
+        self.rfc2308_ttl = rfc2308_ttl
+        self.default_ttl_from_soa = False
         if force_ttl is not None:
             default_ttl = force_ttl
         if default_ttl is None:
@@ -150,6 +154,27 @@ class Reader:
         if not token.is_identifier():
             raise dns.exception.SyntaxError
         return token
+
+    def _implicit_ttl(self) -> int | None:
+        """Return the TTL to use for a record which did not specify one, or
+        ``None`` if no TTL can be determined yet.
+
+        An explicit default (from ``$TTL``, or from the *default_ttl* /
+        *force_ttl* constructor parameters) always wins.  Otherwise, in
+        ``rfc2308_ttl`` mode, the most recently stated TTL (RFC 1035 section
+        5.1) is preferred over a default synthesized from the SOA MINIMUM
+        field, whose overloaded "default TTL" meaning RFC 2308 section 4
+        removed.  In legacy mode the SOA-derived default wins, as it did
+        before RFC 2308.
+        """
+        if self.last_ttl_known and (  # only if the default doesn't take precedence
+            not self.default_ttl_known
+            or (self.rfc2308_ttl and self.default_ttl_from_soa)
+        ):
+            return self.last_ttl
+        if self.default_ttl_known:
+            return self.default_ttl
+        return None
 
     def _rr_line(self) -> None:
         """Process one line from a DNS zone file."""
@@ -218,10 +243,7 @@ class Reader:
                 self.last_ttl = ttl
                 self.last_ttl_known = True
             except dns.ttl.BadTTL:
-                if self.default_ttl_known:
-                    ttl = self.default_ttl
-                elif self.last_ttl_known:
-                    ttl = self.last_ttl
+                ttl = self._implicit_ttl()
                 self.tok.unget(token)
 
         # Type
@@ -262,9 +284,10 @@ class Reader:
             soa_rd = cast(dns.rdtypes.ANY.SOA.SOA, rd)
             self.default_ttl = soa_rd.minimum
             self.default_ttl_known = True
+            self.default_ttl_from_soa = True
             if ttl is None:
                 # if we didn't have a TTL on the SOA, set it!
-                ttl = soa_rd.minimum
+                ttl = self._implicit_ttl()
 
         # TTL check.  We had to wait until now to do this as the SOA RR's
         # own TTL can be inferred from its minimum.
@@ -353,16 +376,11 @@ class Reader:
             if not token.is_identifier():
                 raise dns.exception.SyntaxError
         except dns.ttl.BadTTL:
-            if not (self.last_ttl_known or self.default_ttl_known):
-                raise dns.exception.SyntaxError("Missing default TTL value")
-            if self.default_ttl_known:
-                ttl = self.default_ttl
-            elif self.last_ttl_known:
-                ttl = self.last_ttl
-            else:
-                # We don't go to the extra "look at the SOA" level of effort for
-                # $GENERATE, because the user really ought to have defined a TTL
-                # somehow!
+            # We don't go to the extra "look at the SOA" level of effort for
+            # $GENERATE, because the user really ought to have defined a TTL
+            # somehow!
+            ttl = self._implicit_ttl()
+            if ttl is None:
                 raise dns.exception.SyntaxError("Missing default TTL value")
 
         # Class
@@ -481,6 +499,7 @@ class Reader:
                             self.last_ttl_known,
                             self.default_ttl,
                             self.default_ttl_known,
+                            self.default_ttl_from_soa,
                         ) = self.saved_state.pop(-1)
                         continue
                     break
@@ -507,6 +526,7 @@ class Reader:
                             raise dns.exception.SyntaxError("bad $TTL")
                         self.default_ttl = dns.ttl.from_text(token.value)
                         self.default_ttl_known = True
+                        self.default_ttl_from_soa = False
                         self.tok.get_eol()
                     elif c == "$ORIGIN":
                         self.current_origin = self.tok.get_name()
@@ -538,6 +558,7 @@ class Reader:
                                 self.last_ttl_known,
                                 self.default_ttl,
                                 self.default_ttl_known,
+                                self.default_ttl_from_soa,
                             )
                         )
                         self.current_file = open(filename, encoding="utf-8")
@@ -687,6 +708,7 @@ def read_rrsets(
     idna_codec: dns.name.IDNACodec | None = None,
     origin: dns.name.Name | str | None = dns.name.root,
     relativize: bool = False,
+    rfc2308_ttl: bool = False,
 ) -> list[dns.rrset.RRset]:
     """Read one or more rrsets from the specified text, possibly subject
     to restrictions.
@@ -726,6 +748,10 @@ def read_rrsets(
     :param bool relativize: If ``True``, names are relativized to *origin*;
         if ``False``, relative names in the input are made absolute by
         appending *origin*.
+    :param bool rfc2308_ttl: If ``True``, a TTL-less record inherits the most
+        recently stated TTL in preference to a default derived from the SOA
+        MINIMUM field, per RFC 2308 section 4.  The default is ``False``, the
+        historical behavior.
     :rtype: list[:py:class:`dns.rrset.RRset`]
     """
     if isinstance(origin, str):
@@ -758,6 +784,7 @@ def read_rrsets(
             force_rdclass=rdclass,
             force_rdtype=rdtype,
             default_ttl=default_ttl,
+            rfc2308_ttl=rfc2308_ttl,
         )
         reader.read()
     return manager.rrsets

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -145,6 +145,13 @@ $GENERATE 1-10 foo$ CNAME $.0
 @ 3600 IN NS ns2
 """
 
+soa_before_generate_input = """@ 3600 IN SOA foo bar 1 2 3 4 5
+@ 3600 IN NS ns1
+@ 3600 IN NS ns2
+foo 300 mx 10 target.
+$GENERATE 1-10 foo$ CNAME $.0
+"""
+
 
 def _rdata_sort(a):
     return (a[0], a[2].rdclass, a[2].to_text())
@@ -705,6 +712,30 @@ class GenerateTestCase(unittest.TestCase):
         z = dns.zone.from_text(last_ttl_input, "example")
         rrs = z.find_rrset("foo9", "CNAME")
         self.assertEqual(rrs.ttl, 300)
+
+    def testUsesSOAMinimum(self):
+        z = dns.zone.from_text(soa_before_generate_input, "example")
+        rrs = z.find_rrset("foo9", "CNAME")
+        self.assertEqual(rrs.ttl, 5)
+
+    def testUsesLastTTLInsteadOfSOAMinimum(self):
+        z = dns.zone.from_text(soa_before_generate_input, "example", rfc2308_ttl=True)
+        rrs = z.find_rrset("foo9", "CNAME")
+        self.assertEqual(rrs.ttl, 300)
+
+    def testNoTTL(self):
+        def bad():
+            dns.zone.from_text("$GENERATE 1-10 fooo$ CNAME $.0", "example")
+
+        self.assertRaises(dns.exception.SyntaxError, bad)
+
+    def testNoTTLRFC2308(self):
+        def bad():
+            dns.zone.from_text(
+                "$GENERATE 1-10 fooo$ CNAME $.0", "example", rfc2308_ttl=True
+            )
+
+        self.assertRaises(dns.exception.SyntaxError, bad)
 
     def testClassMismatch(self):
         def bad():

--- a/tests/test_rrset_reader.py
+++ b/tests/test_rrset_reader.py
@@ -136,6 +136,26 @@ bar 30 20 b.
     assert equal_rrsets(rrsets, [expected_mx_3, expected_mx_4])
 
 
+def test_soa_minimum_is_default_ttl():
+    input = """;
+example. 300 soa a. b. 1 2 3 4 5
+bar mx 10 a.
+"""
+    rrsets = read_rrsets(input, origin="example")
+    assert rrsets[0].ttl == 300
+    assert rrsets[1].ttl == 5
+
+
+def test_rfc2308_ttl_prefers_last_ttl():
+    input = """;
+example. 300 soa a. b. 1 2 3 4 5
+bar mx 10 a.
+"""
+    rrsets = read_rrsets(input, origin="example", rfc2308_ttl=True)
+    assert rrsets[0].ttl == 300
+    assert rrsets[1].ttl == 300
+
+
 # also weird but legal
 # input5 = '''foo 30 10 a
 # bar 10 20 foo.

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -61,7 +61,7 @@ ns2 3600 IN A 10.0.0.2
 
 example_text_output_class_before_ttl = """@ IN 3600 SOA foo bar 1 2 3 4 5
 @ 3600 NS ns1 ; no class
-@ NS ns2 ; no class or TTL, TTL inferred from prior record
+@ NS ns2 ; no class or TTL, TTL from the SOA minimum (prior record in RFC 2308 mode)
 bar.foo IN 300 MX 0 blaz.foo
 ns1 IN 3600 A 10.0.0.1
 ns2 IN 3600 A 10.0.0.2
@@ -147,6 +147,45 @@ ttl_from_last_text = """$ORIGIN example.
 ns1 a 10.0.0.1
 ns2 1w1D1h1m1S a 10.0.0.2
 """
+
+# An explicit $TTL is the default TTL in both TTL modes, even though a later
+# RR states a TTL of its own.
+dollar_ttl_wins_text = """$TTL 1h
+$ORIGIN example.
+@ 2h soa foo bar 1 2 3 4 5
+@ 2h ns ns1
+ns1 1w1D1h1m1S a 10.0.0.1
+ns2 a 10.0.0.2
+"""
+
+# A $TTL after the SOA replaces a default TTL taken from the SOA minimum, in
+# both TTL modes.  Before the $TTL, ns1 has no TTL of its own and so shows
+# where the default came from.
+dollar_ttl_after_soa_text = """$ORIGIN example.
+@ 1h soa foo bar 1 2 3 4 5
+@ 1h ns ns1
+ns1 a 10.0.0.1
+$TTL 300
+ns2 a 10.0.0.2
+"""
+
+# No $TTL and no TTL on the SOA, so the SOA minimum is the only TTL there is
+# and is used in both TTL modes.
+ttl_only_from_soa_minimum_text = """$ORIGIN example.
+@ soa foo bar 1 2 3 4 5
+@ ns ns1
+ns1 a 10.0.0.1
+"""
+
+# The $TTL in the included file must not outlive the $INCLUDE; ns2 gets the
+# outer default TTL, which came from the SOA minimum.
+ttl_include_text = """$ORIGIN example.
+@ 1h soa foo bar 1 2 3 4 5
+@ 1h ns ns1
+ns1 1w1D1h1m1S a 10.0.0.1
+$INCLUDE "%s"
+ns2 a 10.0.0.2
+""" % here("ttl_include.text")
 
 # No $TTL and no SOA should raise SyntaxError as no TTL can be determined.
 no_ttl_text = """$ORIGIN example.
@@ -1058,9 +1097,98 @@ class ZoneTestCase(unittest.TestCase):
         )
         self.assertEqual(rds.ttl, 694861)
 
+    def testTTLFromLastInsteadOfSOA(self):
+        # RFC 2308 section 4 removed the "default TTL" meaning of the SOA
+        # minimum, so ns2 inherits the last stated TTL instead of the minimum.
+        z = dns.zone.from_text(
+            ttl_from_soa_text, "example.", relativize=True, rfc2308_ttl=True
+        )
+        rds = z.find_rdataset("@", "SOA")
+        self.assertEqual(rds.ttl, 3600)
+        rds = z.find_rdataset("ns1", "A")
+        self.assertEqual(rds.ttl, 694861)
+        rds = z.find_rdataset("ns2", "A")
+        self.assertEqual(rds.ttl, 694861)
+
+    def testDollarTTLWinsOverLastTTL(self):
+        z = dns.zone.from_text(dollar_ttl_wins_text, "example.", relativize=True)
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 3600)
+        z = dns.zone.from_text(
+            dollar_ttl_wins_text, "example.", relativize=True, rfc2308_ttl=True
+        )
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 3600)
+
+    def testDollarTTLAfterSOAWins(self):
+        z = dns.zone.from_text(dollar_ttl_after_soa_text, "example.", relativize=True)
+        # Until the $TTL is seen, the default TTL is the SOA minimum.
+        self.assertEqual(z.find_rdataset("ns1", "A").ttl, 5)
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 300)
+        z = dns.zone.from_text(
+            dollar_ttl_after_soa_text, "example.", relativize=True, rfc2308_ttl=True
+        )
+        # In RFC 2308 mode the SOA minimum is not a default TTL, so ns1 takes
+        # the last stated TTL, but the $TTL still wins for ns2.
+        self.assertEqual(z.find_rdataset("ns1", "A").ttl, 3600)
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 300)
+
+    def testTTLFromSOAMinimumAsLastResort(self):
+        # Nothing has stated a TTL, so even in RFC 2308 mode the minimum is
+        # the only TTL available.
+        z = dns.zone.from_text(
+            ttl_only_from_soa_minimum_text, "example.", relativize=True
+        )
+        self.assertEqual(z.find_rdataset("@", "SOA").ttl, 5)
+        self.assertEqual(z.find_rdataset("ns1", "A").ttl, 5)
+        z = dns.zone.from_text(
+            ttl_only_from_soa_minimum_text,
+            "example.",
+            relativize=True,
+            rfc2308_ttl=True,
+        )
+        self.assertEqual(z.find_rdataset("@", "SOA").ttl, 5)
+        self.assertEqual(z.find_rdataset("ns1", "A").ttl, 5)
+
+    def testTTLFromLastWithClassBeforeTTL(self):
+        # The <class> <ttl> <type> syntax has its own TTL inheritance code.
+        z = dns.zone.from_text(
+            example_text_output_class_before_ttl, "example.", relativize=True
+        )
+        self.assertEqual(z.find_rdataset("@", "NS").ttl, 5)
+        z = dns.zone.from_text(
+            example_text_output_class_before_ttl,
+            "example.",
+            relativize=True,
+            rfc2308_ttl=True,
+        )
+        self.assertEqual(z.find_rdataset("@", "NS").ttl, 3600)
+
+    def testDollarTTLInIncludeDoesNotEscape(self):
+        z = dns.zone.from_text(
+            ttl_include_text, "example.", relativize=True, allow_include=True
+        )
+        self.assertEqual(z.find_rdataset("included", "A").ttl, 300)
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 5)
+        z = dns.zone.from_text(
+            ttl_include_text,
+            "example.",
+            relativize=True,
+            allow_include=True,
+            rfc2308_ttl=True,
+        )
+        self.assertEqual(z.find_rdataset("included", "A").ttl, 300)
+        self.assertEqual(z.find_rdataset("ns2", "A").ttl, 694861)
+
     def testNoTTL(self):
         def bad():
             dns.zone.from_text(no_ttl_text, "example.", check_origin=False)
+
+        self.assertRaises(dns.exception.SyntaxError, bad)
+
+    def testNoTTLRFC2308(self):
+        def bad():
+            dns.zone.from_text(
+                no_ttl_text, "example.", check_origin=False, rfc2308_ttl=True
+            )
 
         self.assertRaises(dns.exception.SyntaxError, bad)
 

--- a/tests/ttl_include.text
+++ b/tests/ttl_include.text
@@ -1,0 +1,6 @@
+; Copyright (C) Dnspython Contributors, see LICENSE for text of ISC license
+
+; Included by tests/test_zone.py to check that the $TTL set here does not
+; outlive the $INCLUDE.
+$TTL 300
+included a 10.0.0.3


### PR DESCRIPTION
Folks [complaining](https://news.ycombinator.com/item?id=49576309) about this:

Pre-RFC 2308 master files overloaded the SOA MINIMUM field to mean "default TTL for the zone". This is what dnspython does: a record with no TTL takes the SOA minimum whenever no `$TTL` directive has been seen. RFC 2308 section 4 removed that meaning of MINIMUM, leaving RFC 1035 section 5.1 (which says that a record without TTL inherits the most recently stated one).

This PR adds an `rfc2308_ttl` parameter (default `False`) to `dns.zone.from_text()`, `dns.zone.from_file()`, `dns.zonefile.read_rrsets()`, and `dns.zonefile.Reader`, which selects the RFC 2308 interpretation. An explicit default (`$TTL` or `default_ttl`/`force_ttl`) still wins in either mode, and the SOA minimum is still used as a last resort when nothing else has stated a TTL at all, so a zone whose only TTL is the SOA minimum parses identically in both modes.

How it works: the reader now tracks whether the current default TTL comes from SOA MINIMUM (`default_ttl_from_soa`, cleared by `$TTL` and saved/restored across `$INCLUDE` alongside the other TTL state), and the three places that resolved an missing TTL now use a single `_implicit_ttl()` helper instead of each open-coding the precedence. With the flag off, the resolved TTL is unchanged in every reachable state, so existing behavior is preserved.